### PR TITLE
feat: target emulation framework + VR90 minimal recognition

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,8 @@ Core layering in this repo:
 1. `transport` — `RawTransport` implementations (`ENH`, `ENS`, `ebusd-tcp`, loopback).
 2. `protocol` — frame model, CRC handling, and prioritized `Bus` send/receive state machine.
 3. `types` — eBUS codecs (`EXP`, `BCD`, `DATA1b`, `DATA2b`, `DATA2c`, `WORD`, structured types) with replacement-value semantics.
-4. `errors` — sentinel errors + helpers (`IsTransient`, `IsDefinitive`, `IsFatal`) for policy decisions.
+4. `emulation` — target-emulation framework + deterministic harness (VR90 minimal profile).
+5. `errors` — sentinel errors + helpers (`IsTransient`, `IsDefinitive`, `IsFatal`) for policy decisions.
 
 ## Prerequisites
 
@@ -60,6 +61,18 @@ tinygo build -target esp32-coreboard-v2 ./cmd/tinygo-check
 - Real-bus smoke/integration flow is run from `helianthus-ebusgateway` (`cmd/smoke`) and documented here:
   - https://github.com/d3vi1/helianthus-docs-ebus/blob/main/development/smoke-test.md
 - `transport/ebusd_tcp.go` is built only on non-TinyGo targets (`//go:build !tinygo`).
+- For target emulation with strict timing constraints, run near the adapter/firmware edge; `ebusd-tcp` is useful for functional checks but too jittery for precise cycle-accurate emulation.
+
+## Target Emulation (Issue #59 scope)
+
+- `emulation.Target` exposes request matcher + response builder + timing knobs.
+- `emulation.Harness` provides deterministic virtual-time query simulation for tests.
+- `emulation.NewVR90Target` implements minimal VR90 recognition behavior (`07 04` identify) with configurable target address and identity fields (manufacturer/device ID/software/hardware).
+- Minimal smoke check:
+
+```bash
+./scripts/smoke-vr90-minimal.sh
+```
 
 ## Package Map
 
@@ -69,6 +82,7 @@ tinygo build -target esp32-coreboard-v2 ./cmd/tinygo-check
 | `transport` | Byte-level transport adapters | Connect ENH/ENS/ebusd-tcp endpoints |
 | `protocol` | eBUS frame model + `Bus` queue/state machine | Send frames with typed retry semantics |
 | `types` | eBUS value codecs | Decode/encode payload fields |
+| `emulation` | Target-response rules + deterministic harness | Unit/integration test emulated devices |
 | `cmd/tinygo-check` | TinyGo compile probe | Validate package compatibility on embedded targets |
 | `internal/crc` | CRC implementation details | Internal-only support package |
 
