### PR TITLE
ENH: START/STARTED arbitration before sending frames

### DIFF
--- a/protocol/bus.go
+++ b/protocol/bus.go
@@ -46,6 +46,10 @@ type busResult struct {
 	err   error
 }
 
+type arbitrationTransport interface {
+	StartArbitration(master byte) error
+}
+
 // Bus orchestrates prioritized frame sending and transaction matching.
 type Bus struct {
 	transport transport.RawTransport
@@ -170,6 +174,14 @@ func (b *Bus) sendWithRetries(runCtx context.Context, request *busRequest) (*Fra
 			return nil, err
 		}
 
+		if err := b.startArbitration(request.frame.Source); err != nil {
+			if retry, timeoutAttempts2, nackAttempts2 := shouldRetry(err, policy, timeoutAttempts, nackAttempts); retry {
+				timeoutAttempts, nackAttempts = timeoutAttempts2, nackAttempts2
+				continue
+			}
+			return nil, b.wrapRetryError(err)
+		}
+
 		if err := b.writeFrame(request.frame); err != nil {
 			return nil, fmt.Errorf("bus send write: %w", err)
 		}
@@ -225,8 +237,19 @@ func (b *Bus) retryPolicy(frameType FrameType) RetryPolicy {
 	}
 }
 
+func (b *Bus) startArbitration(master byte) error {
+	tr, ok := b.transport.(arbitrationTransport)
+	if !ok {
+		return nil
+	}
+	if err := tr.StartArbitration(master); err != nil {
+		return fmt.Errorf("bus arbitration failed: %w", err)
+	}
+	return nil
+}
+
 func shouldRetry(err error, policy RetryPolicy, timeoutAttempts, nackAttempts int) (bool, int, int) {
-	if errors.Is(err, ebuserrors.ErrTimeout) || errors.Is(err, ebuserrors.ErrCRCMismatch) {
+	if errors.Is(err, ebuserrors.ErrTimeout) || errors.Is(err, ebuserrors.ErrBusCollision) || errors.Is(err, ebuserrors.ErrCRCMismatch) {
 		if timeoutAttempts < policy.TimeoutRetries {
 			return true, timeoutAttempts + 1, nackAttempts
 		}
@@ -240,6 +263,9 @@ func shouldRetry(err error, policy RetryPolicy, timeoutAttempts, nackAttempts in
 }
 
 func (b *Bus) wrapRetryError(err error) error {
+	if errors.Is(err, ebuserrors.ErrBusCollision) {
+		return fmt.Errorf("bus send collision: %w", err)
+	}
 	if errors.Is(err, ebuserrors.ErrTimeout) {
 		return fmt.Errorf("bus send timeout: %w", err)
 	}

--- a/protocol/bus_test.go
+++ b/protocol/bus_test.go
@@ -425,4 +425,144 @@ func TestBus_NACKExhaustedWrapsSentinel(t *testing.T) {
 	}
 }
 
+type arbitratingScriptedTransport struct {
+	mu sync.Mutex
+
+	reads []readEvent
+
+	writes [][]byte
+	calls  []string
+
+	arbitrationMasters []byte
+	arbitrationResults []error
+}
+
+func (s *arbitratingScriptedTransport) StartArbitration(master byte) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.calls = append(s.calls, "arbitrate")
+	s.arbitrationMasters = append(s.arbitrationMasters, master)
+	if len(s.arbitrationResults) == 0 {
+		return nil
+	}
+	err := s.arbitrationResults[0]
+	s.arbitrationResults = s.arbitrationResults[1:]
+	return err
+}
+
+func (s *arbitratingScriptedTransport) ReadByte() (byte, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if len(s.reads) == 0 {
+		return 0, ebuserrors.ErrTimeout
+	}
+	ev := s.reads[0]
+	s.reads = s.reads[1:]
+	return ev.value, ev.err
+}
+
+func (s *arbitratingScriptedTransport) Write(payload []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.calls = append(s.calls, "write")
+	copyPayload := append([]byte(nil), payload...)
+	s.writes = append(s.writes, copyPayload)
+	return len(payload), nil
+}
+
+func (s *arbitratingScriptedTransport) Close() error {
+	return nil
+}
+
+func TestBus_ArbitrationCalledBeforeWrite(t *testing.T) {
+	t.Parallel()
+
+	tr := &arbitratingScriptedTransport{}
+	config := protocol.DefaultBusConfig()
+	bus := protocol.NewBus(tr, config, 8)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	bus.Run(ctx)
+
+	resp, err := bus.Send(ctx, protocol.Frame{
+		Source:    0x10,
+		Target:    protocol.AddressBroadcast,
+		Primary:   0x01,
+		Secondary: 0x02,
+		Data:      []byte{0x03},
+	})
+	if err != nil {
+		t.Fatalf("Send error = %v", err)
+	}
+	if resp != nil {
+		t.Fatalf("response = %+v; want nil", resp)
+	}
+
+	tr.mu.Lock()
+	calls := append([]string(nil), tr.calls...)
+	masters := append([]byte(nil), tr.arbitrationMasters...)
+	tr.mu.Unlock()
+
+	if len(calls) != 2 || calls[0] != "arbitrate" || calls[1] != "write" {
+		t.Fatalf("calls = %v; want [arbitrate write]", calls)
+	}
+	if len(masters) != 1 || masters[0] != 0x10 {
+		t.Fatalf("arbitration masters = %v; want [0x10]", masters)
+	}
+}
+
+func TestBus_RetryOnCollisionDuringArbitration(t *testing.T) {
+	t.Parallel()
+
+	tr := &arbitratingScriptedTransport{
+		arbitrationResults: []error{ebuserrors.ErrBusCollision, nil},
+		reads: []readEvent{
+			{value: protocol.SymbolAck},
+		},
+	}
+	config := protocol.BusConfig{
+		MasterSlave: protocol.RetryPolicy{
+			TimeoutRetries: 0,
+			NACKRetries:    0,
+		},
+		MasterMaster: protocol.RetryPolicy{
+			TimeoutRetries: 1,
+			NACKRetries:    0,
+		},
+	}
+	bus := protocol.NewBus(tr, config, 8)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	bus.Run(ctx)
+
+	resp, err := bus.Send(ctx, protocol.Frame{
+		Source:    0x30,
+		Target:    0x10,
+		Primary:   0x01,
+		Secondary: 0x02,
+		Data:      []byte{0x03},
+	})
+	if err != nil {
+		t.Fatalf("Send error = %v", err)
+	}
+	if resp != nil {
+		t.Fatalf("response = %+v; want nil", resp)
+	}
+
+	tr.mu.Lock()
+	writes := len(tr.writes)
+	masters := append([]byte(nil), tr.arbitrationMasters...)
+	tr.mu.Unlock()
+
+	if writes != 1 {
+		t.Fatalf("writes = %d; want 1", writes)
+	}
+	if len(masters) != 2 {
+		t.Fatalf("arbitration calls = %d; want 2", len(masters))
+	}
+}
+
 var _ transport.RawTransport = (*scriptedTransport)(nil)

--- a/transport/enh_transport.go
+++ b/transport/enh_transport.go
@@ -133,6 +133,85 @@ func (t *ENHTransport) Write(payload []byte) (int, error) {
 	return framesWritten, nil
 }
 
+// StartArbitration requests bus ownership for the given master address.
+// It sends ENHReqStart(master) and blocks until ENHResStarted(master) or ENHResFailed(winner).
+//
+// Any received ENHResReceived bytes observed while waiting are queued so that subsequent ReadByte
+// calls can consume them.
+func (t *ENHTransport) StartArbitration(master byte) error {
+	t.readMu.Lock()
+	defer t.readMu.Unlock()
+
+	t.writeMu.Lock()
+	seq := EncodeENH(ENHReqStart, master)
+	written := 0
+	for written < len(seq) {
+		if err := t.setWriteDeadline(); err != nil {
+			t.writeMu.Unlock()
+			return t.mapWriteError(err)
+		}
+		n, err := t.conn.Write(seq[written:])
+		written += n
+		if err != nil {
+			t.writeMu.Unlock()
+			return t.mapWriteError(err)
+		}
+		if n == 0 {
+			break
+		}
+	}
+	t.writeMu.Unlock()
+	if written != len(seq) {
+		return ebuserrors.ErrInvalidPayload
+	}
+
+	for {
+		if err := t.setReadDeadline(); err != nil {
+			return t.mapReadError(err)
+		}
+
+		n, err := t.conn.Read(t.buffer)
+		if err != nil {
+			return t.mapReadError(err)
+		}
+		if n == 0 {
+			continue
+		}
+
+		msgs, err := t.parser.Parse(t.buffer[:n])
+		if err != nil {
+			return err
+		}
+
+		var arbitrationDone bool
+		var arbitrationErr error
+		for _, msg := range msgs {
+			switch msg.Kind {
+			case ENHMessageData:
+				t.pending = append(t.pending, msg.Byte)
+			case ENHMessageFrame:
+				switch msg.Command {
+				case ENHResReceived:
+					if !t.shouldSuppressEcho(msg.Data) {
+						t.pending = append(t.pending, msg.Data)
+					}
+				case ENHResStarted:
+					if msg.Data == master {
+						arbitrationDone = true
+					}
+				case ENHResFailed:
+					arbitrationDone = true
+					arbitrationErr = fmt.Errorf("enh arbitration failed (master 0x%02x, winner 0x%02x): %w", master, msg.Data, ebuserrors.ErrBusCollision)
+				}
+			}
+		}
+
+		if arbitrationDone {
+			return arbitrationErr
+		}
+	}
+}
+
 func (t *ENHTransport) Close() error {
 	return t.conn.Close()
 }

--- a/transport/enh_transport_test.go
+++ b/transport/enh_transport_test.go
@@ -339,3 +339,115 @@ func TestENHTransport_SuppressesEchoBeforeWriteReturns(t *testing.T) {
 		t.Fatalf("server error = %v", err)
 	}
 }
+
+func TestENHTransport_StartArbitrationStartedQueuesReceivedBytes(t *testing.T) {
+	t.Parallel()
+
+	client, server := net.Pipe()
+	defer client.Close()
+	defer server.Close()
+
+	enh := transport.NewENHTransport(client, 200*time.Millisecond, 200*time.Millisecond)
+	master := byte(0x10)
+
+	serverErr := make(chan error, 1)
+	// Goroutine exits after validating the request and sending responses.
+	go func() {
+		buf := make([]byte, 2)
+		if _, err := io.ReadFull(server, buf); err != nil {
+			serverErr <- err
+			return
+		}
+		want := transport.EncodeENH(transport.ENHReqStart, master)
+		if buf[0] != want[0] || buf[1] != want[1] {
+			serverErr <- errors.New("unexpected arbitration request")
+			return
+		}
+
+		started := transport.EncodeENH(transport.ENHResStarted, master)
+		payload := []byte{0x11, started[0], started[1], 0x22}
+		_, err := server.Write(payload)
+		serverErr <- err
+	}()
+
+	if err := enh.StartArbitration(master); err != nil {
+		t.Fatalf("StartArbitration error = %v", err)
+	}
+
+	got1, err := enh.ReadByte()
+	if err != nil {
+		t.Fatalf("ReadByte error = %v", err)
+	}
+	if got1 != 0x11 {
+		t.Fatalf("ReadByte = 0x%02x; want 0x11", got1)
+	}
+
+	got2, err := enh.ReadByte()
+	if err != nil {
+		t.Fatalf("ReadByte error = %v", err)
+	}
+	if got2 != 0x22 {
+		t.Fatalf("ReadByte = 0x%02x; want 0x22", got2)
+	}
+
+	if err := <-serverErr; err != nil {
+		t.Fatalf("server error = %v", err)
+	}
+}
+
+func TestENHTransport_StartArbitrationFailedQueuesReceivedBytes(t *testing.T) {
+	t.Parallel()
+
+	client, server := net.Pipe()
+	defer client.Close()
+	defer server.Close()
+
+	enh := transport.NewENHTransport(client, 200*time.Millisecond, 200*time.Millisecond)
+	master := byte(0x10)
+	winner := byte(0x30)
+
+	serverErr := make(chan error, 1)
+	// Goroutine exits after validating the request and sending responses.
+	go func() {
+		buf := make([]byte, 2)
+		if _, err := io.ReadFull(server, buf); err != nil {
+			serverErr <- err
+			return
+		}
+		want := transport.EncodeENH(transport.ENHReqStart, master)
+		if buf[0] != want[0] || buf[1] != want[1] {
+			serverErr <- errors.New("unexpected arbitration request")
+			return
+		}
+
+		failed := transport.EncodeENH(transport.ENHResFailed, winner)
+		payload := []byte{0x33, failed[0], failed[1], 0x44}
+		_, err := server.Write(payload)
+		serverErr <- err
+	}()
+
+	err := enh.StartArbitration(master)
+	if !errors.Is(err, ebuserrors.ErrBusCollision) {
+		t.Fatalf("StartArbitration error = %v; want ErrBusCollision", err)
+	}
+
+	got1, err := enh.ReadByte()
+	if err != nil {
+		t.Fatalf("ReadByte error = %v", err)
+	}
+	if got1 != 0x33 {
+		t.Fatalf("ReadByte = 0x%02x; want 0x33", got1)
+	}
+
+	got2, err := enh.ReadByte()
+	if err != nil {
+		t.Fatalf("ReadByte error = %v", err)
+	}
+	if got2 != 0x44 {
+		t.Fatalf("ReadByte = 0x%02x; want 0x44", got2)
+	}
+
+	if err := <-serverErr; err != nil {
+		t.Fatalf("server error = %v", err)
+	}
+}


### PR DESCRIPTION
Implements issue #31: perform ENH START/STARTED arbitration before writing frames.

- ENH transport: send ENHReqStart(master), wait for ENHResStarted(master) or ENHResFailed(winner); queue ENHResReceived bytes while waiting.
- Bus: optionally calls StartArbitration via type assertion; retries arbitration collisions (ErrBusCollision) like timeouts.
- Tests: transport arbitration behavior + bus call order and retry-on-collision.

Tests: go test ./...