### PR TITLE
feat(emulation): add generic identify-only target profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Core layering in this repo:
 1. `transport` — `RawTransport` implementations (`ENH`, `ENS`, `ebusd-tcp`, loopback).
 2. `protocol` — frame model, CRC handling, and prioritized `Bus` send/receive state machine.
 3. `types` — eBUS codecs (`EXP`, `BCD`, `DATA1b`, `DATA2b`, `DATA2c`, `WORD`, structured types) with replacement-value semantics.
-4. `emulation` — target-emulation framework + deterministic harness (VR90 minimal profile).
+4. `emulation` — target-emulation framework + deterministic harness (identify-only profiles with VR90/VR_71 presets).
 5. `errors` — sentinel errors + helpers (`IsTransient`, `IsDefinitive`, `IsFatal`) for policy decisions.
 
 ## Prerequisites
@@ -63,14 +63,17 @@ tinygo build -target esp32-coreboard-v2 ./cmd/tinygo-check
 - `transport/ebusd_tcp.go` is built only on non-TinyGo targets (`//go:build !tinygo`).
 - For target emulation with strict timing constraints, run near the adapter/firmware edge; `ebusd-tcp` is useful for functional checks but too jittery for precise cycle-accurate emulation.
 
-## Target Emulation (Issue #59 scope)
+## Target Emulation (Issues #59/#64 scope)
 
 - `emulation.Target` exposes request matcher + response builder + timing knobs.
 - `emulation.Harness` provides deterministic virtual-time query simulation for tests.
-- `emulation.NewVR90Target` implements minimal VR90 recognition behavior (`07 04` identify) with configurable target address and identity fields (manufacturer/device ID/software/hardware).
+- `emulation.NewIdentifyOnlyTarget` provides a generic identify-only constructor (`07 04`) for address + identity + timing profiles.
+- `emulation.PresetVR90IdentifyOnlyProfile` and `emulation.PresetVR71IdentifyOnlyProfile` provide predefined profiles.
+- `emulation.NewVR90Target` remains backward-compatible and delegates to the generic identify-only profile API.
 - Minimal smoke check:
 
 ```bash
+./scripts/smoke-identify-only.sh
 ./scripts/smoke-vr90-minimal.sh
 ```
 
@@ -125,10 +128,11 @@ _ = err
 
 Tip: use a bounded context (`context.WithTimeout`) for `Send` calls on multi-initiator buses.
 
-### 4) Work on target emulation / VR90 minimal behavior
+### 4) Work on target emulation / identify-only behavior
 
 ```bash
 go test ./emulation -count=1
+./scripts/smoke-identify-only.sh
 ./scripts/smoke-vr90-minimal.sh
 ```
 

