### PR TITLE
bus: retry collisions until ctx deadline

### DIFF
--- a/protocol/bus.go
+++ b/protocol/bus.go
@@ -231,7 +231,11 @@ func (b *Bus) startArbitration(master byte) error {
 }
 
 func shouldRetry(err error, policy RetryPolicy, timeoutAttempts, nackAttempts int) (bool, int, int) {
-	if errors.Is(err, ebuserrors.ErrTimeout) || errors.Is(err, ebuserrors.ErrBusCollision) || errors.Is(err, ebuserrors.ErrCRCMismatch) {
+	// Collisions are transient bus-ownership events; keep retrying (bounded by ctx).
+	if errors.Is(err, ebuserrors.ErrBusCollision) {
+		return true, timeoutAttempts, nackAttempts
+	}
+	if errors.Is(err, ebuserrors.ErrTimeout) || errors.Is(err, ebuserrors.ErrCRCMismatch) {
 		if timeoutAttempts < policy.TimeoutRetries {
 			return true, timeoutAttempts + 1, nackAttempts
 		}

--- a/protocol/bus_test.go
+++ b/protocol/bus_test.go
@@ -670,4 +670,51 @@ func TestBus_RetryOnCollisionDuringWriteWaitsForSyn(t *testing.T) {
 	}
 }
 
+func TestBus_RetryOnCollisionDoesNotConsumeTimeoutRetries(t *testing.T) {
+	t.Parallel()
+
+	frame := protocol.Frame{
+		Source:    0x10,
+		Target:    0x08,
+		Primary:   0x07,
+		Secondary: 0x04,
+	}
+
+	data := byte(0x10)
+	respCRC := protocol.CRC([]byte{0x01, data})
+	tr := &collisionOnceTransport{
+		collideOnFirstEcho: true,
+		inbound: []readEvent{
+			{value: protocol.SymbolSyn},
+			{value: protocol.SymbolSyn},
+			{value: protocol.SymbolAck},
+			{value: 0x01},
+			{value: data},
+			{value: respCRC},
+		},
+	}
+	config := protocol.BusConfig{
+		MasterSlave: protocol.RetryPolicy{
+			TimeoutRetries: 0,
+			NACKRetries:    0,
+		},
+		MasterMaster: protocol.RetryPolicy{
+			TimeoutRetries: 0,
+			NACKRetries:    0,
+		},
+	}
+	bus := protocol.NewBus(tr, config, 8)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	bus.Run(ctx)
+
+	resp, err := bus.Send(ctx, frame)
+	if err != nil {
+		t.Fatalf("Send error = %v", err)
+	}
+	if resp == nil || len(resp.Data) != 1 || resp.Data[0] != data {
+		t.Fatalf("response = %+v; want data [0x10]", resp)
+	}
+}
+
 var _ transport.RawTransport = (*scriptedTransport)(nil)


### PR DESCRIPTION
Fixes #43.

- Treat ErrBusCollision as a retryable condition that does not consume TimeoutRetries (still bounded by request context).
- Add unit test proving collision retry works even with TimeoutRetries=0.