### PR TITLE
bus: reset SYN backoff decoder on timeout

### DIFF
--- a/protocol/bus.go
+++ b/protocol/bus.go
@@ -502,6 +502,7 @@ func (b *Bus) waitForSyn(runCtx, reqCtx context.Context, count int) error {
 		value, err := decoder.readSymbol(b, runCtx, reqCtx)
 		if err != nil {
 			if errors.Is(err, ebuserrors.ErrTimeout) {
+				decoder.escape = false
 				continue
 			}
 			return err

--- a/protocol/bus_test.go
+++ b/protocol/bus_test.go
@@ -575,6 +575,8 @@ func TestBus_RetryOnCollisionDuringArbitration(t *testing.T) {
 	tr := &arbitratingScriptedTransport{
 		arbitrationResults: []error{ebuserrors.ErrBusCollision, nil},
 		inbound: []readEvent{
+			{value: protocol.SymbolEscape},
+			{err: ebuserrors.ErrTimeout},
 			{value: protocol.SymbolSyn},
 			{value: protocol.SymbolSyn},
 			{value: protocol.SymbolAck},


### PR DESCRIPTION
Fixes #45.

Codex review follow-up from PR #42: waitForSyn now resets decoder escape state on ErrTimeout so a partial ESC + timeout does not poison subsequent reads (e.g. idle SYN).

Tests:
- Updated arbitration collision test to cover ESC + timeout + SYN sequence.
- go test ./...
- go run ./cmd/tinygo-check