### PR TITLE
bus: bound collision retries for non-cancelable contexts

### DIFF
--- a/protocol/bus.go
+++ b/protocol/bus.go
@@ -168,6 +168,7 @@ func (b *Bus) sendWithRetries(runCtx context.Context, request *busRequest) (*Fra
 
 	timeoutAttempts := 0
 	nackAttempts := 0
+	allowUnboundedCollision := isBoundedContext(request.ctx)
 
 	for {
 		if err := b.contextError(runCtx, request.ctx); err != nil {
@@ -184,7 +185,7 @@ func (b *Bus) sendWithRetries(runCtx context.Context, request *busRequest) (*Fra
 				}
 				continue
 			}
-			if retry, timeoutAttempts2, nackAttempts2 := shouldRetry(err, policy, timeoutAttempts, nackAttempts); retry {
+			if retry, timeoutAttempts2, nackAttempts2 := shouldRetry(err, policy, timeoutAttempts, nackAttempts, allowUnboundedCollision); retry {
 				timeoutAttempts, nackAttempts = timeoutAttempts2, nackAttempts2
 				continue
 			}
@@ -195,7 +196,7 @@ func (b *Bus) sendWithRetries(runCtx context.Context, request *busRequest) (*Fra
 		if err == nil {
 			return response, nil
 		}
-		if retry, timeoutAttempts2, nackAttempts2 := shouldRetry(err, policy, timeoutAttempts, nackAttempts); retry {
+		if retry, timeoutAttempts2, nackAttempts2 := shouldRetry(err, policy, timeoutAttempts, nackAttempts, allowUnboundedCollision); retry {
 			timeoutAttempts, nackAttempts = timeoutAttempts2, nackAttempts2
 			if errors.Is(err, ebuserrors.ErrBusCollision) {
 				if waitErr := b.waitForSyn(runCtx, request.ctx, 2); waitErr != nil {
@@ -230,10 +231,16 @@ func (b *Bus) startArbitration(master byte) error {
 	return nil
 }
 
-func shouldRetry(err error, policy RetryPolicy, timeoutAttempts, nackAttempts int) (bool, int, int) {
-	// Collisions are transient bus-ownership events; keep retrying (bounded by ctx).
+func shouldRetry(err error, policy RetryPolicy, timeoutAttempts, nackAttempts int, allowUnboundedCollision bool) (bool, int, int) {
+	// Collisions are transient bus-ownership events; retry until ctx deadline/cancel.
 	if errors.Is(err, ebuserrors.ErrBusCollision) {
-		return true, timeoutAttempts, nackAttempts
+		if allowUnboundedCollision {
+			return true, timeoutAttempts, nackAttempts
+		}
+		if timeoutAttempts < policy.TimeoutRetries {
+			return true, timeoutAttempts + 1, nackAttempts
+		}
+		return false, timeoutAttempts, nackAttempts
 	}
 	if errors.Is(err, ebuserrors.ErrTimeout) || errors.Is(err, ebuserrors.ErrCRCMismatch) {
 		if timeoutAttempts < policy.TimeoutRetries {
@@ -246,6 +253,16 @@ func shouldRetry(err error, policy RetryPolicy, timeoutAttempts, nackAttempts in
 		}
 	}
 	return false, timeoutAttempts, nackAttempts
+}
+
+func isBoundedContext(ctx context.Context) bool {
+	if ctx == nil {
+		return false
+	}
+	if _, ok := ctx.Deadline(); ok {
+		return true
+	}
+	return ctx.Done() != nil
 }
 
 func (b *Bus) wrapRetryError(err error) error {

--- a/protocol/bus_test.go
+++ b/protocol/bus_test.go
@@ -719,4 +719,48 @@ func TestBus_RetryOnCollisionDoesNotConsumeTimeoutRetries(t *testing.T) {
 	}
 }
 
+func TestBus_CollisionRetryRespectsTimeoutRetriesWithoutDeadline(t *testing.T) {
+	t.Parallel()
+
+	frame := protocol.Frame{
+		Source:    0x10,
+		Target:    0x08,
+		Primary:   0x07,
+		Secondary: 0x04,
+	}
+
+	data := byte(0x10)
+	respCRC := protocol.CRC([]byte{0x01, data})
+	tr := &collisionOnceTransport{
+		collideOnFirstEcho: true,
+		inbound: []readEvent{
+			{value: protocol.SymbolSyn},
+			{value: protocol.SymbolSyn},
+			{value: protocol.SymbolAck},
+			{value: 0x01},
+			{value: data},
+			{value: respCRC},
+		},
+	}
+	config := protocol.BusConfig{
+		MasterSlave: protocol.RetryPolicy{
+			TimeoutRetries: 0,
+			NACKRetries:    0,
+		},
+		MasterMaster: protocol.RetryPolicy{
+			TimeoutRetries: 0,
+			NACKRetries:    0,
+		},
+	}
+	bus := protocol.NewBus(tr, config, 8)
+	runCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	bus.Run(runCtx)
+
+	_, err := bus.Send(context.Background(), frame)
+	if !errors.Is(err, ebuserrors.ErrBusCollision) {
+		t.Fatalf("Send error = %v; want ErrBusCollision", err)
+	}
+}
+
 var _ transport.RawTransport = (*scriptedTransport)(nil)


### PR DESCRIPTION
Fixes #47.

- Only retry ErrBusCollision unbounded when the request context is cancelable or has a deadline.
- For non-cancelable contexts (Background/TODO), collisions respect RetryPolicy.TimeoutRetries to avoid infinite loops.
- Add unit test covering Background context + TimeoutRetries=0.