### PR TITLE
Fix ENH waitForSyn timeout reset and bound collisions

### DIFF
--- a/protocol/bus.go
+++ b/protocol/bus.go
@@ -180,10 +180,14 @@ func (b *Bus) sendWithRetries(runCtx context.Context, request *busRequest) (*Fra
 				// Arbitration can be lost while another master owns the bus.
 				// ebusd waits for subsequent SYN symbols before retrying; do the
 				// same here (bounded by request context deadline).
-				if waitErr := b.waitForSyn(runCtx, request.ctx, 2); waitErr != nil {
-					return nil, b.wrapRetryError(waitErr)
+				if retry, timeoutAttempts2, nackAttempts2 := shouldRetry(err, policy, timeoutAttempts, nackAttempts, allowUnboundedCollision); retry {
+					timeoutAttempts, nackAttempts = timeoutAttempts2, nackAttempts2
+					if waitErr := b.waitForSyn(runCtx, request.ctx, 2); waitErr != nil {
+						return nil, b.wrapRetryError(waitErr)
+					}
+					continue
 				}
-				continue
+				return nil, b.wrapRetryError(err)
 			}
 			if retry, timeoutAttempts2, nackAttempts2 := shouldRetry(err, policy, timeoutAttempts, nackAttempts, allowUnboundedCollision); retry {
 				timeoutAttempts, nackAttempts = timeoutAttempts2, nackAttempts2
@@ -262,7 +266,7 @@ func isBoundedContext(ctx context.Context) bool {
 	if _, ok := ctx.Deadline(); ok {
 		return true
 	}
-	return ctx.Done() != nil
+	return false
 }
 
 func (b *Bus) wrapRetryError(err error) error {
@@ -303,6 +307,9 @@ func (d *busDecoder) readSymbol(b *Bus, runCtx, reqCtx context.Context) (byte, e
 	for {
 		raw, err := b.readByte(runCtx, reqCtx)
 		if err != nil {
+			if errors.Is(err, ebuserrors.ErrTimeout) {
+				d.escape = false
+			}
 			return 0, err
 		}
 
@@ -519,7 +526,6 @@ func (b *Bus) waitForSyn(runCtx, reqCtx context.Context, count int) error {
 		value, err := decoder.readSymbol(b, runCtx, reqCtx)
 		if err != nil {
 			if errors.Is(err, ebuserrors.ErrTimeout) {
-				decoder.escape = false
 				continue
 			}
 			return err

--- a/protocol/bus_test.go
+++ b/protocol/bus_test.go
@@ -618,6 +618,51 @@ func TestBus_RetryOnCollisionDuringArbitration(t *testing.T) {
 	}
 }
 
+func TestBus_ArbitrationCollisionBoundWithoutDeadline(t *testing.T) {
+	t.Parallel()
+
+	frame := protocol.Frame{
+		Source:    0x30,
+		Target:    0x10,
+		Primary:   0x01,
+		Secondary: 0x02,
+		Data:      []byte{0x03},
+	}
+
+	tr := &arbitratingScriptedTransport{
+		arbitrationResults: []error{ebuserrors.ErrBusCollision, ebuserrors.ErrBusCollision},
+	}
+	config := protocol.BusConfig{
+		MasterSlave: protocol.RetryPolicy{
+			TimeoutRetries: 0,
+			NACKRetries:    0,
+		},
+		MasterMaster: protocol.RetryPolicy{
+			TimeoutRetries: 0,
+			NACKRetries:    0,
+		},
+	}
+	bus := protocol.NewBus(tr, config, 8)
+	runCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	bus.Run(runCtx)
+
+	reqCtx, reqCancel := context.WithCancel(context.Background())
+	defer reqCancel()
+
+	_, err := bus.Send(reqCtx, frame)
+	if !errors.Is(err, ebuserrors.ErrBusCollision) {
+		t.Fatalf("Send error = %v; want ErrBusCollision", err)
+	}
+
+	tr.mu.Lock()
+	masters := len(tr.arbitrationMasters)
+	tr.mu.Unlock()
+	if masters != 1 {
+		t.Fatalf("arbitration calls = %d; want 1", masters)
+	}
+}
+
 func TestBus_RetryOnCollisionDuringWriteWaitsForSyn(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- reset decoder escape state on read timeouts to avoid invalid payloads after waitForSyn timeouts
- bound arbitration collision retries when the request context has no deadline
- add test coverage for bounded arbitration collision retries without deadlines

## Testing
- go test ./...

Closes #49
Smoke test: not required