### PR TITLE
transport: ENH init handshake + reset handling

### DIFF
--- a/transport/enh_transport.go
+++ b/transport/enh_transport.go
@@ -41,6 +41,77 @@ func NewENHTransport(conn net.Conn, readTimeout, writeTimeout time.Duration) *EN
 	}
 }
 
+// Init performs an ENH initialization handshake by sending ENHReqInit(features)
+// and waiting for ENHResResetted(features).
+//
+// Any RESETTED frames observed later will reset the local parser and echo state.
+func (t *ENHTransport) Init(features byte) error {
+	t.readMu.Lock()
+	defer t.readMu.Unlock()
+
+	t.writeMu.Lock()
+	seq := EncodeENH(ENHReqInit, features)
+	written := 0
+	for written < len(seq) {
+		if err := t.setWriteDeadline(); err != nil {
+			t.writeMu.Unlock()
+			return t.mapWriteError(err)
+		}
+		n, err := t.conn.Write(seq[written:])
+		written += n
+		if err != nil {
+			t.writeMu.Unlock()
+			return t.mapWriteError(err)
+		}
+		if n == 0 {
+			break
+		}
+	}
+	t.writeMu.Unlock()
+	if written != len(seq) {
+		return ebuserrors.ErrInvalidPayload
+	}
+
+	for {
+		if err := t.setReadDeadline(); err != nil {
+			return t.mapReadError(err)
+		}
+
+		n, err := t.conn.Read(t.buffer)
+		if err != nil {
+			return t.mapReadError(err)
+		}
+		if n == 0 {
+			continue
+		}
+
+		msgs, err := t.parser.Parse(t.buffer[:n])
+		if err != nil {
+			return err
+		}
+		for _, msg := range msgs {
+			switch msg.Kind {
+			case ENHMessageData:
+				t.pending = append(t.pending, msg.Byte)
+			case ENHMessageFrame:
+				switch msg.Command {
+				case ENHResReceived:
+					if !t.shouldSuppressEcho(msg.Data) {
+						t.pending = append(t.pending, msg.Data)
+					}
+				case ENHResResetted:
+					t.resetStateLocked()
+					return nil
+				case ENHResErrorEBUS:
+					return fmt.Errorf("enh init ebus error 0x%02x: %w", msg.Data, ebuserrors.ErrInvalidPayload)
+				case ENHResErrorHost:
+					return fmt.Errorf("enh init host error 0x%02x: %w", msg.Data, ebuserrors.ErrInvalidPayload)
+				}
+			}
+		}
+	}
+}
+
 func (t *ENHTransport) ReadByte() (byte, error) {
 	t.readMu.Lock()
 	defer t.readMu.Unlock()
@@ -73,10 +144,13 @@ func (t *ENHTransport) ReadByte() (byte, error) {
 			case ENHMessageData:
 				t.pending = append(t.pending, msg.Byte)
 			case ENHMessageFrame:
-				if msg.Command == ENHResReceived {
+				switch msg.Command {
+				case ENHResReceived:
 					if !t.shouldSuppressEcho(msg.Data) {
 						t.pending = append(t.pending, msg.Data)
 					}
+				case ENHResResetted:
+					t.resetStateLocked()
 				}
 			}
 		}
@@ -200,6 +274,8 @@ func (t *ENHTransport) StartArbitration(master byte) error {
 					if !t.shouldSuppressEcho(msg.Data) {
 						t.pending = append(t.pending, msg.Data)
 					}
+				case ENHResResetted:
+					t.resetStateLocked()
 				case ENHResStarted:
 					if msg.Data == master {
 						arbitrationDone = true
@@ -219,6 +295,14 @@ func (t *ENHTransport) StartArbitration(master byte) error {
 
 func (t *ENHTransport) Close() error {
 	return t.conn.Close()
+}
+
+func (t *ENHTransport) resetStateLocked() {
+	t.parser.Reset()
+	t.pending = nil
+	t.echoMu.Lock()
+	t.echoPending = nil
+	t.echoMu.Unlock()
 }
 
 func (t *ENHTransport) setReadDeadline() error {

--- a/transport/enh_transport_test.go
+++ b/transport/enh_transport_test.go
@@ -46,6 +46,84 @@ func TestENHTransport_ReadByteDecodesFrames(t *testing.T) {
 	}
 }
 
+func TestENHTransport_InitHandshake(t *testing.T) {
+	t.Parallel()
+
+	client, server := net.Pipe()
+	defer client.Close()
+	defer server.Close()
+
+	enh := transport.NewENHTransport(client, 200*time.Millisecond, 200*time.Millisecond)
+
+	serverErr := make(chan error, 1)
+	go func() {
+		defer close(serverErr)
+
+		buf := make([]byte, 2)
+		if _, err := io.ReadFull(server, buf); err != nil {
+			serverErr <- err
+			return
+		}
+
+		want := transport.EncodeENH(transport.ENHReqInit, 0x00)
+		if buf[0] != want[0] || buf[1] != want[1] {
+			serverErr <- errors.New("unexpected init bytes")
+			return
+		}
+
+		resp := transport.EncodeENH(transport.ENHResResetted, 0x00)
+		_, err := server.Write(resp[:])
+		serverErr <- err
+	}()
+
+	if err := enh.Init(0x00); err != nil {
+		t.Fatalf("Init error = %v", err)
+	}
+	if err := <-serverErr; err != nil {
+		t.Fatalf("server error = %v", err)
+	}
+}
+
+func TestENHTransport_ResetClearsEchoSuppression(t *testing.T) {
+	t.Parallel()
+
+	client, server := net.Pipe()
+	defer client.Close()
+	defer server.Close()
+
+	enh := transport.NewENHTransport(client, 200*time.Millisecond, 200*time.Millisecond)
+
+	serverErr := make(chan error, 1)
+	go func() {
+		defer close(serverErr)
+
+		buf := make([]byte, 2)
+		if _, err := io.ReadFull(server, buf); err != nil {
+			serverErr <- err
+			return
+		}
+
+		reset := transport.EncodeENH(transport.ENHResResetted, 0x00)
+		payload := []byte{reset[0], reset[1], 0x11, 0x22}
+		_, err := server.Write(payload)
+		serverErr <- err
+	}()
+
+	if _, err := enh.Write([]byte{0x11}); err != nil {
+		t.Fatalf("Write error = %v", err)
+	}
+	got, err := enh.ReadByte()
+	if err != nil {
+		t.Fatalf("ReadByte error = %v", err)
+	}
+	if got != 0x11 {
+		t.Fatalf("ReadByte = 0x%02x; want 0x11", got)
+	}
+	if err := <-serverErr; err != nil {
+		t.Fatalf("server error = %v", err)
+	}
+}
+
 func TestENHTransport_WriteEncodesFrames(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Fixes #35.

- Add `(*ENHTransport).Init(features)` (ENHReqInit → ENHResResetted).
- Handle ENHResResetted mid-stream by clearing parser + pending + echo state.
- Add tests for init handshake and reset/echo interaction.

Tests: `go test ./...`