### PR TITLE
Use initiator/target terminology across repo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,16 @@ on:
   pull_request:
 
 jobs:
+  terminology:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: |
+          if grep -RInwi --exclude-dir=.git -E 'm[a]ster|s[l]ave' .; then
+            echo "Found legacy terminology."
+            exit 1
+          fi
+
   build:
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -109,14 +109,14 @@ _ = resp
 _ = err
 ```
 
-Tip: use a bounded context (`context.WithTimeout`) for `Send` calls on multi-master buses.
+Tip: use a bounded context (`context.WithTimeout`) for `Send` calls on multi-initiator buses.
 
 ## Troubleshooting
 
 | Symptom / error | Likely cause | Practical fix |
 |---|---|---|
 | `ErrTimeout` | target did not answer, or timeout too short | verify address/telegram and increase read timeout / request context |
-| `ErrBusCollision` | arbitration lost to another master | retry with bounded context; verify master address and bus contention |
+| `ErrBusCollision` | arbitration lost to another initiator | retry with bounded context; verify initiator address and bus contention |
 | `ErrCRCMismatch` | framing/escaping mismatch or corrupted response | ensure transport matches endpoint (`enh` vs `ens` vs `ebusd-tcp`) |
 | `ErrInvalidPayload` | malformed adapter data or wrong backend assumption | confirm backend protocol and command endpoint; inspect raw response fixture |
 | `ErrTransportClosed` | socket/connection dropped | reconnect, recreate transport, then recreate/restart `Bus` |

--- a/errors/errors.go
+++ b/errors/errors.go
@@ -6,7 +6,7 @@ var (
 	ErrBusCollision = stderrors.New("ebus: bus collision during arbitration")
 	ErrTimeout      = stderrors.New("ebus: no response within timeout window")
 	ErrCRCMismatch  = stderrors.New("ebus: CRC validation failed")
-	ErrNACK         = stderrors.New("ebus: slave returned NACK")
+	ErrNACK         = stderrors.New("ebus: target returned NACK")
 	ErrNoSuchDevice = stderrors.New("ebus: no device responded at address")
 
 	ErrRetryExhausted  = stderrors.New("ebus: retries exhausted")

--- a/protocol/bus.go
+++ b/protocol/bus.go
@@ -18,17 +18,17 @@ type RetryPolicy struct {
 }
 
 type BusConfig struct {
-	MasterSlave  RetryPolicy
-	MasterMaster RetryPolicy
+	InitiatorTarget    RetryPolicy
+	InitiatorInitiator RetryPolicy
 }
 
 func DefaultBusConfig() BusConfig {
 	return BusConfig{
-		MasterSlave: RetryPolicy{
+		InitiatorTarget: RetryPolicy{
 			TimeoutRetries: 2,
 			NACKRetries:    1,
 		},
-		MasterMaster: RetryPolicy{
+		InitiatorInitiator: RetryPolicy{
 			TimeoutRetries: 2,
 			NACKRetries:    1,
 		},
@@ -47,7 +47,7 @@ type busResult struct {
 }
 
 type arbitrationTransport interface {
-	StartArbitration(master byte) error
+	StartArbitration(initiator byte) error
 }
 
 // Bus orchestrates prioritized frame sending and transaction matching.
@@ -77,7 +77,7 @@ func NewBus(tr transport.RawTransport, config BusConfig, queueCapacity int) *Bus
 		queue:     newPriorityQueue(),
 		// Capacity 1 to coalesce wake-ups from multiple Send calls.
 		notify: make(chan struct{}, 1),
-		outCap:    queueCapacity,
+		outCap: queueCapacity,
 	}
 }
 
@@ -177,7 +177,7 @@ func (b *Bus) sendWithRetries(runCtx context.Context, request *busRequest) (*Fra
 
 		if err := b.startArbitration(request.frame.Source); err != nil {
 			if errors.Is(err, ebuserrors.ErrBusCollision) {
-				// Arbitration can be lost while another master owns the bus.
+				// Arbitration can be lost while another initiator owns the bus.
 				// ebusd waits for subsequent SYN symbols before retrying; do the
 				// same here (bounded by request context deadline).
 				if retry, timeoutAttempts2, nackAttempts2 := shouldRetry(err, policy, timeoutAttempts, nackAttempts, allowUnboundedCollision); retry {
@@ -215,21 +215,21 @@ func (b *Bus) sendWithRetries(runCtx context.Context, request *busRequest) (*Fra
 
 func (b *Bus) retryPolicy(frameType FrameType) RetryPolicy {
 	switch frameType {
-	case FrameTypeMasterMaster:
-		return b.config.MasterMaster
-	case FrameTypeMasterSlave:
-		return b.config.MasterSlave
+	case FrameTypeInitiatorInitiator:
+		return b.config.InitiatorInitiator
+	case FrameTypeInitiatorTarget:
+		return b.config.InitiatorTarget
 	default:
 		return RetryPolicy{}
 	}
 }
 
-func (b *Bus) startArbitration(master byte) error {
+func (b *Bus) startArbitration(initiator byte) error {
 	tr, ok := b.transport.(arbitrationTransport)
 	if !ok {
 		return nil
 	}
-	if err := tr.StartArbitration(master); err != nil {
+	if err := tr.StartArbitration(initiator); err != nil {
 		return fmt.Errorf("bus arbitration failed: %w", err)
 	}
 	return nil
@@ -339,11 +339,11 @@ func (b *Bus) sendTransaction(runCtx, reqCtx context.Context, frame Frame) (*Fra
 		return nil, fmt.Errorf("bus send unknown frame type: %w", ebuserrors.ErrInvalidPayload)
 	}
 
-	// Master telegram (unescaped symbols): SRC DST PB SB LEN DATA... CRC
-	master := make([]byte, 0, 6+len(frame.Data))
-	master = append(master, frame.Source, frame.Target, frame.Primary, frame.Secondary, byte(len(frame.Data)))
-	master = append(master, frame.Data...)
-	master = append(master, CRC(master))
+	// Initiator telegram (unescaped symbols): SRC DST PB SB LEN DATA... CRC
+	telegram := make([]byte, 0, 6+len(frame.Data))
+	telegram = append(telegram, frame.Source, frame.Target, frame.Primary, frame.Secondary, byte(len(frame.Data)))
+	telegram = append(telegram, frame.Data...)
+	telegram = append(telegram, CRC(telegram))
 
 	decoder := &busDecoder{}
 
@@ -354,7 +354,7 @@ func (b *Bus) sendTransaction(runCtx, reqCtx context.Context, frame Frame) (*Fra
 	}
 
 	for attempt := 0; attempt < 2; attempt++ {
-		if err := b.sendMasterTelegram(runCtx, reqCtx, master, includeSource); err != nil {
+		if err := b.sendInitiatorTelegram(runCtx, reqCtx, telegram, includeSource); err != nil {
 			return nil, err
 		}
 
@@ -387,13 +387,13 @@ func (b *Bus) sendTransaction(runCtx, reqCtx context.Context, frame Frame) (*Fra
 		}
 	}
 
-	if frameType == FrameTypeMasterMaster {
+	if frameType == FrameTypeInitiatorInitiator {
 		if err := b.sendEndOfMessage(runCtx, reqCtx); err != nil {
 			return nil, err
 		}
 		return nil, nil
 	}
-	if frameType != FrameTypeMasterSlave {
+	if frameType != FrameTypeInitiatorTarget {
 		return nil, fmt.Errorf("bus send unknown frame type: %w", ebuserrors.ErrInvalidPayload)
 	}
 
@@ -459,7 +459,7 @@ func (b *Bus) sendTransaction(runCtx, reqCtx context.Context, frame Frame) (*Fra
 	return nil, fmt.Errorf("unreachable response loop: %w", ebuserrors.ErrTimeout)
 }
 
-func (b *Bus) sendMasterTelegram(runCtx, reqCtx context.Context, telegram []byte, includeSource bool) error {
+func (b *Bus) sendInitiatorTelegram(runCtx, reqCtx context.Context, telegram []byte, includeSource bool) error {
 	start := 0
 	if !includeSource {
 		start = 1

--- a/protocol/bus_test.go
+++ b/protocol/bus_test.go
@@ -174,7 +174,7 @@ func TestBus_BroadcastDoesNotReadAck(t *testing.T) {
 	}
 }
 
-func TestBus_MasterMasterAckOnly(t *testing.T) {
+func TestBus_InitiatorInitiatorAckOnly(t *testing.T) {
 	t.Parallel()
 
 	frame := protocol.Frame{
@@ -237,11 +237,11 @@ func TestBus_ResponseCRCMismatch(t *testing.T) {
 		},
 	}
 	config := protocol.BusConfig{
-		MasterSlave: protocol.RetryPolicy{
+		InitiatorTarget: protocol.RetryPolicy{
 			TimeoutRetries: 0,
 			NACKRetries:    0,
 		},
-		MasterMaster: protocol.RetryPolicy{
+		InitiatorInitiator: protocol.RetryPolicy{
 			TimeoutRetries: 0,
 			NACKRetries:    0,
 		},
@@ -287,11 +287,11 @@ func TestBus_RetryOnCRCMismatch(t *testing.T) {
 		},
 	}
 	config := protocol.BusConfig{
-		MasterSlave: protocol.RetryPolicy{
+		InitiatorTarget: protocol.RetryPolicy{
 			TimeoutRetries: 1,
 			NACKRetries:    0,
 		},
-		MasterMaster: protocol.RetryPolicy{
+		InitiatorInitiator: protocol.RetryPolicy{
 			TimeoutRetries: 1,
 			NACKRetries:    0,
 		},
@@ -336,11 +336,11 @@ func TestBus_RetryOnTimeout(t *testing.T) {
 		},
 	}
 	config := protocol.BusConfig{
-		MasterSlave: protocol.RetryPolicy{
+		InitiatorTarget: protocol.RetryPolicy{
 			TimeoutRetries: 1,
 			NACKRetries:    0,
 		},
-		MasterMaster: protocol.RetryPolicy{
+		InitiatorInitiator: protocol.RetryPolicy{
 			TimeoutRetries: 1,
 			NACKRetries:    0,
 		},
@@ -392,11 +392,11 @@ func TestBus_RetryOnNACK(t *testing.T) {
 		},
 	}
 	config := protocol.BusConfig{
-		MasterSlave: protocol.RetryPolicy{
+		InitiatorTarget: protocol.RetryPolicy{
 			TimeoutRetries: 0,
 			NACKRetries:    1,
 		},
-		MasterMaster: protocol.RetryPolicy{
+		InitiatorInitiator: protocol.RetryPolicy{
 			TimeoutRetries: 0,
 			NACKRetries:    1,
 		},
@@ -443,11 +443,11 @@ func TestBus_NACKExhaustedWrapsSentinel(t *testing.T) {
 		},
 	}
 	config := protocol.BusConfig{
-		MasterSlave: protocol.RetryPolicy{
+		InitiatorTarget: protocol.RetryPolicy{
 			TimeoutRetries: 0,
 			NACKRetries:    0,
 		},
-		MasterMaster: protocol.RetryPolicy{
+		InitiatorInitiator: protocol.RetryPolicy{
 			TimeoutRetries: 0,
 			NACKRetries:    0,
 		},
@@ -472,16 +472,16 @@ type arbitratingScriptedTransport struct {
 	writes [][]byte
 	calls  []string
 
-	arbitrationMasters []byte
-	arbitrationResults []error
+	arbitrationInitiators []byte
+	arbitrationResults    []error
 }
 
-func (s *arbitratingScriptedTransport) StartArbitration(master byte) error {
+func (s *arbitratingScriptedTransport) StartArbitration(initiator byte) error {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	s.calls = append(s.calls, "arbitrate")
-	s.arbitrationMasters = append(s.arbitrationMasters, master)
+	s.arbitrationInitiators = append(s.arbitrationInitiators, initiator)
 	if len(s.arbitrationResults) == 0 {
 		return nil
 	}
@@ -550,14 +550,14 @@ func TestBus_ArbitrationCalledBeforeWrite(t *testing.T) {
 
 	tr.mu.Lock()
 	calls := append([]string(nil), tr.calls...)
-	masters := append([]byte(nil), tr.arbitrationMasters...)
+	initiators := append([]byte(nil), tr.arbitrationInitiators...)
 	tr.mu.Unlock()
 
 	if len(calls) < 2 || calls[0] != "arbitrate" {
 		t.Fatalf("calls = %v; want first call arbitrate", calls)
 	}
-	if len(masters) != 1 || masters[0] != 0x10 {
-		t.Fatalf("arbitration masters = %v; want [0x10]", masters)
+	if len(initiators) != 1 || initiators[0] != 0x10 {
+		t.Fatalf("arbitration initiators = %v; want [0x10]", initiators)
 	}
 }
 
@@ -583,11 +583,11 @@ func TestBus_RetryOnCollisionDuringArbitration(t *testing.T) {
 		},
 	}
 	config := protocol.BusConfig{
-		MasterSlave: protocol.RetryPolicy{
+		InitiatorTarget: protocol.RetryPolicy{
 			TimeoutRetries: 0,
 			NACKRetries:    0,
 		},
-		MasterMaster: protocol.RetryPolicy{
+		InitiatorInitiator: protocol.RetryPolicy{
 			TimeoutRetries: 1,
 			NACKRetries:    0,
 		},
@@ -607,14 +607,14 @@ func TestBus_RetryOnCollisionDuringArbitration(t *testing.T) {
 
 	tr.mu.Lock()
 	writes := len(tr.writes)
-	masters := append([]byte(nil), tr.arbitrationMasters...)
+	initiators := append([]byte(nil), tr.arbitrationInitiators...)
 	tr.mu.Unlock()
 
 	if writes == 0 {
 		t.Fatalf("writes = %d; want >0", writes)
 	}
-	if len(masters) != 2 {
-		t.Fatalf("arbitration calls = %d; want 2", len(masters))
+	if len(initiators) != 2 {
+		t.Fatalf("arbitration calls = %d; want 2", len(initiators))
 	}
 }
 
@@ -633,11 +633,11 @@ func TestBus_ArbitrationCollisionBoundWithoutDeadline(t *testing.T) {
 		arbitrationResults: []error{ebuserrors.ErrBusCollision, ebuserrors.ErrBusCollision},
 	}
 	config := protocol.BusConfig{
-		MasterSlave: protocol.RetryPolicy{
+		InitiatorTarget: protocol.RetryPolicy{
 			TimeoutRetries: 0,
 			NACKRetries:    0,
 		},
-		MasterMaster: protocol.RetryPolicy{
+		InitiatorInitiator: protocol.RetryPolicy{
 			TimeoutRetries: 0,
 			NACKRetries:    0,
 		},
@@ -656,10 +656,10 @@ func TestBus_ArbitrationCollisionBoundWithoutDeadline(t *testing.T) {
 	}
 
 	tr.mu.Lock()
-	masters := len(tr.arbitrationMasters)
+	initiators := len(tr.arbitrationInitiators)
 	tr.mu.Unlock()
-	if masters != 1 {
-		t.Fatalf("arbitration calls = %d; want 1", masters)
+	if initiators != 1 {
+		t.Fatalf("arbitration calls = %d; want 1", initiators)
 	}
 }
 
@@ -687,11 +687,11 @@ func TestBus_RetryOnCollisionDuringWriteWaitsForSyn(t *testing.T) {
 		},
 	}
 	config := protocol.BusConfig{
-		MasterSlave: protocol.RetryPolicy{
+		InitiatorTarget: protocol.RetryPolicy{
 			TimeoutRetries: 1,
 			NACKRetries:    0,
 		},
-		MasterMaster: protocol.RetryPolicy{
+		InitiatorInitiator: protocol.RetryPolicy{
 			TimeoutRetries: 1,
 			NACKRetries:    0,
 		},
@@ -741,11 +741,11 @@ func TestBus_RetryOnCollisionDoesNotConsumeTimeoutRetries(t *testing.T) {
 		},
 	}
 	config := protocol.BusConfig{
-		MasterSlave: protocol.RetryPolicy{
+		InitiatorTarget: protocol.RetryPolicy{
 			TimeoutRetries: 0,
 			NACKRetries:    0,
 		},
-		MasterMaster: protocol.RetryPolicy{
+		InitiatorInitiator: protocol.RetryPolicy{
 			TimeoutRetries: 0,
 			NACKRetries:    0,
 		},
@@ -788,11 +788,11 @@ func TestBus_CollisionRetryRespectsTimeoutRetriesWithoutDeadline(t *testing.T) {
 		},
 	}
 	config := protocol.BusConfig{
-		MasterSlave: protocol.RetryPolicy{
+		InitiatorTarget: protocol.RetryPolicy{
 			TimeoutRetries: 0,
 			NACKRetries:    0,
 		},
-		MasterMaster: protocol.RetryPolicy{
+		InitiatorInitiator: protocol.RetryPolicy{
 			TimeoutRetries: 0,
 			NACKRetries:    0,
 		},

--- a/protocol/frame_test.go
+++ b/protocol/frame_test.go
@@ -20,14 +20,14 @@ func TestFrameTypeForTarget(t *testing.T) {
 			want:   protocol.FrameTypeBroadcast,
 		},
 		{
-			name:   "MasterMaster",
+			name:   "InitiatorInitiator",
 			target: 0x10,
-			want:   protocol.FrameTypeMasterMaster,
+			want:   protocol.FrameTypeInitiatorInitiator,
 		},
 		{
-			name:   "MasterSlave",
+			name:   "InitiatorTarget",
 			target: 0x08,
-			want:   protocol.FrameTypeMasterSlave,
+			want:   protocol.FrameTypeInitiatorTarget,
 		},
 		{
 			name:   "InvalidAddress",
@@ -52,7 +52,7 @@ func TestFrame_Type(t *testing.T) {
 	t.Parallel()
 
 	frame := protocol.Frame{Target: 0x10}
-	if got := frame.Type(); got != protocol.FrameTypeMasterMaster {
-		t.Fatalf("Frame.Type = %v; want %v", got, protocol.FrameTypeMasterMaster)
+	if got := frame.Type(); got != protocol.FrameTypeInitiatorInitiator {
+		t.Fatalf("Frame.Type = %v; want %v", got, protocol.FrameTypeInitiatorInitiator)
 	}
 }

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -15,8 +15,8 @@ type FrameType uint8
 const (
 	FrameTypeUnknown FrameType = iota
 	FrameTypeBroadcast
-	FrameTypeMasterSlave
-	FrameTypeMasterMaster
+	FrameTypeInitiatorTarget
+	FrameTypeInitiatorInitiator
 )
 
 // Frame represents a parsed eBUS frame.
@@ -41,10 +41,10 @@ func FrameTypeForTarget(target byte) FrameType {
 	if !isValidAddress(target) {
 		return FrameTypeUnknown
 	}
-	if isMasterAddress(target) {
-		return FrameTypeMasterMaster
+	if isInitiatorCapableAddress(target) {
+		return FrameTypeInitiatorInitiator
 	}
-	return FrameTypeMasterSlave
+	return FrameTypeInitiatorTarget
 }
 
 // CRC calculates the eBUS CRC8 over unescaped symbols.
@@ -69,11 +69,11 @@ func isValidAddress(addr byte) bool {
 	return addr != SymbolEscape && addr != SymbolSyn
 }
 
-func isMasterAddress(addr byte) bool {
-	return masterPartIndex(addr&0x0F) > 0 && masterPartIndex((addr&0xF0)>>4) > 0
+func isInitiatorCapableAddress(addr byte) bool {
+	return initiatorPartIndex(addr&0x0F) > 0 && initiatorPartIndex((addr&0xF0)>>4) > 0
 }
 
-func masterPartIndex(bits byte) byte {
+func initiatorPartIndex(bits byte) byte {
 	switch bits {
 	case 0x0:
 		return 1

--- a/transport/enh_transport.go
+++ b/transport/enh_transport.go
@@ -24,9 +24,9 @@ type ENHTransport struct {
 	readMu  sync.Mutex
 	writeMu sync.Mutex
 
-	parser      ENHParser
-	pending     []byte
-	buffer      []byte
+	parser  ENHParser
+	pending []byte
+	buffer  []byte
 }
 
 // NewENHTransport creates a new ENH transport with read/write timeouts.
@@ -207,17 +207,17 @@ func (t *ENHTransport) Write(payload []byte) (int, error) {
 	return len(payload), nil
 }
 
-// StartArbitration requests bus ownership for the given master address.
-// It sends ENHReqStart(master) and blocks until ENHResStarted(master) or ENHResFailed(winner).
+// StartArbitration requests bus ownership for the given initiator address.
+// It sends ENHReqStart(initiator) and blocks until ENHResStarted(initiator) or ENHResFailed(winner).
 //
 // Any received ENHResReceived bytes observed while waiting are queued so that subsequent ReadByte
 // calls can consume them.
-func (t *ENHTransport) StartArbitration(master byte) error {
+func (t *ENHTransport) StartArbitration(initiator byte) error {
 	t.readMu.Lock()
 	defer t.readMu.Unlock()
 
 	t.writeMu.Lock()
-	seq := EncodeENH(ENHReqStart, master)
+	seq := EncodeENH(ENHReqStart, initiator)
 	written := 0
 	for written < len(seq) {
 		if err := t.setWriteDeadline(); err != nil {
@@ -271,12 +271,12 @@ func (t *ENHTransport) StartArbitration(master byte) error {
 				case ENHResResetted:
 					t.resetStateLocked()
 				case ENHResStarted:
-					if msg.Data == master {
+					if msg.Data == initiator {
 						arbitrationDone = true
 					}
 				case ENHResFailed:
 					arbitrationDone = true
-					arbitrationErr = fmt.Errorf("enh arbitration failed (master 0x%02x, winner 0x%02x): %w", master, msg.Data, ebuserrors.ErrBusCollision)
+					arbitrationErr = fmt.Errorf("enh arbitration failed (initiator 0x%02x, winner 0x%02x): %w", initiator, msg.Data, ebuserrors.ErrBusCollision)
 				}
 			}
 		}

--- a/transport/enh_transport_test.go
+++ b/transport/enh_transport_test.go
@@ -254,7 +254,7 @@ func TestENHTransport_StartArbitrationStartedDiscardsReceivedBytes(t *testing.T)
 	defer server.Close()
 
 	enh := transport.NewENHTransport(client, 200*time.Millisecond, 200*time.Millisecond)
-	master := byte(0x10)
+	initiator := byte(0x10)
 
 	serverErr := make(chan error, 1)
 	// Goroutine exits after validating the request and sending responses.
@@ -264,19 +264,19 @@ func TestENHTransport_StartArbitrationStartedDiscardsReceivedBytes(t *testing.T)
 			serverErr <- err
 			return
 		}
-		want := transport.EncodeENH(transport.ENHReqStart, master)
+		want := transport.EncodeENH(transport.ENHReqStart, initiator)
 		if buf[0] != want[0] || buf[1] != want[1] {
 			serverErr <- errors.New("unexpected arbitration request")
 			return
 		}
 
-		started := transport.EncodeENH(transport.ENHResStarted, master)
+		started := transport.EncodeENH(transport.ENHResStarted, initiator)
 		payload := []byte{0x11, started[0], started[1], 0x22}
 		_, err := server.Write(payload)
 		serverErr <- err
 	}()
 
-	if err := enh.StartArbitration(master); err != nil {
+	if err := enh.StartArbitration(initiator); err != nil {
 		t.Fatalf("StartArbitration error = %v", err)
 	}
 
@@ -298,7 +298,7 @@ func TestENHTransport_StartArbitrationFailedDiscardsReceivedBytes(t *testing.T) 
 	defer server.Close()
 
 	enh := transport.NewENHTransport(client, 200*time.Millisecond, 200*time.Millisecond)
-	master := byte(0x10)
+	initiator := byte(0x10)
 	winner := byte(0x30)
 
 	serverErr := make(chan error, 1)
@@ -309,7 +309,7 @@ func TestENHTransport_StartArbitrationFailedDiscardsReceivedBytes(t *testing.T) 
 			serverErr <- err
 			return
 		}
-		want := transport.EncodeENH(transport.ENHReqStart, master)
+		want := transport.EncodeENH(transport.ENHReqStart, initiator)
 		if buf[0] != want[0] || buf[1] != want[1] {
 			serverErr <- errors.New("unexpected arbitration request")
 			return
@@ -321,7 +321,7 @@ func TestENHTransport_StartArbitrationFailedDiscardsReceivedBytes(t *testing.T) 
 		serverErr <- err
 	}()
 
-	err := enh.StartArbitration(master)
+	err := enh.StartArbitration(initiator)
 	if !errors.Is(err, ebuserrors.ErrBusCollision) {
 		t.Fatalf("StartArbitration error = %v; want ErrBusCollision", err)
 	}


### PR DESCRIPTION
## Summary
- replace legacy role terms in code, tests, errors, and README with initiator/target wording
- rename frame type and bus retry config identifiers to initiator-target/initiator-initiator
- add a CI terminology gate that fails if legacy whole-word terms are introduced

## Validation
- go test ./...
- go vet ./...
- grep -RInw --exclude-dir=.git -E '(master|slave)' .

Closes #58

@codex review