### PR TITLE
Bus: skip idle SYN while waiting for ACK

### DIFF
--- a/protocol/bus.go
+++ b/protocol/bus.go
@@ -272,17 +272,21 @@ func (b *Bus) writeFrame(frame Frame) error {
 }
 
 func (b *Bus) readAck(runCtx, reqCtx context.Context) error {
-	value, err := b.readByte(runCtx, reqCtx)
-	if err != nil {
-		return err
-	}
-	switch value {
-	case SymbolAck:
-		return nil
-	case SymbolNack:
-		return fmt.Errorf("nack received: %w", ebuserrors.ErrNACK)
-	default:
-		return fmt.Errorf("unexpected ack symbol 0x%02x: %w", value, ebuserrors.ErrInvalidPayload)
+	for {
+		value, err := b.readByte(runCtx, reqCtx)
+		if err != nil {
+			return err
+		}
+		switch value {
+		case SymbolSyn:
+			continue
+		case SymbolAck:
+			return nil
+		case SymbolNack:
+			return fmt.Errorf("nack received: %w", ebuserrors.ErrNACK)
+		default:
+			return fmt.Errorf("unexpected ack symbol 0x%02x: %w", value, ebuserrors.ErrInvalidPayload)
+		}
 	}
 }
 

--- a/protocol/bus_test.go
+++ b/protocol/bus_test.go
@@ -132,6 +132,43 @@ func TestBus_MasterMasterAckOnly(t *testing.T) {
 	}
 }
 
+func TestBus_ReadAckSkipsSyn(t *testing.T) {
+	t.Parallel()
+
+	tr := &scriptedTransport{
+		reads: []readEvent{
+			{value: protocol.SymbolSyn},
+			{value: protocol.SymbolSyn},
+			{value: protocol.SymbolAck},
+		},
+	}
+	config := protocol.DefaultBusConfig()
+	bus := protocol.NewBus(tr, config, 8)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	bus.Run(ctx)
+
+	resp, err := bus.Send(ctx, protocol.Frame{
+		Source:    0x30,
+		Target:    0x10,
+		Primary:   0x01,
+		Secondary: 0x02,
+		Data:      []byte{0x03},
+	})
+	if err != nil {
+		t.Fatalf("Send error = %v", err)
+	}
+	if resp != nil {
+		t.Fatalf("response = %+v; want nil", resp)
+	}
+	if tr.readsConsumed() != 3 {
+		t.Fatalf("reads = %d; want 3", tr.readsConsumed())
+	}
+	if tr.writeCount() != 1 {
+		t.Fatalf("writes = %d; want 1", tr.writeCount())
+	}
+}
+
 func TestBus_ResponseCRCMismatch(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## What
- skip idle SYN (0xAA) bytes in ACK/NACK reads
- cover SYN skipping with a bus test

## Why
Idle SYN bytes can appear while waiting for an ACK; they should be ignored.

## Tests
- go test ./...

Smoke test: not required

Closes #25