### PR TITLE
Ignore noise bytes while waiting for ACK

### DIFF
--- a/protocol/bus.go
+++ b/protocol/bus.go
@@ -278,14 +278,12 @@ func (b *Bus) readAck(runCtx, reqCtx context.Context) error {
 			return err
 		}
 		switch value {
-		case SymbolSyn:
-			continue
 		case SymbolAck:
 			return nil
 		case SymbolNack:
 			return fmt.Errorf("nack received: %w", ebuserrors.ErrNACK)
 		default:
-			return fmt.Errorf("unexpected ack symbol 0x%02x: %w", value, ebuserrors.ErrInvalidPayload)
+			continue
 		}
 	}
 }

--- a/protocol/bus_test.go
+++ b/protocol/bus_test.go
@@ -169,6 +169,44 @@ func TestBus_ReadAckSkipsSyn(t *testing.T) {
 	}
 }
 
+func TestBus_ReadAckSkipsNoiseBytes(t *testing.T) {
+	t.Parallel()
+
+	tr := &scriptedTransport{
+		reads: []readEvent{
+			{value: 0x10},
+			{value: 0x55},
+			{value: protocol.SymbolSyn},
+			{value: protocol.SymbolAck},
+		},
+	}
+	config := protocol.DefaultBusConfig()
+	bus := protocol.NewBus(tr, config, 8)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	bus.Run(ctx)
+
+	resp, err := bus.Send(ctx, protocol.Frame{
+		Source:    0x30,
+		Target:    0x10,
+		Primary:   0x01,
+		Secondary: 0x02,
+		Data:      []byte{0x03},
+	})
+	if err != nil {
+		t.Fatalf("Send error = %v", err)
+	}
+	if resp != nil {
+		t.Fatalf("response = %+v; want nil", resp)
+	}
+	if tr.readsConsumed() != 4 {
+		t.Fatalf("reads = %d; want 4", tr.readsConsumed())
+	}
+	if tr.writeCount() != 1 {
+		t.Fatalf("writes = %d; want 1", tr.writeCount())
+	}
+}
+
 func TestBus_ResponseCRCMismatch(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## What
- ignore non-ACK/NACK bytes while waiting for ACK
- add protocol test covering noise before ACK

## Why
- matches bus behavior when noise appears on the line

## Testing
- go test ./...

## Smoke Test
- not required (not run)

Closes #27