### PR TITLE
Add optional VR90 B509 scan.id discovery emulation

### DIFF
--- a/emulation/vr90.go
+++ b/emulation/vr90.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"strings"
 	"time"
+
+	"github.com/d3vi1/helianthus-ebusgo/protocol"
 )
 
 const (
@@ -12,6 +14,13 @@ const (
 	DefaultVR90DeviceID     = "B7V00"
 	DefaultVR90Software     = uint16(0x0422)
 	DefaultVR90Hardware     = uint16(0x5503)
+	DefaultVR90ScanID       = "21231600202609140953035469N6"
+
+	vr90B509ScanIDSelectorStart = byte(0x24)
+	vr90B509ScanIDSelectorEnd   = byte(0x27)
+	vr90B509ScanIDChunkSize     = 8
+	vr90B509ScanIDChunkCount    = 4
+	vr90B509ScanIDLength        = vr90B509ScanIDChunkSize * vr90B509ScanIDChunkCount
 )
 
 var (
@@ -23,13 +32,15 @@ var (
 )
 
 type VR90Profile struct {
-	Address       byte
-	Manufacturer  byte
-	DeviceID      string
-	Software      uint16
-	Hardware      uint16
-	ResponseDelay time.Duration
-	Timing        TimingConstraints
+	Address             byte
+	Manufacturer        byte
+	DeviceID            string
+	Software            uint16
+	Hardware            uint16
+	EnableB509Discovery bool
+	ScanID              string
+	ResponseDelay       time.Duration
+	Timing              TimingConstraints
 }
 
 func DefaultVR90Profile() VR90Profile {
@@ -39,6 +50,7 @@ func DefaultVR90Profile() VR90Profile {
 		DeviceID:      DefaultVR90DeviceID,
 		Software:      DefaultVR90Software,
 		Hardware:      DefaultVR90Hardware,
+		ScanID:        DefaultVR90ScanID,
 		ResponseDelay: defaultVR90ResponseDelay,
 		Timing:        defaultVR90Timing,
 	}
@@ -49,7 +61,7 @@ func NewVR90Target(profile VR90Profile) (*Target, error) {
 	if err != nil {
 		return nil, err
 	}
-	return NewIdentifyOnlyTarget(IdentifyOnlyProfile{
+	target, err := NewIdentifyOnlyTarget(IdentifyOnlyProfile{
 		Name:          fmt.Sprintf("vr90-minimal-0x%02x", normalized.Address),
 		Address:       normalized.Address,
 		Manufacturer:  normalized.Manufacturer,
@@ -59,6 +71,34 @@ func NewVR90Target(profile VR90Profile) (*Target, error) {
 		ResponseDelay: normalized.ResponseDelay,
 		Timing:        normalized.Timing,
 	})
+	if err != nil {
+		return nil, err
+	}
+	if !normalized.EnableB509Discovery {
+		return target, nil
+	}
+
+	scanID := normalized.ScanID
+	target.Rules = append(target.Rules, Rule{
+		Name: "vaillant-b509-scanid",
+		Matcher: MatchFunc(func(frame protocol.Frame) bool {
+			return frame.Primary == 0xB5 &&
+				frame.Secondary == 0x09 &&
+				len(frame.Data) == 1 &&
+				isVR90B509ScanIDSelector(frame.Data[0])
+		}),
+		Builder: BuildFunc(func(frame protocol.Frame) (ResponsePlan, error) {
+			chunk, ok := vr90B509ScanIDChunk(scanID, frame.Data[0])
+			if !ok {
+				return ResponsePlan{}, fmt.Errorf("vr90 unsupported b509 selector 0x%02x: %w", frame.Data[0], ErrNoMatchingRule)
+			}
+			return ResponsePlan{
+				Delay: normalized.ResponseDelay,
+				Data:  chunk,
+			}, nil
+		}),
+	})
+	return target, nil
 }
 
 func normalizeVR90Profile(profile VR90Profile) (VR90Profile, error) {
@@ -86,6 +126,7 @@ func normalizeVR90Profile(profile VR90Profile) (VR90Profile, error) {
 	if !profile.Timing.active() {
 		profile.Timing = defaultVR90Timing
 	}
+	profile.ScanID = normalizeVR90ScanID(profile.ScanID)
 	if err := profile.Timing.validate(profile.ResponseDelay); err != nil {
 		return VR90Profile{}, err
 	}
@@ -99,4 +140,39 @@ func normalizeVR90Profile(profile VR90Profile) (VR90Profile, error) {
 	}
 	profile.DeviceID = trimmed
 	return profile, nil
+}
+
+func normalizeVR90ScanID(scanID string) string {
+	trimmed := strings.TrimSpace(scanID)
+	if trimmed == "" {
+		trimmed = DefaultVR90ScanID
+	}
+	if len(trimmed) > vr90B509ScanIDLength {
+		trimmed = trimmed[:vr90B509ScanIDLength]
+	}
+	if len(trimmed) == vr90B509ScanIDLength {
+		return trimmed
+	}
+	padded := make([]byte, vr90B509ScanIDLength)
+	copy(padded, trimmed)
+	for idx := len(trimmed); idx < len(padded); idx++ {
+		padded[idx] = ' '
+	}
+	return string(padded)
+}
+
+func isVR90B509ScanIDSelector(selector byte) bool {
+	return selector >= vr90B509ScanIDSelectorStart && selector <= vr90B509ScanIDSelectorEnd
+}
+
+func vr90B509ScanIDChunk(scanID string, selector byte) ([]byte, bool) {
+	if !isVR90B509ScanIDSelector(selector) {
+		return nil, false
+	}
+	normalized := normalizeVR90ScanID(scanID)
+	offset := int(selector-vr90B509ScanIDSelectorStart) * vr90B509ScanIDChunkSize
+	chunk := make([]byte, 1, 1+vr90B509ScanIDChunkSize)
+	chunk[0] = 0x00
+	chunk = append(chunk, normalized[offset:offset+vr90B509ScanIDChunkSize]...)
+	return chunk, true
 }

--- a/emulation/vr90_test.go
+++ b/emulation/vr90_test.go
@@ -195,6 +195,205 @@ func TestVR90Target_NoMatchForOtherQueries(t *testing.T) {
 	}
 }
 
+func TestVR90B509ScanIDChunkEncoding(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name         string
+		scanID       string
+		wantSegments [4]string
+	}{
+		{
+			name:   "default padding",
+			scanID: "",
+			wantSegments: [4]string{
+				"21231600",
+				"20260914",
+				"09530354",
+				"69N6    ",
+			},
+		},
+		{
+			name:   "short padded",
+			scanID: "ABCD",
+			wantSegments: [4]string{
+				"ABCD    ",
+				"        ",
+				"        ",
+				"        ",
+			},
+		},
+		{
+			name:   "long truncated",
+			scanID: "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+			wantSegments: [4]string{
+				"01234567",
+				"89ABCDEF",
+				"GHIJKLMN",
+				"OPQRSTUV",
+			},
+		},
+	}
+
+	for _, test := range cases {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			for idx := 0; idx < vr90B509ScanIDChunkCount; idx++ {
+				selector := vr90B509ScanIDSelectorStart + byte(idx)
+				chunk, ok := vr90B509ScanIDChunk(test.scanID, selector)
+				if !ok {
+					t.Fatalf("vr90B509ScanIDChunk() ok = false for selector 0x%02x", selector)
+				}
+				want := append([]byte{0x00}, []byte(test.wantSegments[idx])...)
+				if !bytes.Equal(chunk, want) {
+					t.Fatalf("selector 0x%02x chunk = %x; want %x", selector, chunk, want)
+				}
+			}
+		})
+	}
+}
+
+func TestVR90Target_B509SelectorBehavior(t *testing.T) {
+	t.Parallel()
+
+	profile := DefaultVR90Profile()
+	profile.EnableB509Discovery = true
+	profile.ScanID = "21231600202609140953035469N6"
+
+	target, err := NewVR90Target(profile)
+	if err != nil {
+		t.Fatalf("NewVR90Target() error = %v", err)
+	}
+
+	cases := []struct {
+		name     string
+		data     []byte
+		wantData []byte
+		wantErr  error
+	}{
+		{
+			name:     "selector 0x24",
+			data:     []byte{0x24},
+			wantData: []byte{0x00, '2', '1', '2', '3', '1', '6', '0', '0'},
+		},
+		{
+			name:     "selector 0x25",
+			data:     []byte{0x25},
+			wantData: []byte{0x00, '2', '0', '2', '6', '0', '9', '1', '4'},
+		},
+		{
+			name:     "selector 0x26",
+			data:     []byte{0x26},
+			wantData: []byte{0x00, '0', '9', '5', '3', '0', '3', '5', '4'},
+		},
+		{
+			name:     "selector 0x27",
+			data:     []byte{0x27},
+			wantData: []byte{0x00, '6', '9', 'N', '6', ' ', ' ', ' ', ' '},
+		},
+		{
+			name:    "unknown selector unmatched",
+			data:    []byte{0x28},
+			wantErr: ErrNoMatchingRule,
+		},
+		{
+			name:    "known selector with extra data unmatched",
+			data:    []byte{0x24, 0x00},
+			wantErr: ErrNoMatchingRule,
+		},
+	}
+
+	for _, test := range cases {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			response, err := target.Emulate(RequestEvent{
+				Frame: protocol.Frame{
+					Source:    0x10,
+					Target:    DefaultVR90Address,
+					Primary:   0xB5,
+					Secondary: 0x09,
+					Data:      append([]byte(nil), test.data...),
+				},
+			})
+
+			if test.wantErr != nil {
+				if !errors.Is(err, test.wantErr) {
+					t.Fatalf("Emulate() error = %v; want %v", err, test.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("Emulate() error = %v", err)
+			}
+			if response.Frame.Primary != 0xB5 || response.Frame.Secondary != 0x09 {
+				t.Fatalf("Frame PB/SB = 0x%02x/0x%02x; want 0xB5/0x09", response.Frame.Primary, response.Frame.Secondary)
+			}
+			if !bytes.Equal(response.Frame.Data, test.wantData) {
+				t.Fatalf("Frame data = %x; want %x", response.Frame.Data, test.wantData)
+			}
+		})
+	}
+}
+
+func TestVR90Target_B509DiscoveryDisabledByDefault(t *testing.T) {
+	t.Parallel()
+
+	target, err := NewVR90Target(DefaultVR90Profile())
+	if err != nil {
+		t.Fatalf("NewVR90Target() error = %v", err)
+	}
+
+	_, err = target.Emulate(RequestEvent{
+		Frame: protocol.Frame{
+			Source:    0x10,
+			Target:    DefaultVR90Address,
+			Primary:   0xB5,
+			Secondary: 0x09,
+			Data:      []byte{0x24},
+		},
+	})
+	if !errors.Is(err, ErrNoMatchingRule) {
+		t.Fatalf("Emulate() error = %v; want %v", err, ErrNoMatchingRule)
+	}
+}
+
+func TestVR90Target_B509DiscoveryPreservesIdentify(t *testing.T) {
+	t.Parallel()
+
+	profile := DefaultVR90Profile()
+	profile.EnableB509Discovery = true
+	target, err := NewVR90Target(profile)
+	if err != nil {
+		t.Fatalf("NewVR90Target() error = %v", err)
+	}
+
+	response, err := target.Emulate(RequestEvent{
+		Frame: protocol.Frame{
+			Source:    0x10,
+			Target:    DefaultVR90Address,
+			Primary:   0x07,
+			Secondary: 0x04,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Emulate() error = %v", err)
+	}
+
+	wantData := []byte{
+		DefaultVR90Manufacturer,
+		'B', '7', 'V', '0', '0',
+		0x04, 0x22,
+		0x55, 0x03,
+	}
+	if !bytes.Equal(response.Frame.Data, wantData) {
+		t.Fatalf("Frame data = %x; want %x", response.Frame.Data, wantData)
+	}
+}
+
 func TestSmokeVR90MinimalQuerySet(t *testing.T) {
 	target, err := NewVR90Target(DefaultVR90Profile())
 	if err != nil {
@@ -228,6 +427,93 @@ func TestSmokeVR90MinimalQuerySet(t *testing.T) {
 	}
 	if gotID := string(response.Frame.Data[1:6]); gotID != DefaultVR90DeviceID {
 		t.Fatalf("DeviceID = %q; want %q", gotID, DefaultVR90DeviceID)
+	}
+
+	if err := ValidateResponseEnvelope(responses, ResponseEnvelope{
+		MinDelay: 5 * time.Millisecond,
+		MaxDelay: 30 * time.Millisecond,
+	}); err != nil {
+		t.Fatalf("ValidateResponseEnvelope() error = %v", err)
+	}
+}
+
+func TestSmokeVR90B509DiscoveryQuerySet(t *testing.T) {
+	profile := DefaultVR90Profile()
+	profile.EnableB509Discovery = true
+
+	target, err := NewVR90Target(profile)
+	if err != nil {
+		t.Fatalf("NewVR90Target() error = %v", err)
+	}
+
+	harness := NewHarness(target)
+	responses, err := harness.RunSequence([]QueryStep{
+		{
+			Frame: protocol.Frame{
+				Source:    0x10,
+				Target:    DefaultVR90Address,
+				Primary:   0x07,
+				Secondary: 0x04,
+			},
+		},
+		{
+			Frame: protocol.Frame{
+				Source:    0x10,
+				Target:    DefaultVR90Address,
+				Primary:   0xB5,
+				Secondary: 0x09,
+				Data:      []byte{0x24},
+			},
+		},
+		{
+			Frame: protocol.Frame{
+				Source:    0x10,
+				Target:    DefaultVR90Address,
+				Primary:   0xB5,
+				Secondary: 0x09,
+				Data:      []byte{0x25},
+			},
+		},
+		{
+			Frame: protocol.Frame{
+				Source:    0x10,
+				Target:    DefaultVR90Address,
+				Primary:   0xB5,
+				Secondary: 0x09,
+				Data:      []byte{0x26},
+			},
+		},
+		{
+			Frame: protocol.Frame{
+				Source:    0x10,
+				Target:    DefaultVR90Address,
+				Primary:   0xB5,
+				Secondary: 0x09,
+				Data:      []byte{0x27},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("RunSequence() error = %v", err)
+	}
+	if len(responses) != 5 {
+		t.Fatalf("len(responses) = %d; want 5", len(responses))
+	}
+
+	wantChunks := [][]byte{
+		{0x00, '2', '1', '2', '3', '1', '6', '0', '0'},
+		{0x00, '2', '0', '2', '6', '0', '9', '1', '4'},
+		{0x00, '0', '9', '5', '3', '0', '3', '5', '4'},
+		{0x00, '6', '9', 'N', '6', ' ', ' ', ' ', ' '},
+	}
+	for idx := range wantChunks {
+		response := responses[idx+1]
+		if response.Frame.Primary != 0xB5 || response.Frame.Secondary != 0x09 {
+			t.Fatalf("response[%d] PB/SB = 0x%02x/0x%02x; want 0xB5/0x09", idx+1, response.Frame.Primary, response.Frame.Secondary)
+		}
+		if !bytes.Equal(response.Frame.Data, wantChunks[idx]) {
+			t.Fatalf("response[%d] data = %x; want %x", idx+1, response.Frame.Data, wantChunks[idx])
+		}
 	}
 
 	if err := ValidateResponseEnvelope(responses, ResponseEnvelope{

--- a/scripts/smoke-vr90-minimal.sh
+++ b/scripts/smoke-vr90-minimal.sh
@@ -4,4 +4,4 @@ set -euo pipefail
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$repo_root"
 
-go test ./emulation -run '^TestSmokeVR90MinimalQuerySet$' -count=1 -v "$@"
+go test ./emulation -run '^TestSmokeVR90(MinimalQuerySet|B509DiscoveryQuerySet)$' -count=1 -v "$@"


### PR DESCRIPTION
## Summary
- add optional VR90 B509 (0xB5/0x09) scan.id discovery emulation for selectors 0x24..0x27
- keep existing 0x07/0x04 identify behavior unchanged and leave unknown selectors unmatched
- add table-driven tests for chunk encoding/normalization and selector matching, plus smoke coverage for B509 path
- update VR90 smoke script to run both minimal and B509 discovery smoke tests

## Validation
- go test ./emulation -count=1
- ./scripts/smoke-vr90-minimal.sh
- go test ./... -count=1

Closes #68