@@ -110,6 +124,13 @@ _ = err
 ```
 
 Tip: use a bounded context (`context.WithTimeout`) for `Send` calls on multi-initiator buses.
+
+### 4) Work on target emulation / VR90 minimal behavior
+
+```bash
+go test ./emulation -count=1
+./scripts/smoke-vr90-minimal.sh
+```
 
 ## Troubleshooting
 

--- a/emulation/framework.go
+++ b/emulation/framework.go
@@ -1,0 +1,181 @@
+package emulation
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/d3vi1/helianthus-ebusgo/protocol"
+)
+
+var (
+	ErrNoMatchingRule        = errors.New("target emulation no matching rule")
+	ErrTimingConstraint      = errors.New("target emulation timing constraint")
+	ErrInvalidConfiguration  = errors.New("target emulation invalid configuration")
+	ErrRequestTargetMismatch = errors.New("target emulation request target mismatch")
+)
+
+type RequestMatcher interface {
+	Match(frame protocol.Frame) bool
+}
+
+type MatchFunc func(frame protocol.Frame) bool
+
+func (fn MatchFunc) Match(frame protocol.Frame) bool {
+	if fn == nil {
+		return false
+	}
+	return fn(frame)
+}
+
+type ResponseBuilder interface {
+	Build(frame protocol.Frame) (ResponsePlan, error)
+}
+
+type BuildFunc func(frame protocol.Frame) (ResponsePlan, error)
+
+func (fn BuildFunc) Build(frame protocol.Frame) (ResponsePlan, error) {
+	if fn == nil {
+		return ResponsePlan{}, fmt.Errorf("missing response builder: %w", ErrInvalidConfiguration)
+	}
+	return fn(frame)
+}
+
+type ResponsePlan struct {
+	Delay time.Duration
+	Data  []byte
+}
+
+type TimingConstraints struct {
+	MinResponseDelay time.Duration
+	MaxResponseDelay time.Duration
+}
+
+func (c TimingConstraints) validate(delay time.Duration) error {
+	if c.MinResponseDelay < 0 || c.MaxResponseDelay < 0 {
+		return fmt.Errorf("negative timing constraint: %w", ErrInvalidConfiguration)
+	}
+	if c.MaxResponseDelay > 0 && c.MinResponseDelay > c.MaxResponseDelay {
+		return fmt.Errorf("min delay exceeds max delay: %w", ErrInvalidConfiguration)
+	}
+	if delay < 0 {
+		return fmt.Errorf("negative response delay: %w", ErrTimingConstraint)
+	}
+	if delay < c.MinResponseDelay {
+		return fmt.Errorf("response delay %s below min %s: %w", delay, c.MinResponseDelay, ErrTimingConstraint)
+	}
+	if c.MaxResponseDelay > 0 && delay > c.MaxResponseDelay {
+		return fmt.Errorf("response delay %s above max %s: %w", delay, c.MaxResponseDelay, ErrTimingConstraint)
+	}
+	return nil
+}
+
+func (c TimingConstraints) active() bool {
+	return c.MinResponseDelay != 0 || c.MaxResponseDelay != 0
+}
+
+type Rule struct {
+	Name    string
+	Matcher RequestMatcher
+	Builder ResponseBuilder
+	Timing  TimingConstraints
+}
+
+type RequestEvent struct {
+	At    time.Duration
+	Frame protocol.Frame
+}
+
+type EmulatedResponse struct {
+	Rule      string
+	Requested time.Duration
+	RespondAt time.Duration
+	Frame     protocol.Frame
+}
+
+type Target struct {
+	Name          string
+	Address       byte
+	DefaultTiming TimingConstraints
+	Rules         []Rule
+}
+
+func (t *Target) Emulate(event RequestEvent) (EmulatedResponse, error) {
+	if t == nil {
+		return EmulatedResponse{}, fmt.Errorf("missing target: %w", ErrInvalidConfiguration)
+	}
+	if event.Frame.Target != t.Address {
+		return EmulatedResponse{}, fmt.Errorf(
+			"request target 0x%02x does not match emulated target 0x%02x: %w",
+			event.Frame.Target,
+			t.Address,
+			ErrRequestTargetMismatch,
+		)
+	}
+
+	for _, rule := range t.Rules {
+		if rule.Matcher == nil {
+			return EmulatedResponse{}, fmt.Errorf("rule %q missing matcher: %w", rule.Name, ErrInvalidConfiguration)
+		}
+		if !rule.Matcher.Match(event.Frame) {
+			continue
+		}
+		if rule.Builder == nil {
+			return EmulatedResponse{}, fmt.Errorf("rule %q missing builder: %w", rule.Name, ErrInvalidConfiguration)
+		}
+		plan, err := rule.Builder.Build(event.Frame)
+		if err != nil {
+			return EmulatedResponse{}, err
+		}
+
+		timing := rule.Timing
+		if !timing.active() {
+			timing = t.DefaultTiming
+		}
+		if err := timing.validate(plan.Delay); err != nil {
+			return EmulatedResponse{}, err
+		}
+
+		return EmulatedResponse{
+			Rule:      rule.Name,
+			Requested: event.At,
+			RespondAt: event.At + plan.Delay,
+			Frame: protocol.Frame{
+				Source:    t.Address,
+				Target:    event.Frame.Source,
+				Primary:   event.Frame.Primary,
+				Secondary: event.Frame.Secondary,
+				Data:      append([]byte(nil), plan.Data...),
+			},
+		}, nil
+	}
+
+	return EmulatedResponse{}, fmt.Errorf("request pb=0x%02x sb=0x%02x: %w", event.Frame.Primary, event.Frame.Secondary, ErrNoMatchingRule)
+}
+
+func MatchPrimarySecondary(primary, secondary byte) MatchFunc {
+	return func(frame protocol.Frame) bool {
+		return frame.Primary == primary && frame.Secondary == secondary
+	}
+}
+
+func MatchPrimarySecondaryWithPrefix(primary, secondary byte, prefix []byte) MatchFunc {
+	copied := append([]byte(nil), prefix...)
+	return func(frame protocol.Frame) bool {
+		if frame.Primary != primary || frame.Secondary != secondary {
+			return false
+		}
+		if len(copied) == 0 {
+			return true
+		}
+		if len(frame.Data) < len(copied) {
+			return false
+		}
+		for idx := range copied {
+			if frame.Data[idx] != copied[idx] {
+				return false
+			}
+		}
+		return true
+	}
+}

--- a/emulation/framework_test.go
+++ b/emulation/framework_test.go
@@ -1,0 +1,251 @@
+package emulation
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/d3vi1/helianthus-ebusgo/protocol"
+)
+
+func TestTargetEmulate_MirrorResponseFrame(t *testing.T) {
+	t.Parallel()
+
+	responsePayload := []byte{0xB5, 0x42}
+	target := &Target{
+		Name:    "test-target",
+		Address: 0x15,
+		Rules: []Rule{
+			{
+				Name:    "identify",
+				Matcher: MatchPrimarySecondary(0x07, 0x04),
+				Builder: BuildFunc(func(protocol.Frame) (ResponsePlan, error) {
+					return ResponsePlan{
+						Delay: 9 * time.Millisecond,
+						Data:  responsePayload,
+					}, nil
+				}),
+			},
+		},
+	}
+
+	request := protocol.Frame{
+		Source:    0x10,
+		Target:    0x15,
+		Primary:   0x07,
+		Secondary: 0x04,
+	}
+	got, err := target.Emulate(RequestEvent{At: 50 * time.Millisecond, Frame: request})
+	if err != nil {
+		t.Fatalf("Emulate error = %v", err)
+	}
+	if got.Rule != "identify" {
+		t.Fatalf("Rule = %q; want identify", got.Rule)
+	}
+	if got.Requested != 50*time.Millisecond {
+		t.Fatalf("Requested = %s; want %s", got.Requested, 50*time.Millisecond)
+	}
+	if got.RespondAt != 59*time.Millisecond {
+		t.Fatalf("RespondAt = %s; want %s", got.RespondAt, 59*time.Millisecond)
+	}
+	if got.Frame.Source != 0x15 || got.Frame.Target != 0x10 {
+		t.Fatalf("Frame source/target = 0x%02x/0x%02x; want 0x15/0x10", got.Frame.Source, got.Frame.Target)
+	}
+	if got.Frame.Primary != 0x07 || got.Frame.Secondary != 0x04 {
+		t.Fatalf("Frame PB/SB = 0x%02x/0x%02x; want 0x07/0x04", got.Frame.Primary, got.Frame.Secondary)
+	}
+	if !bytes.Equal(got.Frame.Data, responsePayload) {
+		t.Fatalf("Frame data = %x; want %x", got.Frame.Data, responsePayload)
+	}
+
+	responsePayload[0] = 0x00
+	if got.Frame.Data[0] != 0xB5 {
+		t.Fatalf("Frame data was not copied, got %x", got.Frame.Data)
+	}
+}
+
+func TestTargetEmulate_Errors(t *testing.T) {
+	t.Parallel()
+
+	validRequest := protocol.Frame{
+		Source:    0x10,
+		Target:    0x15,
+		Primary:   0x07,
+		Secondary: 0x04,
+	}
+
+	cases := []struct {
+		name   string
+		target *Target
+		event  RequestEvent
+		want   error
+	}{
+		{
+			name:   "nil target",
+			target: nil,
+			event: RequestEvent{
+				Frame: validRequest,
+			},
+			want: ErrInvalidConfiguration,
+		},
+		{
+			name: "target mismatch",
+			target: &Target{
+				Address: 0x08,
+			},
+			event: RequestEvent{
+				Frame: validRequest,
+			},
+			want: ErrRequestTargetMismatch,
+		},
+		{
+			name: "missing matcher",
+			target: &Target{
+				Address: 0x15,
+				Rules: []Rule{
+					{
+						Name: "broken",
+					},
+				},
+			},
+			event: RequestEvent{
+				Frame: validRequest,
+			},
+			want: ErrInvalidConfiguration,
+		},
+		{
+			name: "missing builder",
+			target: &Target{
+				Address: 0x15,
+				Rules: []Rule{
+					{
+						Name:    "broken",
+						Matcher: MatchPrimarySecondary(0x07, 0x04),
+					},
+				},
+			},
+			event: RequestEvent{
+				Frame: validRequest,
+			},
+			want: ErrInvalidConfiguration,
+		},
+		{
+			name: "no matching rule",
+			target: &Target{
+				Address: 0x15,
+				Rules: []Rule{
+					{
+						Name:    "other",
+						Matcher: MatchPrimarySecondary(0x01, 0x02),
+						Builder: BuildFunc(func(protocol.Frame) (ResponsePlan, error) {
+							return ResponsePlan{}, nil
+						}),
+					},
+				},
+			},
+			event: RequestEvent{
+				Frame: validRequest,
+			},
+			want: ErrNoMatchingRule,
+		},
+		{
+			name: "timing constraint violation",
+			target: &Target{
+				Address: 0x15,
+				DefaultTiming: TimingConstraints{
+					MinResponseDelay: 10 * time.Millisecond,
+					MaxResponseDelay: 15 * time.Millisecond,
+				},
+				Rules: []Rule{
+					{
+						Name:    "identify",
+						Matcher: MatchPrimarySecondary(0x07, 0x04),
+						Builder: BuildFunc(func(protocol.Frame) (ResponsePlan, error) {
+							return ResponsePlan{
+								Delay: 2 * time.Millisecond,
+								Data:  []byte{0x00},
+							}, nil
+						}),
+					},
+				},
+			},
+			event: RequestEvent{
+				Frame: validRequest,
+			},
+			want: ErrTimingConstraint,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := tc.target.Emulate(tc.event)
+			if !errors.Is(err, tc.want) {
+				t.Fatalf("Emulate error = %v; want %v", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestMatchPrimarySecondaryWithPrefix(t *testing.T) {
+	t.Parallel()
+
+	matcher := MatchPrimarySecondaryWithPrefix(0x07, 0x04, []byte{0x01, 0x02})
+
+	tests := []struct {
+		name  string
+		frame protocol.Frame
+		want  bool
+	}{
+		{
+			name: "matches exact prefix",
+			frame: protocol.Frame{
+				Primary:   0x07,
+				Secondary: 0x04,
+				Data:      []byte{0x01, 0x02, 0x03},
+			},
+			want: true,
+		},
+		{
+			name: "fails on wrong prefix",
+			frame: protocol.Frame{
+				Primary:   0x07,
+				Secondary: 0x04,
+				Data:      []byte{0x01, 0xFF, 0x03},
+			},
+			want: false,
+		},
+		{
+			name: "fails on short data",
+			frame: protocol.Frame{
+				Primary:   0x07,
+				Secondary: 0x04,
+				Data:      []byte{0x01},
+			},
+			want: false,
+		},
+		{
+			name: "fails on different pb sb",
+			frame: protocol.Frame{
+				Primary:   0x07,
+				Secondary: 0x05,
+				Data:      []byte{0x01, 0x02},
+			},
+			want: false,
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := matcher.Match(test.frame); got != test.want {
+				t.Fatalf("Match() = %v; want %v", got, test.want)
+			}
+		})
+	}
+}

--- a/emulation/harness.go
+++ b/emulation/harness.go
@@ -1,0 +1,125 @@
+package emulation
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/d3vi1/helianthus-ebusgo/protocol"
+)
+
+type ResponseEnvelope struct {
+	MinDelay time.Duration
+	MaxDelay time.Duration
+}
+
+func (e ResponseEnvelope) validate() error {
+	if e.MinDelay < 0 || e.MaxDelay < 0 {
+		return fmt.Errorf("negative response envelope: %w", ErrInvalidConfiguration)
+	}
+	if e.MaxDelay > 0 && e.MinDelay > e.MaxDelay {
+		return fmt.Errorf("envelope min delay exceeds max delay: %w", ErrInvalidConfiguration)
+	}
+	return nil
+}
+
+func ValidateResponseEnvelope(responses []EmulatedResponse, envelope ResponseEnvelope) error {
+	if err := envelope.validate(); err != nil {
+		return err
+	}
+	for idx, response := range responses {
+		delay := response.RespondAt - response.Requested
+		if delay < envelope.MinDelay {
+			return fmt.Errorf(
+				"response[%d] delay %s below envelope min %s: %w",
+				idx,
+				delay,
+				envelope.MinDelay,
+				ErrTimingConstraint,
+			)
+		}
+		if envelope.MaxDelay > 0 && delay > envelope.MaxDelay {
+			return fmt.Errorf(
+				"response[%d] delay %s above envelope max %s: %w",
+				idx,
+				delay,
+				envelope.MaxDelay,
+				ErrTimingConstraint,
+			)
+		}
+	}
+	return nil
+}
+
+type QueryStep struct {
+	Advance time.Duration
+	Frame   protocol.Frame
+}
+
+type Harness struct {
+	target  *Target
+	now     time.Duration
+	history []EmulatedResponse
+}
+
+func NewHarness(target *Target) *Harness {
+	return &Harness{
+		target: target,
+	}
+}
+
+func (h *Harness) Now() time.Duration {
+	if h == nil {
+		return 0
+	}
+	return h.now
+}
+
+func (h *Harness) Advance(delta time.Duration) {
+	if h == nil || delta <= 0 {
+		return
+	}
+	h.now += delta
+}
+
+func (h *Harness) Query(frame protocol.Frame) (EmulatedResponse, error) {
+	if h == nil || h.target == nil {
+		return EmulatedResponse{}, fmt.Errorf("missing harness target: %w", ErrInvalidConfiguration)
+	}
+	response, err := h.target.Emulate(RequestEvent{
+		At:    h.now,
+		Frame: frame,
+	})
+	if err != nil {
+		return EmulatedResponse{}, err
+	}
+	h.history = append(h.history, response)
+	return response, nil
+}
+
+func (h *Harness) RunSequence(steps []QueryStep) ([]EmulatedResponse, error) {
+	if h == nil || h.target == nil {
+		return nil, fmt.Errorf("missing harness target: %w", ErrInvalidConfiguration)
+	}
+	out := make([]EmulatedResponse, 0, len(steps))
+	for idx, step := range steps {
+		if step.Advance < 0 {
+			return nil, fmt.Errorf("step[%d] negative advance: %w", idx, ErrInvalidConfiguration)
+		}
+		h.Advance(step.Advance)
+		response, err := h.Query(step.Frame)
+		if err != nil {
+			return nil, fmt.Errorf("step[%d]: %w", idx, err)
+		}
+		out = append(out, response)
+	}
+	return out, nil
+}
+
+func (h *Harness) History() []EmulatedResponse {
+	if h == nil || len(h.history) == 0 {
+		return nil
+	}
+	out := make([]EmulatedResponse, len(h.history))
+	copy(out, h.history)
+	return out
+}

--- a/emulation/harness_test.go
+++ b/emulation/harness_test.go
@@ -1,0 +1,208 @@
+package emulation
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/d3vi1/helianthus-ebusgo/protocol"
+)
+
+func TestHarnessRunSequence_Deterministic(t *testing.T) {
+	t.Parallel()
+
+	target := &Target{
+		Name:    "deterministic",
+		Address: 0x15,
+		Rules: []Rule{
+			{
+				Name:    "identify",
+				Matcher: MatchPrimarySecondary(0x07, 0x04),
+				Builder: BuildFunc(func(protocol.Frame) (ResponsePlan, error) {
+					return ResponsePlan{
+						Delay: 8 * time.Millisecond,
+						Data:  []byte{0xB5},
+					}, nil
+				}),
+			},
+		},
+	}
+
+	harness := NewHarness(target)
+	responses, err := harness.RunSequence([]QueryStep{
+		{
+			Frame: protocol.Frame{
+				Source:    0x10,
+				Target:    0x15,
+				Primary:   0x07,
+				Secondary: 0x04,
+			},
+		},
+		{
+			Advance: 12 * time.Millisecond,
+			Frame: protocol.Frame{
+				Source:    0x11,
+				Target:    0x15,
+				Primary:   0x07,
+				Secondary: 0x04,
+			},
+		},
+		{
+			Advance: 3 * time.Millisecond,
+			Frame: protocol.Frame{
+				Source:    0x12,
+				Target:    0x15,
+				Primary:   0x07,
+				Secondary: 0x04,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("RunSequence error = %v", err)
+	}
+	if len(responses) != 3 {
+		t.Fatalf("len(responses) = %d; want 3", len(responses))
+	}
+
+	wantRequested := []time.Duration{0, 12 * time.Millisecond, 15 * time.Millisecond}
+	wantRespondAt := []time.Duration{8 * time.Millisecond, 20 * time.Millisecond, 23 * time.Millisecond}
+	wantSources := []byte{0x10, 0x11, 0x12}
+	for idx := range responses {
+		response := responses[idx]
+		if response.Requested != wantRequested[idx] {
+			t.Fatalf("responses[%d].Requested = %s; want %s", idx, response.Requested, wantRequested[idx])
+		}
+		if response.RespondAt != wantRespondAt[idx] {
+			t.Fatalf("responses[%d].RespondAt = %s; want %s", idx, response.RespondAt, wantRespondAt[idx])
+		}
+		if response.Frame.Source != 0x15 || response.Frame.Target != wantSources[idx] {
+			t.Fatalf("responses[%d].Frame source/target = 0x%02x/0x%02x; want 0x15/0x%02x", idx, response.Frame.Source, response.Frame.Target, wantSources[idx])
+		}
+	}
+	if harness.Now() != 15*time.Millisecond {
+		t.Fatalf("Now() = %s; want %s", harness.Now(), 15*time.Millisecond)
+	}
+
+	history := harness.History()
+	if len(history) != len(responses) {
+		t.Fatalf("len(history) = %d; want %d", len(history), len(responses))
+	}
+	for idx := range responses {
+		if history[idx].Requested != responses[idx].Requested || history[idx].RespondAt != responses[idx].RespondAt {
+			t.Fatalf("history[%d] does not match response[%d]", idx, idx)
+		}
+	}
+}
+
+func TestHarnessRunSequence_Errors(t *testing.T) {
+	t.Parallel()
+
+	target := &Target{
+		Address: 0x15,
+		Rules: []Rule{
+			{
+				Name:    "identify",
+				Matcher: MatchPrimarySecondary(0x07, 0x04),
+				Builder: BuildFunc(func(protocol.Frame) (ResponsePlan, error) {
+					return ResponsePlan{
+						Delay: 8 * time.Millisecond,
+						Data:  []byte{0xB5},
+					}, nil
+				}),
+			},
+		},
+	}
+
+	cases := []struct {
+		name    string
+		harness *Harness
+		steps   []QueryStep
+		want    error
+	}{
+		{
+			name:    "missing target",
+			harness: NewHarness(nil),
+			steps: []QueryStep{
+				{
+					Frame: protocol.Frame{},
+				},
+			},
+			want: ErrInvalidConfiguration,
+		},
+		{
+			name:    "negative advance",
+			harness: NewHarness(target),
+			steps: []QueryStep{
+				{
+					Advance: -time.Millisecond,
+					Frame:   protocol.Frame{},
+				},
+			},
+			want: ErrInvalidConfiguration,
+		},
+		{
+			name:    "query mismatch",
+			harness: NewHarness(target),
+			steps: []QueryStep{
+				{
+					Frame: protocol.Frame{
+						Source:    0x10,
+						Target:    0x08,
+						Primary:   0x07,
+						Secondary: 0x04,
+					},
+				},
+			},
+			want: ErrRequestTargetMismatch,
+		},
+	}
+
+	for _, test := range cases {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := test.harness.RunSequence(test.steps)
+			if !errors.Is(err, test.want) {
+				t.Fatalf("RunSequence error = %v; want %v", err, test.want)
+			}
+		})
+	}
+}
+
+func TestValidateResponseEnvelope(t *testing.T) {
+	t.Parallel()
+
+	responses := []EmulatedResponse{
+		{
+			Requested: 0,
+			RespondAt: 8 * time.Millisecond,
+		},
+		{
+			Requested: 10 * time.Millisecond,
+			RespondAt: 21 * time.Millisecond,
+		},
+	}
+
+	if err := ValidateResponseEnvelope(responses, ResponseEnvelope{
+		MinDelay: 5 * time.Millisecond,
+		MaxDelay: 15 * time.Millisecond,
+	}); err != nil {
+		t.Fatalf("ValidateResponseEnvelope() error = %v", err)
+	}
+
+	err := ValidateResponseEnvelope(responses, ResponseEnvelope{
+		MinDelay: 9 * time.Millisecond,
+		MaxDelay: 15 * time.Millisecond,
+	})
+	if !errors.Is(err, ErrTimingConstraint) {
+		t.Fatalf("ValidateResponseEnvelope() error = %v; want %v", err, ErrTimingConstraint)
+	}
+
+	err = ValidateResponseEnvelope(responses, ResponseEnvelope{
+		MinDelay: -time.Millisecond,
+	})
+	if !errors.Is(err, ErrInvalidConfiguration) {
+		t.Fatalf("ValidateResponseEnvelope() error = %v; want %v", err, ErrInvalidConfiguration)
+	}
+}

--- a/emulation/vr90.go
+++ b/emulation/vr90.go
@@ -1,0 +1,126 @@
+package emulation
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/d3vi1/helianthus-ebusgo/protocol"
+)
+
+const (
+	DefaultVR90Address      = byte(0x15)
+	DefaultVR90Manufacturer = byte(0xB5)
+	DefaultVR90DeviceID     = "B7V00"
+	DefaultVR90Software     = uint16(0x0422)
+	DefaultVR90Hardware     = uint16(0x5503)
+	vr90DeviceIDLength      = 5
+)
+
+var (
+	defaultVR90ResponseDelay = 8 * time.Millisecond
+	defaultVR90Timing        = TimingConstraints{
+		MinResponseDelay: 5 * time.Millisecond,
+		MaxResponseDelay: 30 * time.Millisecond,
+	}
+)
+
+type VR90Profile struct {
+	Address       byte
+	Manufacturer  byte
+	DeviceID      string
+	Software      uint16
+	Hardware      uint16
+	ResponseDelay time.Duration
+	Timing        TimingConstraints
+}
+
+func DefaultVR90Profile() VR90Profile {
+	return VR90Profile{
+		Address:       DefaultVR90Address,
+		Manufacturer:  DefaultVR90Manufacturer,
+		DeviceID:      DefaultVR90DeviceID,
+		Software:      DefaultVR90Software,
+		Hardware:      DefaultVR90Hardware,
+		ResponseDelay: defaultVR90ResponseDelay,
+		Timing:        defaultVR90Timing,
+	}
+}
+
+func NewVR90Target(profile VR90Profile) (*Target, error) {
+	normalized, err := normalizeVR90Profile(profile)
+	if err != nil {
+		return nil, err
+	}
+	return &Target{
+		Name:          fmt.Sprintf("vr90-minimal-0x%02x", normalized.Address),
+		Address:       normalized.Address,
+		DefaultTiming: normalized.Timing,
+		Rules: []Rule{
+			{
+				Name:    "identify",
+				Matcher: MatchPrimarySecondary(0x07, 0x04),
+				Builder: BuildFunc(func(_ protocol.Frame) (ResponsePlan, error) {
+					return ResponsePlan{
+						Delay: normalized.ResponseDelay,
+						Data:  normalized.identificationPayload(),
+					}, nil
+				}),
+			},
+		},
+	}, nil
+}
+
+func normalizeVR90Profile(profile VR90Profile) (VR90Profile, error) {
+	if profile.Address == 0 {
+		profile.Address = DefaultVR90Address
+	}
+	if profile.Manufacturer == 0 {
+		profile.Manufacturer = DefaultVR90Manufacturer
+	}
+	if strings.TrimSpace(profile.DeviceID) == "" {
+		profile.DeviceID = DefaultVR90DeviceID
+	}
+	if profile.Software == 0 {
+		profile.Software = DefaultVR90Software
+	}
+	if profile.Hardware == 0 {
+		profile.Hardware = DefaultVR90Hardware
+	}
+	if profile.ResponseDelay <= 0 {
+		profile.ResponseDelay = defaultVR90ResponseDelay
+	}
+	if !profile.Timing.active() {
+		profile.Timing = defaultVR90Timing
+	}
+	if err := profile.Timing.validate(profile.ResponseDelay); err != nil {
+		return VR90Profile{}, err
+	}
+
+	trimmed := strings.TrimSpace(profile.DeviceID)
+	if trimmed == "" {
+		return VR90Profile{}, fmt.Errorf("vr90 profile empty device id: %w", ErrInvalidConfiguration)
+	}
+	if len(trimmed) > vr90DeviceIDLength {
+		trimmed = trimmed[:vr90DeviceIDLength]
+	}
+	profile.DeviceID = trimmed
+	return profile, nil
+}
+
+func (profile VR90Profile) identificationPayload() []byte {
+	deviceID := fmt.Sprintf("%-*s", vr90DeviceIDLength, profile.DeviceID)
+	payload := []byte{
+		profile.Manufacturer,
+		deviceID[0],
+		deviceID[1],
+		deviceID[2],
+		deviceID[3],
+		deviceID[4],
+		byte(profile.Software >> 8),
+		byte(profile.Software & 0xFF),
+		byte(profile.Hardware >> 8),
+		byte(profile.Hardware & 0xFF),
+	}
+	return payload
+}

--- a/emulation/vr90_test.go
+++ b/emulation/vr90_test.go
@@ -1,0 +1,204 @@
+package emulation
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/d3vi1/helianthus-ebusgo/protocol"
+)
+
+func TestNewVR90Target_IdentifyResponseUsesProfile(t *testing.T) {
+	t.Parallel()
+
+	target, err := NewVR90Target(VR90Profile{
+		Address:       0x30,
+		Manufacturer:  0xAA,
+		DeviceID:      "R90A1",
+		Software:      0x1234,
+		Hardware:      0x5678,
+		ResponseDelay: 9 * time.Millisecond,
+		Timing: TimingConstraints{
+			MinResponseDelay: 5 * time.Millisecond,
+			MaxResponseDelay: 15 * time.Millisecond,
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewVR90Target() error = %v", err)
+	}
+
+	response, err := target.Emulate(RequestEvent{
+		At: 40 * time.Millisecond,
+		Frame: protocol.Frame{
+			Source:    0x10,
+			Target:    0x30,
+			Primary:   0x07,
+			Secondary: 0x04,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Emulate() error = %v", err)
+	}
+
+	if response.Rule != "identify" {
+		t.Fatalf("Rule = %q; want identify", response.Rule)
+	}
+	if response.RespondAt != 49*time.Millisecond {
+		t.Fatalf("RespondAt = %s; want %s", response.RespondAt, 49*time.Millisecond)
+	}
+	if response.Frame.Source != 0x30 || response.Frame.Target != 0x10 {
+		t.Fatalf("Frame source/target = 0x%02x/0x%02x; want 0x30/0x10", response.Frame.Source, response.Frame.Target)
+	}
+	wantData := []byte{
+		0xAA, 'R', '9', '0', 'A', '1',
+		0x12, 0x34,
+		0x56, 0x78,
+	}
+	if !bytes.Equal(response.Frame.Data, wantData) {
+		t.Fatalf("Frame data = %x; want %x", response.Frame.Data, wantData)
+	}
+}
+
+func TestNewVR90Target_NormalizesDefaults(t *testing.T) {
+	t.Parallel()
+
+	target, err := NewVR90Target(VR90Profile{})
+	if err != nil {
+		t.Fatalf("NewVR90Target() error = %v", err)
+	}
+	if target.Address != DefaultVR90Address {
+		t.Fatalf("Address = 0x%02x; want 0x%02x", target.Address, DefaultVR90Address)
+	}
+
+	response, err := target.Emulate(RequestEvent{
+		Frame: protocol.Frame{
+			Source:    0x10,
+			Target:    DefaultVR90Address,
+			Primary:   0x07,
+			Secondary: 0x04,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Emulate() error = %v", err)
+	}
+
+	wantData := []byte{
+		DefaultVR90Manufacturer,
+		'B', '7', 'V', '0', '0',
+		0x04, 0x22,
+		0x55, 0x03,
+	}
+	if !bytes.Equal(response.Frame.Data, wantData) {
+		t.Fatalf("Frame data = %x; want %x", response.Frame.Data, wantData)
+	}
+}
+
+func TestNewVR90Target_Errors(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		profile VR90Profile
+		want    error
+	}{
+		{
+			name: "timing violation",
+			profile: VR90Profile{
+				ResponseDelay: 2 * time.Millisecond,
+				Timing: TimingConstraints{
+					MinResponseDelay: 5 * time.Millisecond,
+					MaxResponseDelay: 10 * time.Millisecond,
+				},
+			},
+			want: ErrTimingConstraint,
+		},
+		{
+			name: "invalid timing range",
+			profile: VR90Profile{
+				ResponseDelay: 8 * time.Millisecond,
+				Timing: TimingConstraints{
+					MinResponseDelay: 10 * time.Millisecond,
+					MaxResponseDelay: 5 * time.Millisecond,
+				},
+			},
+			want: ErrInvalidConfiguration,
+		},
+	}
+
+	for _, test := range cases {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := NewVR90Target(test.profile)
+			if !errors.Is(err, test.want) {
+				t.Fatalf("NewVR90Target() error = %v; want %v", err, test.want)
+			}
+		})
+	}
+}
+
+func TestVR90Target_NoMatchForOtherQueries(t *testing.T) {
+	t.Parallel()
+
+	target, err := NewVR90Target(DefaultVR90Profile())
+	if err != nil {
+		t.Fatalf("NewVR90Target() error = %v", err)
+	}
+
+	_, err = target.Emulate(RequestEvent{
+		Frame: protocol.Frame{
+			Source:    0x10,
+			Target:    DefaultVR90Address,
+			Primary:   0x01,
+			Secondary: 0x02,
+		},
+	})
+	if !errors.Is(err, ErrNoMatchingRule) {
+		t.Fatalf("Emulate() error = %v; want %v", err, ErrNoMatchingRule)
+	}
+}
+
+func TestSmokeVR90MinimalQuerySet(t *testing.T) {
+	target, err := NewVR90Target(DefaultVR90Profile())
+	if err != nil {
+		t.Fatalf("NewVR90Target() error = %v", err)
+	}
+
+	harness := NewHarness(target)
+	responses, err := harness.RunSequence([]QueryStep{
+		{
+			Frame: protocol.Frame{
+				Source:    0x10,
+				Target:    DefaultVR90Address,
+				Primary:   0x07,
+				Secondary: 0x04,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("RunSequence() error = %v", err)
+	}
+	if len(responses) != 1 {
+		t.Fatalf("len(responses) = %d; want 1", len(responses))
+	}
+
+	response := responses[0]
+	if response.Frame.Source != DefaultVR90Address || response.Frame.Target != 0x10 {
+		t.Fatalf("Frame source/target = 0x%02x/0x%02x; want 0x%02x/0x10", response.Frame.Source, response.Frame.Target, DefaultVR90Address)
+	}
+	if response.Frame.Primary != 0x07 || response.Frame.Secondary != 0x04 {
+		t.Fatalf("Frame PB/SB = 0x%02x/0x%02x; want 0x07/0x04", response.Frame.Primary, response.Frame.Secondary)
+	}
+	if gotID := string(response.Frame.Data[1:6]); gotID != DefaultVR90DeviceID {
+		t.Fatalf("DeviceID = %q; want %q", gotID, DefaultVR90DeviceID)
+	}
+
+	if err := ValidateResponseEnvelope(responses, ResponseEnvelope{
+		MinDelay: 5 * time.Millisecond,
+		MaxDelay: 30 * time.Millisecond,
+	}); err != nil {
+		t.Fatalf("ValidateResponseEnvelope() error = %v", err)
+	}
+}

--- a/scripts/smoke-vr90-minimal.sh
+++ b/scripts/smoke-vr90-minimal.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+go test ./emulation -run '^TestSmokeVR90MinimalQuerySet$' -count=1 -v "$@"


### PR DESCRIPTION
## Summary
- add target emulation framework with request matcher, response builder, and timing constraints
- add deterministic emulation harness with response envelope validation and tests
- add minimal VR90 target emulator recognition behavior for `07 04` identify with configurable address and identity fields
- add minimal smoke-test script for the VR90 query set and README guidance

## Validation
- go test ./...
- ./scripts/smoke-vr90-minimal.sh

Closes #59