--- a/emulation/identify_only.go
+++ b/emulation/identify_only.go
@@ -1,0 +1,139 @@
+package emulation
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/d3vi1/helianthus-ebusgo/protocol"
+)
+
+const (
+	identifyOnlyDeviceIDLength = 5
+
+	DefaultVR71Address      = byte(0x26)
+	DefaultVR71Manufacturer = byte(0xB5)
+	DefaultVR71DeviceID     = "VR_71"
+	DefaultVR71Software     = uint16(0x0100)
+	DefaultVR71Hardware     = uint16(0x5904)
+)
+
+var (
+	defaultIdentifyOnlyResponseDelay = 8 * time.Millisecond
+	defaultIdentifyOnlyTiming        = TimingConstraints{
+		MinResponseDelay: 5 * time.Millisecond,
+		MaxResponseDelay: 30 * time.Millisecond,
+	}
+)
+
+type IdentifyOnlyProfile struct {
+	Name          string
+	Address       byte
+	Manufacturer  byte
+	DeviceID      string
+	Software      uint16
+	Hardware      uint16
+	ResponseDelay time.Duration
+	Timing        TimingConstraints
+}
+
+func PresetVR90IdentifyOnlyProfile() IdentifyOnlyProfile {
+	return IdentifyOnlyProfile{
+		Name:          fmt.Sprintf("vr90-minimal-0x%02x", DefaultVR90Address),
+		Address:       DefaultVR90Address,
+		Manufacturer:  DefaultVR90Manufacturer,
+		DeviceID:      DefaultVR90DeviceID,
+		Software:      DefaultVR90Software,
+		Hardware:      DefaultVR90Hardware,
+		ResponseDelay: defaultVR90ResponseDelay,
+		Timing:        defaultVR90Timing,
+	}
+}
+
+func PresetVR71IdentifyOnlyProfile() IdentifyOnlyProfile {
+	return IdentifyOnlyProfile{
+		Name:          fmt.Sprintf("vr71-minimal-0x%02x", DefaultVR71Address),
+		Address:       DefaultVR71Address,
+		Manufacturer:  DefaultVR71Manufacturer,
+		DeviceID:      DefaultVR71DeviceID,
+		Software:      DefaultVR71Software,
+		Hardware:      DefaultVR71Hardware,
+		ResponseDelay: defaultIdentifyOnlyResponseDelay,
+		Timing:        defaultIdentifyOnlyTiming,
+	}
+}
+
+func NewIdentifyOnlyTarget(profile IdentifyOnlyProfile) (*Target, error) {
+	normalized, err := normalizeIdentifyOnlyProfile(profile)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Target{
+		Name:          normalized.Name,
+		Address:       normalized.Address,
+		DefaultTiming: normalized.Timing,
+		Rules: []Rule{
+			{
+				Name:    "identify",
+				Matcher: MatchPrimarySecondary(0x07, 0x04),
+				Builder: BuildFunc(func(_ protocol.Frame) (ResponsePlan, error) {
+					return ResponsePlan{
+						Delay: normalized.ResponseDelay,
+						Data:  normalized.identificationPayload(),
+					}, nil
+				}),
+			},
+		},
+	}, nil
+}
+
+func normalizeIdentifyOnlyProfile(profile IdentifyOnlyProfile) (IdentifyOnlyProfile, error) {
+	profile.Name = strings.TrimSpace(profile.Name)
+	if profile.Name == "" {
+		profile.Name = fmt.Sprintf("identify-only-0x%02x", profile.Address)
+	}
+	if profile.Address == 0 {
+		return IdentifyOnlyProfile{}, fmt.Errorf("identify-only profile empty address: %w", ErrInvalidConfiguration)
+	}
+	if profile.Manufacturer == 0 {
+		return IdentifyOnlyProfile{}, fmt.Errorf("identify-only profile empty manufacturer: %w", ErrInvalidConfiguration)
+	}
+
+	trimmed := strings.TrimSpace(profile.DeviceID)
+	if trimmed == "" {
+		return IdentifyOnlyProfile{}, fmt.Errorf("identify-only profile empty device id: %w", ErrInvalidConfiguration)
+	}
+	if len(trimmed) > identifyOnlyDeviceIDLength {
+		trimmed = trimmed[:identifyOnlyDeviceIDLength]
+	}
+	profile.DeviceID = trimmed
+
+	if profile.ResponseDelay <= 0 {
+		profile.ResponseDelay = defaultIdentifyOnlyResponseDelay
+	}
+	if !profile.Timing.active() {
+		profile.Timing = defaultIdentifyOnlyTiming
+	}
+	if err := profile.Timing.validate(profile.ResponseDelay); err != nil {
+		return IdentifyOnlyProfile{}, err
+	}
+
+	return profile, nil
+}
+
+func (profile IdentifyOnlyProfile) identificationPayload() []byte {
+	deviceID := fmt.Sprintf("%-*s", identifyOnlyDeviceIDLength, profile.DeviceID)
+	return []byte{
+		profile.Manufacturer,
+		deviceID[0],
+		deviceID[1],
+		deviceID[2],
+		deviceID[3],
+		deviceID[4],
+		byte(profile.Software >> 8),
+		byte(profile.Software & 0xFF),
+		byte(profile.Hardware >> 8),
+		byte(profile.Hardware & 0xFF),
+	}
+}

