### PR TITLE
fix: preserve VR90 zero IDs and deep-copy harness history

### DIFF
--- a/emulation/harness.go
+++ b/emulation/harness.go
@@ -120,6 +120,9 @@ func (h *Harness) History() []EmulatedResponse {
 		return nil
 	}
 	out := make([]EmulatedResponse, len(h.history))
-	copy(out, h.history)
+	for idx := range h.history {
+		out[idx] = h.history[idx]
+		out[idx].Frame.Data = append([]byte(nil), h.history[idx].Frame.Data...)
+	}
 	return out
 }

--- a/emulation/harness_test.go
+++ b/emulation/harness_test.go
@@ -170,6 +170,48 @@ func TestHarnessRunSequence_Errors(t *testing.T) {
 	}
 }
 
+func TestHarnessHistory_DeepCopiesFrameData(t *testing.T) {
+	t.Parallel()
+
+	target := &Target{
+		Address: 0x15,
+		Rules: []Rule{
+			{
+				Name:    "identify",
+				Matcher: MatchPrimarySecondary(0x07, 0x04),
+				Builder: BuildFunc(func(protocol.Frame) (ResponsePlan, error) {
+					return ResponsePlan{
+						Delay: 8 * time.Millisecond,
+						Data:  []byte{0xB5},
+					}, nil
+				}),
+			},
+		},
+	}
+
+	harness := NewHarness(target)
+	_, err := harness.Query(protocol.Frame{
+		Source:    0x10,
+		Target:    0x15,
+		Primary:   0x07,
+		Secondary: 0x04,
+	})
+	if err != nil {
+		t.Fatalf("Query() error = %v", err)
+	}
+
+	history := harness.History()
+	if len(history) != 1 {
+		t.Fatalf("len(history) = %d; want 1", len(history))
+	}
+	history[0].Frame.Data[0] = 0x00
+
+	freshHistory := harness.History()
+	if got := freshHistory[0].Frame.Data[0]; got != 0xB5 {
+		t.Fatalf("freshHistory[0].Frame.Data[0] = 0x%02x; want 0xb5", got)
+	}
+}
+
 func TestValidateResponseEnvelope(t *testing.T) {
 	t.Parallel()
 

--- a/emulation/vr90.go
+++ b/emulation/vr90.go
@@ -72,6 +72,11 @@ func NewVR90Target(profile VR90Profile) (*Target, error) {
 }
 
 func normalizeVR90Profile(profile VR90Profile) (VR90Profile, error) {
+	hasIdentityOverrides := profile.Manufacturer != 0 ||
+		strings.TrimSpace(profile.DeviceID) != "" ||
+		profile.Software != 0 ||
+		profile.Hardware != 0
+
 	if profile.Address == 0 {
 		profile.Address = DefaultVR90Address
 	}
@@ -81,10 +86,8 @@ func normalizeVR90Profile(profile VR90Profile) (VR90Profile, error) {
 	if strings.TrimSpace(profile.DeviceID) == "" {
 		profile.DeviceID = DefaultVR90DeviceID
 	}
-	if profile.Software == 0 {
+	if !hasIdentityOverrides {
 		profile.Software = DefaultVR90Software
-	}
-	if profile.Hardware == 0 {
 		profile.Hardware = DefaultVR90Hardware
 	}
 	if profile.ResponseDelay <= 0 {

--- a/emulation/vr90_test.go
+++ b/emulation/vr90_test.go
@@ -94,6 +94,41 @@ func TestNewVR90Target_NormalizesDefaults(t *testing.T) {
 	}
 }
 
+func TestNewVR90Target_PreservesZeroSoftwareHardware(t *testing.T) {
+	t.Parallel()
+
+	profile := DefaultVR90Profile()
+	profile.Software = 0x0000
+	profile.Hardware = 0x0000
+
+	target, err := NewVR90Target(profile)
+	if err != nil {
+		t.Fatalf("NewVR90Target() error = %v", err)
+	}
+
+	response, err := target.Emulate(RequestEvent{
+		Frame: protocol.Frame{
+			Source:    0x10,
+			Target:    DefaultVR90Address,
+			Primary:   0x07,
+			Secondary: 0x04,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Emulate() error = %v", err)
+	}
+
+	wantData := []byte{
+		DefaultVR90Manufacturer,
+		'B', '7', 'V', '0', '0',
+		0x00, 0x00,
+		0x00, 0x00,
+	}
+	if !bytes.Equal(response.Frame.Data, wantData) {
+		t.Fatalf("Frame data = %x; want %x", response.Frame.Data, wantData)
+	}
+}
+
 func TestNewVR90Target_Errors(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- preserve explicit `0x0000` VR90 software/hardware values whenever any identity fields are overridden
- keep legacy defaults for software/hardware when identity fields are fully omitted
- deep-copy `Frame.Data` bytes when returning `Harness.History()`
- add regression tests for zero-valued VR90 identity bytes and history payload copy isolation

## Validation
- go test ./emulation -count=1
- go test ./... -count=1
- ./scripts/smoke-vr90-minimal.sh

Closes #62
