### PR TITLE
Fix ENH echo suppression for missing address echoes

### DIFF
--- a/transport/enh_transport.go
+++ b/transport/enh_transport.go
@@ -91,18 +91,15 @@ func (t *ENHTransport) Write(payload []byte) (int, error) {
 		return 0, nil
 	}
 
-	isEBUSFrame := len(payload) >= 6 && payload[4] == byte(len(payload)-6)
 	framesWritten := 0
-	for index, payloadByte := range payload {
+	for _, payloadByte := range payload {
 		if err := t.setWriteDeadline(); err != nil {
 			return framesWritten, t.mapWriteError(err)
 		}
 
 		enqueued := false
-		if !(isEBUSFrame && index < 2) {
-			t.enqueueEcho([]byte{payloadByte})
-			enqueued = true
-		}
+		t.enqueueEcho([]byte{payloadByte})
+		enqueued = true
 		seq := EncodeENH(ENHReqSend, payloadByte)
 		written := 0
 		for written < len(seq) {
@@ -180,11 +177,17 @@ func (t *ENHTransport) shouldSuppressEcho(value byte) bool {
 	if len(t.echoPending) == 0 {
 		return false
 	}
-	if t.echoPending[0] != value {
-		return false
+	if t.echoPending[0] == value {
+		t.echoPending = t.echoPending[1:]
+		return true
 	}
-	t.echoPending = t.echoPending[1:]
-	return true
+	for skip := 1; skip <= 2 && skip < len(t.echoPending); skip++ {
+		if t.echoPending[skip] == value {
+			t.echoPending = t.echoPending[skip+1:]
+			return true
+		}
+	}
+	return false
 }
 
 func (t *ENHTransport) enqueueEcho(payload []byte) {

--- a/transport/enh_transport_test.go
+++ b/transport/enh_transport_test.go
@@ -174,7 +174,7 @@ func TestENHTransport_SuppressesEchoedBytes(t *testing.T) {
 	}
 }
 
-func TestENHTransport_SuppressesEchoedBytesSkipsArbitration(t *testing.T) {
+func TestENHTransport_SuppressesEchoedBytesFullSequence(t *testing.T) {
 	t.Parallel()
 
 	client, server := net.Pipe()
@@ -192,16 +192,13 @@ func TestENHTransport_SuppressesEchoedBytesSkipsArbitration(t *testing.T) {
 			serverErr <- err
 			return
 		}
-		seqEcho0 := transport.EncodeENH(transport.ENHResReceived, payload[0])
-		seqEcho1 := transport.EncodeENH(transport.ENHResReceived, payload[1])
-		seqEcho2 := transport.EncodeENH(transport.ENHResReceived, payload[2])
-		seqNonEcho := transport.EncodeENH(transport.ENHResReceived, 0x99)
-		response := []byte{
-			seqEcho0[0], seqEcho0[1],
-			seqEcho1[0], seqEcho1[1],
-			seqEcho2[0], seqEcho2[1],
-			seqNonEcho[0], seqNonEcho[1],
+		response := make([]byte, 0, len(payload)*2+2)
+		for _, value := range payload {
+			seqEcho := transport.EncodeENH(transport.ENHResReceived, value)
+			response = append(response, seqEcho[0], seqEcho[1])
 		}
+		seqNonEcho := transport.EncodeENH(transport.ENHResReceived, 0x99)
+		response = append(response, seqNonEcho[0], seqNonEcho[1])
 		_, err := server.Write(response)
 		serverErr <- err
 	}()
@@ -210,15 +207,58 @@ func TestENHTransport_SuppressesEchoedBytesSkipsArbitration(t *testing.T) {
 		t.Fatalf("Write error = %v", err)
 	}
 
-	want := []byte{payload[0], payload[1], 0x99}
-	for index, expected := range want {
-		got, err := enh.ReadByte()
-		if err != nil {
-			t.Fatalf("ReadByte[%d] error = %v", index, err)
+	got, err := enh.ReadByte()
+	if err != nil {
+		t.Fatalf("ReadByte error = %v", err)
+	}
+	if got != 0x99 {
+		t.Fatalf("ReadByte = 0x%02x; want 0x99", got)
+	}
+
+	if err := <-serverErr; err != nil {
+		t.Fatalf("server error = %v", err)
+	}
+}
+
+func TestENHTransport_SuppressesEchoedBytesMissingAddress(t *testing.T) {
+	t.Parallel()
+
+	client, server := net.Pipe()
+	defer client.Close()
+	defer server.Close()
+
+	enh := transport.NewENHTransport(client, 200*time.Millisecond, 200*time.Millisecond)
+
+	payload := []byte{0x10, 0x20, 0x30, 0x40, 0x01, 0x55, 0x66}
+	serverErr := make(chan error, 1)
+	// Goroutine exits after draining frames and writing responses.
+	go func() {
+		buf := make([]byte, len(payload)*2)
+		if _, err := io.ReadFull(server, buf); err != nil {
+			serverErr <- err
+			return
 		}
-		if got != expected {
-			t.Fatalf("ReadByte[%d] = 0x%02x; want 0x%02x", index, got, expected)
+		response := make([]byte, 0, (len(payload)-2)*2+2)
+		for _, value := range payload[2:] {
+			seqEcho := transport.EncodeENH(transport.ENHResReceived, value)
+			response = append(response, seqEcho[0], seqEcho[1])
 		}
+		seqNonEcho := transport.EncodeENH(transport.ENHResReceived, 0x99)
+		response = append(response, seqNonEcho[0], seqNonEcho[1])
+		_, err := server.Write(response)
+		serverErr <- err
+	}()
+
+	if _, err := enh.Write(payload); err != nil {
+		t.Fatalf("Write error = %v", err)
+	}
+
+	got, err := enh.ReadByte()
+	if err != nil {
+		t.Fatalf("ReadByte error = %v", err)
+	}
+	if got != 0x99 {
+		t.Fatalf("ReadByte = 0x%02x; want 0x99", got)
 	}
 
 	if err := <-serverErr; err != nil {


### PR DESCRIPTION
## What
- Always enqueue echo suppression for all sent bytes
- Tolerate missing address echoes by skipping up to two pending bytes
- Add tests for full echo and missing address cases

## Why
- Align ENH echo suppression with bus behavior and Issue #23

## Testing
- go test ./...

Closes #23

Smoke test required: NO