--- a/emulation/identify_only_test.go
+++ b/emulation/identify_only_test.go
@@ -1,0 +1,243 @@
+package emulation
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/d3vi1/helianthus-ebusgo/protocol"
+)
+
+func TestNewIdentifyOnlyTarget_ConstructorAndPayload(t *testing.T) {
+	t.Parallel()
+
+	target, err := NewIdentifyOnlyTarget(IdentifyOnlyProfile{
+		Name:          "  custom-identify  ",
+		Address:       0x30,
+		Manufacturer:  0xAA,
+		DeviceID:      "R71LONG",
+		Software:      0x1234,
+		Hardware:      0x5678,
+		ResponseDelay: 9 * time.Millisecond,
+		Timing: TimingConstraints{
+			MinResponseDelay: 5 * time.Millisecond,
+			MaxResponseDelay: 15 * time.Millisecond,
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewIdentifyOnlyTarget() error = %v", err)
+	}
+
+	if target.Name != "custom-identify" {
+		t.Fatalf("Name = %q; want %q", target.Name, "custom-identify")
+	}
+	if target.Address != 0x30 {
+		t.Fatalf("Address = 0x%02x; want 0x30", target.Address)
+	}
+
+	response, err := target.Emulate(RequestEvent{
+		At: 20 * time.Millisecond,
+		Frame: protocol.Frame{
+			Source:    0x10,
+			Target:    0x30,
+			Primary:   0x07,
+			Secondary: 0x04,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Emulate() error = %v", err)
+	}
+	if response.RespondAt != 29*time.Millisecond {
+		t.Fatalf("RespondAt = %s; want %s", response.RespondAt, 29*time.Millisecond)
+	}
+
+	wantData := []byte{
+		0xAA, 'R', '7', '1', 'L', 'O',
+		0x12, 0x34,
+		0x56, 0x78,
+	}
+	if !bytes.Equal(response.Frame.Data, wantData) {
+		t.Fatalf("Frame data = %x; want %x", response.Frame.Data, wantData)
+	}
+}
+
+func TestNewIdentifyOnlyTarget_Errors(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		profile IdentifyOnlyProfile
+		want    error
+	}{
+		{
+			name: "empty address",
+			profile: IdentifyOnlyProfile{
+				Manufacturer: 0xB5,
+				DeviceID:     "VR_71",
+			},
+			want: ErrInvalidConfiguration,
+		},
+		{
+			name: "empty manufacturer",
+			profile: IdentifyOnlyProfile{
+				Address:  0x26,
+				DeviceID: "VR_71",
+			},
+			want: ErrInvalidConfiguration,
+		},
+		{
+			name: "empty device id",
+			profile: IdentifyOnlyProfile{
+				Address:      0x26,
+				Manufacturer: 0xB5,
+				DeviceID:     "   ",
+			},
+			want: ErrInvalidConfiguration,
+		},
+		{
+			name: "timing violation",
+			profile: IdentifyOnlyProfile{
+				Address:       0x26,
+				Manufacturer:  0xB5,
+				DeviceID:      "VR_71",
+				ResponseDelay: 2 * time.Millisecond,
+				Timing: TimingConstraints{
+					MinResponseDelay: 5 * time.Millisecond,
+					MaxResponseDelay: 15 * time.Millisecond,
+				},
+			},
+			want: ErrTimingConstraint,
+		},
+	}
+
+	for _, test := range cases {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := NewIdentifyOnlyTarget(test.profile)
+			if !errors.Is(err, test.want) {
+				t.Fatalf("NewIdentifyOnlyTarget() error = %v; want %v", err, test.want)
+			}
+		})
+	}
+}
+
+func TestIdentifyOnlyProfile_Presets(t *testing.T) {
+	t.Parallel()
+
+	vr90 := PresetVR90IdentifyOnlyProfile()
+	if vr90.Address != DefaultVR90Address ||
+		vr90.Manufacturer != DefaultVR90Manufacturer ||
+		vr90.DeviceID != DefaultVR90DeviceID ||
+		vr90.Software != DefaultVR90Software ||
+		vr90.Hardware != DefaultVR90Hardware {
+		t.Fatalf("VR90 preset mismatch: %+v", vr90)
+	}
+
+	vr71 := PresetVR71IdentifyOnlyProfile()
+	if vr71.Address != DefaultVR71Address ||
+		vr71.Manufacturer != DefaultVR71Manufacturer ||
+		vr71.DeviceID != DefaultVR71DeviceID ||
+		vr71.Software != DefaultVR71Software ||
+		vr71.Hardware != DefaultVR71Hardware {
+		t.Fatalf("VR_71 preset mismatch: %+v", vr71)
+	}
+}
+
+func TestIdentifyOnlyTarget_RepeatedQueryBehavior(t *testing.T) {
+	t.Parallel()
+
+	profile := PresetVR71IdentifyOnlyProfile()
+	target, err := NewIdentifyOnlyTarget(profile)
+	if err != nil {
+		t.Fatalf("NewIdentifyOnlyTarget() error = %v", err)
+	}
+
+	harness := NewHarness(target)
+	frame := protocol.Frame{
+		Source:    0x10,
+		Target:    profile.Address,
+		Primary:   0x07,
+		Secondary: 0x04,
+	}
+
+	first, err := harness.Query(frame)
+	if err != nil {
+		t.Fatalf("Query(first) error = %v", err)
+	}
+	first.Frame.Data[0] = 0x00
+
+	harness.Advance(3 * time.Millisecond)
+	second, err := harness.Query(frame)
+	if err != nil {
+		t.Fatalf("Query(second) error = %v", err)
+	}
+
+	if second.Requested != 3*time.Millisecond {
+		t.Fatalf("second.Requested = %s; want %s", second.Requested, 3*time.Millisecond)
+	}
+	if second.RespondAt != 11*time.Millisecond {
+		t.Fatalf("second.RespondAt = %s; want %s", second.RespondAt, 11*time.Millisecond)
+	}
+
+	wantData := profile.identificationPayload()
+	if !bytes.Equal(second.Frame.Data, wantData) {
+		t.Fatalf("second.Frame.Data = %x; want %x", second.Frame.Data, wantData)
+	}
+}
+
+func TestSmokeIdentifyOnlyProfileValidation(t *testing.T) {
+	cases := []struct {
+		name    string
+		profile IdentifyOnlyProfile
+	}{
+		{
+			name:    "vr90",
+			profile: PresetVR90IdentifyOnlyProfile(),
+		},
+		{
+			name:    "vr_71",
+			profile: PresetVR71IdentifyOnlyProfile(),
+		},
+	}
+
+	for _, test := range cases {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			target, err := NewIdentifyOnlyTarget(test.profile)
+			if err != nil {
+				t.Fatalf("NewIdentifyOnlyTarget() error = %v", err)
+			}
+
+			harness := NewHarness(target)
+			responses, err := harness.RunSequence([]QueryStep{
+				{
+					Frame: protocol.Frame{
+						Source:    0x10,
+						Target:    test.profile.Address,
+						Primary:   0x07,
+						Secondary: 0x04,
+					},
+				},
+			})
+			if err != nil {
+				t.Fatalf("RunSequence() error = %v", err)
+			}
+			if len(responses) != 1 {
+				t.Fatalf("len(responses) = %d; want 1", len(responses))
+			}
+			if !bytes.Equal(responses[0].Frame.Data, test.profile.identificationPayload()) {
+				t.Fatalf("Frame data = %x; want %x", responses[0].Frame.Data, test.profile.identificationPayload())
+			}
+
+			if err := ValidateResponseEnvelope(responses, ResponseEnvelope{
+				MinDelay: test.profile.Timing.MinResponseDelay,
+				MaxDelay: test.profile.Timing.MaxResponseDelay,
+			}); err != nil {
+				t.Fatalf("ValidateResponseEnvelope() error = %v", err)
+			}
+		})
+	}
+}

--- a/emulation/vr90.go
+++ b/emulation/vr90.go
@@ -4,8 +4,6 @@ import (
 	"fmt"
 	"strings"
 	"time"
-
-	"github.com/d3vi1/helianthus-ebusgo/protocol"
 )
 
 const (
@@ -14,7 +12,6 @@ const (
 	DefaultVR90DeviceID     = "B7V00"
 	DefaultVR90Software     = uint16(0x0422)
 	DefaultVR90Hardware     = uint16(0x5503)
-	vr90DeviceIDLength      = 5
 )
 
 var (
@@ -52,23 +49,16 @@ func NewVR90Target(profile VR90Profile) (*Target, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &Target{
+	return NewIdentifyOnlyTarget(IdentifyOnlyProfile{
 		Name:          fmt.Sprintf("vr90-minimal-0x%02x", normalized.Address),
 		Address:       normalized.Address,
-		DefaultTiming: normalized.Timing,
-		Rules: []Rule{
-			{
-				Name:    "identify",
-				Matcher: MatchPrimarySecondary(0x07, 0x04),
-				Builder: BuildFunc(func(_ protocol.Frame) (ResponsePlan, error) {
-					return ResponsePlan{
-						Delay: normalized.ResponseDelay,
-						Data:  normalized.identificationPayload(),
-					}, nil
-				}),
-			},
-		},
-	}, nil
+		Manufacturer:  normalized.Manufacturer,
+		DeviceID:      normalized.DeviceID,
+		Software:      normalized.Software,
+		Hardware:      normalized.Hardware,
+		ResponseDelay: normalized.ResponseDelay,
+		Timing:        normalized.Timing,
+	})
 }
 
 func normalizeVR90Profile(profile VR90Profile) (VR90Profile, error) {
@@ -104,26 +94,9 @@ func normalizeVR90Profile(profile VR90Profile) (VR90Profile, error) {
 	if trimmed == "" {
 		return VR90Profile{}, fmt.Errorf("vr90 profile empty device id: %w", ErrInvalidConfiguration)
 	}
-	if len(trimmed) > vr90DeviceIDLength {
-		trimmed = trimmed[:vr90DeviceIDLength]
+	if len(trimmed) > identifyOnlyDeviceIDLength {
+		trimmed = trimmed[:identifyOnlyDeviceIDLength]
 	}
 	profile.DeviceID = trimmed
 	return profile, nil
-}
-
-func (profile VR90Profile) identificationPayload() []byte {
-	deviceID := fmt.Sprintf("%-*s", vr90DeviceIDLength, profile.DeviceID)
-	payload := []byte{
-		profile.Manufacturer,
-		deviceID[0],
-		deviceID[1],
-		deviceID[2],
-		deviceID[3],
-		deviceID[4],
-		byte(profile.Software >> 8),
-		byte(profile.Software & 0xFF),
-		byte(profile.Hardware >> 8),
-		byte(profile.Hardware & 0xFF),
-	}
-	return payload
 }

--- a/scripts/smoke-identify-only.sh
+++ b/scripts/smoke-identify-only.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+go test ./emulation -run '^TestSmokeIdentifyOnlyProfileValidation$' -count=1 -v "$@"


### PR DESCRIPTION
## Summary
- add a generic identify-only profile API in `emulation` via `IdentifyOnlyProfile` + `NewIdentifyOnlyTarget`
- add presets for `VR90` and `VR_71` (`PresetVR90IdentifyOnlyProfile`, `PresetVR71IdentifyOnlyProfile`)
- keep `NewVR90Target` backward-compatible by delegating to the generic constructor
- add constructor/payload/repeated-query tests and identify-only smoke validation script
- update README emulation section for the new API/smoke command

## Tests
- go test ./emulation -count=1
- ./scripts/smoke-identify-only.sh
- ./scripts/smoke-vr90-minimal.sh
- go vet ./...
- go test -race -count=1 ./...
- go build ./...

Closes #64