### PR TITLE
feat(emulation): add VR90 profile-driven mapped commands

### DIFF
--- a/emulation/vr90.go
+++ b/emulation/vr90.go
@@ -1,6 +1,7 @@
 package emulation
 
 import (
+	"bytes"
 	"fmt"
 	"strings"
 	"time"
@@ -39,8 +40,18 @@ type VR90Profile struct {
 	Hardware            uint16
 	EnableB509Discovery bool
 	ScanID              string
+	MappedCommands      []VR90MappedCommand
 	ResponseDelay       time.Duration
 	Timing              TimingConstraints
+}
+
+type VR90MappedCommand struct {
+	Name          string
+	Primary       byte
+	Secondary     byte
+	PayloadExact  []byte
+	PayloadPrefix []byte
+	ResponseData  []byte
 }
 
 func DefaultVR90Profile() VR90Profile {
@@ -74,30 +85,31 @@ func NewVR90Target(profile VR90Profile) (*Target, error) {
 	if err != nil {
 		return nil, err
 	}
-	if !normalized.EnableB509Discovery {
-		return target, nil
+	if normalized.EnableB509Discovery {
+		scanID := normalized.ScanID
+		target.Rules = append(target.Rules, Rule{
+			Name: "vaillant-b509-scanid",
+			Matcher: MatchFunc(func(frame protocol.Frame) bool {
+				return frame.Primary == 0xB5 &&
+					frame.Secondary == 0x09 &&
+					len(frame.Data) == 1 &&
+					isVR90B509ScanIDSelector(frame.Data[0])
+			}),
+			Builder: BuildFunc(func(frame protocol.Frame) (ResponsePlan, error) {
+				chunk, ok := vr90B509ScanIDChunk(scanID, frame.Data[0])
+				if !ok {
+					return ResponsePlan{}, fmt.Errorf("vr90 unsupported b509 selector 0x%02x: %w", frame.Data[0], ErrNoMatchingRule)
+				}
+				return ResponsePlan{
+					Delay: normalized.ResponseDelay,
+					Data:  chunk,
+				}, nil
+			}),
+		})
 	}
-
-	scanID := normalized.ScanID
-	target.Rules = append(target.Rules, Rule{
-		Name: "vaillant-b509-scanid",
-		Matcher: MatchFunc(func(frame protocol.Frame) bool {
-			return frame.Primary == 0xB5 &&
-				frame.Secondary == 0x09 &&
-				len(frame.Data) == 1 &&
-				isVR90B509ScanIDSelector(frame.Data[0])
-		}),
-		Builder: BuildFunc(func(frame protocol.Frame) (ResponsePlan, error) {
-			chunk, ok := vr90B509ScanIDChunk(scanID, frame.Data[0])
-			if !ok {
-				return ResponsePlan{}, fmt.Errorf("vr90 unsupported b509 selector 0x%02x: %w", frame.Data[0], ErrNoMatchingRule)
-			}
-			return ResponsePlan{
-				Delay: normalized.ResponseDelay,
-				Data:  chunk,
-			}, nil
-		}),
-	})
+	for idx := range normalized.MappedCommands {
+		target.Rules = append(target.Rules, vr90MappedRule(normalized.MappedCommands[idx], normalized.ResponseDelay))
+	}
 	return target, nil
 }
 
@@ -139,7 +151,77 @@ func normalizeVR90Profile(profile VR90Profile) (VR90Profile, error) {
 		trimmed = trimmed[:identifyOnlyDeviceIDLength]
 	}
 	profile.DeviceID = trimmed
+
+	normalizedCommands, err := normalizeVR90MappedCommands(profile.MappedCommands)
+	if err != nil {
+		return VR90Profile{}, err
+	}
+	profile.MappedCommands = normalizedCommands
 	return profile, nil
+}
+
+func normalizeVR90MappedCommands(commands []VR90MappedCommand) ([]VR90MappedCommand, error) {
+	if len(commands) == 0 {
+		return nil, nil
+	}
+
+	normalized := make([]VR90MappedCommand, 0, len(commands))
+	for idx := range commands {
+		command := commands[idx]
+		command.Name = strings.TrimSpace(command.Name)
+		if command.Name == "" {
+			command.Name = fmt.Sprintf("mapped-pb-0x%02x-sb-0x%02x-%d", command.Primary, command.Secondary, idx)
+		}
+		if len(command.PayloadExact) > 0 && len(command.PayloadPrefix) > 0 {
+			return nil, fmt.Errorf(
+				"vr90 mapped command[%d] has both exact and prefix payload matchers: %w",
+				idx,
+				ErrInvalidConfiguration,
+			)
+		}
+		if len(command.ResponseData) == 0 {
+			return nil, fmt.Errorf(
+				"vr90 mapped command[%d] empty response payload: %w",
+				idx,
+				ErrInvalidConfiguration,
+			)
+		}
+		command.PayloadExact = append([]byte(nil), command.PayloadExact...)
+		command.PayloadPrefix = append([]byte(nil), command.PayloadPrefix...)
+		command.ResponseData = append([]byte(nil), command.ResponseData...)
+		normalized = append(normalized, command)
+	}
+
+	return normalized, nil
+}
+
+func vr90MappedRule(command VR90MappedCommand, delay time.Duration) Rule {
+	responsePayload := append([]byte(nil), command.ResponseData...)
+	return Rule{
+		Name:    command.Name,
+		Matcher: vr90MappedCommandMatcher(command),
+		Builder: BuildFunc(func(protocol.Frame) (ResponsePlan, error) {
+			return ResponsePlan{
+				Delay: delay,
+				Data:  append([]byte(nil), responsePayload...),
+			}, nil
+		}),
+	}
+}
+
+func vr90MappedCommandMatcher(command VR90MappedCommand) MatchFunc {
+	if len(command.PayloadExact) > 0 {
+		payload := append([]byte(nil), command.PayloadExact...)
+		return func(frame protocol.Frame) bool {
+			return frame.Primary == command.Primary &&
+				frame.Secondary == command.Secondary &&
+				bytes.Equal(frame.Data, payload)
+		}
+	}
+	if len(command.PayloadPrefix) > 0 {
+		return MatchPrimarySecondaryWithPrefix(command.Primary, command.Secondary, command.PayloadPrefix)
+	}
+	return MatchPrimarySecondary(command.Primary, command.Secondary)
 }
 
 func normalizeVR90ScanID(scanID string) string {

--- a/emulation/vr90_test.go
+++ b/emulation/vr90_test.go
@@ -159,6 +159,33 @@ func TestNewVR90Target_Errors(t *testing.T) {
 			},
 			want: ErrInvalidConfiguration,
 		},
+		{
+			name: "mapped command has exact and prefix matchers",
+			profile: VR90Profile{
+				MappedCommands: []VR90MappedCommand{
+					{
+						Primary:       0xB5,
+						Secondary:     0x06,
+						PayloadExact:  []byte{0x01},
+						PayloadPrefix: []byte{0x01},
+						ResponseData:  []byte{0x00},
+					},
+				},
+			},
+			want: ErrInvalidConfiguration,
+		},
+		{
+			name: "mapped command empty response",
+			profile: VR90Profile{
+				MappedCommands: []VR90MappedCommand{
+					{
+						Primary:   0xB5,
+						Secondary: 0x06,
+					},
+				},
+			},
+			want: ErrInvalidConfiguration,
+		},
 	}
 
 	for _, test := range cases {
@@ -394,6 +421,212 @@ func TestVR90Target_B509DiscoveryPreservesIdentify(t *testing.T) {
 	}
 }
 
+func TestVR90Target_MappedCommandResponse(t *testing.T) {
+	t.Parallel()
+
+	profile := DefaultVR90Profile()
+	profile.MappedCommands = []VR90MappedCommand{
+		{
+			Name:          "mapped-room-temp",
+			Primary:       0xB5,
+			Secondary:     0x06,
+			PayloadPrefix: []byte{0x01, 0x00},
+			ResponseData:  []byte{0x00, 0x2A, 0x10},
+		},
+	}
+	target, err := NewVR90Target(profile)
+	if err != nil {
+		t.Fatalf("NewVR90Target() error = %v", err)
+	}
+
+	response, err := target.Emulate(RequestEvent{
+		At: 30 * time.Millisecond,
+		Frame: protocol.Frame{
+			Source:    0x10,
+			Target:    DefaultVR90Address,
+			Primary:   0xB5,
+			Secondary: 0x06,
+			Data:      []byte{0x01, 0x00, 0x7F},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Emulate() error = %v", err)
+	}
+	if response.Rule != "mapped-room-temp" {
+		t.Fatalf("Rule = %q; want mapped-room-temp", response.Rule)
+	}
+	if response.RespondAt != 38*time.Millisecond {
+		t.Fatalf("RespondAt = %s; want %s", response.RespondAt, 38*time.Millisecond)
+	}
+	wantData := []byte{0x00, 0x2A, 0x10}
+	if !bytes.Equal(response.Frame.Data, wantData) {
+		t.Fatalf("Frame data = %x; want %x", response.Frame.Data, wantData)
+	}
+
+	response.Frame.Data[0] = 0xFF
+	next, err := target.Emulate(RequestEvent{
+		At: 50 * time.Millisecond,
+		Frame: protocol.Frame{
+			Source:    0x10,
+			Target:    DefaultVR90Address,
+			Primary:   0xB5,
+			Secondary: 0x06,
+			Data:      []byte{0x01, 0x00, 0x7F},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Emulate() second call error = %v", err)
+	}
+	if !bytes.Equal(next.Frame.Data, wantData) {
+		t.Fatalf("second Frame data = %x; want %x", next.Frame.Data, wantData)
+	}
+}
+
+func TestVR90Target_MappedCommandPrecedence(t *testing.T) {
+	t.Parallel()
+
+	t.Run("built-in rules win over mapped collisions", func(t *testing.T) {
+		t.Parallel()
+
+		profile := DefaultVR90Profile()
+		profile.EnableB509Discovery = true
+		profile.MappedCommands = []VR90MappedCommand{
+			{
+				Name:         "mapped-identify-collision",
+				Primary:      0x07,
+				Secondary:    0x04,
+				ResponseData: []byte{0xAA},
+			},
+			{
+				Name:         "mapped-b509-collision",
+				Primary:      0xB5,
+				Secondary:    0x09,
+				PayloadExact: []byte{0x24},
+				ResponseData: []byte{0xBB},
+			},
+		}
+		target, err := NewVR90Target(profile)
+		if err != nil {
+			t.Fatalf("NewVR90Target() error = %v", err)
+		}
+
+		identify, err := target.Emulate(RequestEvent{
+			Frame: protocol.Frame{
+				Source:    0x10,
+				Target:    DefaultVR90Address,
+				Primary:   0x07,
+				Secondary: 0x04,
+			},
+		})
+		if err != nil {
+			t.Fatalf("identify Emulate() error = %v", err)
+		}
+		if identify.Rule != "identify" {
+			t.Fatalf("identify Rule = %q; want identify", identify.Rule)
+		}
+
+		b509, err := target.Emulate(RequestEvent{
+			Frame: protocol.Frame{
+				Source:    0x10,
+				Target:    DefaultVR90Address,
+				Primary:   0xB5,
+				Secondary: 0x09,
+				Data:      []byte{0x24},
+			},
+		})
+		if err != nil {
+			t.Fatalf("b509 Emulate() error = %v", err)
+		}
+		if b509.Rule != "vaillant-b509-scanid" {
+			t.Fatalf("b509 Rule = %q; want vaillant-b509-scanid", b509.Rule)
+		}
+		wantChunk, ok := vr90B509ScanIDChunk(profile.ScanID, 0x24)
+		if !ok {
+			t.Fatalf("vr90B509ScanIDChunk() ok = false")
+		}
+		if !bytes.Equal(b509.Frame.Data, wantChunk) {
+			t.Fatalf("b509 Frame data = %x; want %x", b509.Frame.Data, wantChunk)
+		}
+	})
+
+	t.Run("mapped commands follow declaration order", func(t *testing.T) {
+		t.Parallel()
+
+		profile := DefaultVR90Profile()
+		profile.MappedCommands = []VR90MappedCommand{
+			{
+				Name:          "first-prefix",
+				Primary:       0xB5,
+				Secondary:     0x06,
+				PayloadPrefix: []byte{0x01},
+				ResponseData:  []byte{0x10},
+			},
+			{
+				Name:         "second-exact",
+				Primary:      0xB5,
+				Secondary:    0x06,
+				PayloadExact: []byte{0x01, 0x02},
+				ResponseData: []byte{0x20},
+			},
+		}
+		target, err := NewVR90Target(profile)
+		if err != nil {
+			t.Fatalf("NewVR90Target() error = %v", err)
+		}
+
+		response, err := target.Emulate(RequestEvent{
+			Frame: protocol.Frame{
+				Source:    0x10,
+				Target:    DefaultVR90Address,
+				Primary:   0xB5,
+				Secondary: 0x06,
+				Data:      []byte{0x01, 0x02},
+			},
+		})
+		if err != nil {
+			t.Fatalf("Emulate() error = %v", err)
+		}
+		if response.Rule != "first-prefix" {
+			t.Fatalf("Rule = %q; want first-prefix", response.Rule)
+		}
+		if !bytes.Equal(response.Frame.Data, []byte{0x10}) {
+			t.Fatalf("Frame data = %x; want %x", response.Frame.Data, []byte{0x10})
+		}
+	})
+}
+
+func TestVR90Target_MappedCommandUnknownFallback(t *testing.T) {
+	t.Parallel()
+
+	profile := DefaultVR90Profile()
+	profile.MappedCommands = []VR90MappedCommand{
+		{
+			Name:          "mapped-room-temp",
+			Primary:       0xB5,
+			Secondary:     0x06,
+			PayloadPrefix: []byte{0x01, 0x00},
+			ResponseData:  []byte{0x00, 0x2A, 0x10},
+		},
+	}
+	target, err := NewVR90Target(profile)
+	if err != nil {
+		t.Fatalf("NewVR90Target() error = %v", err)
+	}
+
+	_, err = target.Emulate(RequestEvent{
+		Frame: protocol.Frame{
+			Source:    0x10,
+			Target:    DefaultVR90Address,
+			Primary:   0xB5,
+			Secondary: 0x06,
+			Data:      []byte{0x01, 0x01},
+		},
+	})
+	if !errors.Is(err, ErrNoMatchingRule) {
+		t.Fatalf("Emulate() error = %v; want %v", err, ErrNoMatchingRule)
+	}
+}
+
 func TestSmokeVR90MinimalQuerySet(t *testing.T) {
 	target, err := NewVR90Target(DefaultVR90Profile())
 	if err != nil {
@@ -514,6 +747,100 @@ func TestSmokeVR90B509DiscoveryQuerySet(t *testing.T) {
 		if !bytes.Equal(response.Frame.Data, wantChunks[idx]) {
 			t.Fatalf("response[%d] data = %x; want %x", idx+1, response.Frame.Data, wantChunks[idx])
 		}
+	}
+
+	if err := ValidateResponseEnvelope(responses, ResponseEnvelope{
+		MinDelay: 5 * time.Millisecond,
+		MaxDelay: 30 * time.Millisecond,
+	}); err != nil {
+		t.Fatalf("ValidateResponseEnvelope() error = %v", err)
+	}
+}
+
+func TestSmokeVR90MappedCommandQuerySet(t *testing.T) {
+	profile := DefaultVR90Profile()
+	profile.EnableB509Discovery = true
+	profile.MappedCommands = []VR90MappedCommand{
+		{
+			Name:          "mapped-room-temp",
+			Primary:       0xB5,
+			Secondary:     0x06,
+			PayloadPrefix: []byte{0x01, 0x00},
+			ResponseData:  []byte{0x00, 0x2A, 0x10},
+		},
+	}
+
+	target, err := NewVR90Target(profile)
+	if err != nil {
+		t.Fatalf("NewVR90Target() error = %v", err)
+	}
+
+	harness := NewHarness(target)
+	responses, err := harness.RunSequence([]QueryStep{
+		{
+			Frame: protocol.Frame{
+				Source:    0x10,
+				Target:    DefaultVR90Address,
+				Primary:   0x07,
+				Secondary: 0x04,
+			},
+		},
+		{
+			Frame: protocol.Frame{
+				Source:    0x10,
+				Target:    DefaultVR90Address,
+				Primary:   0xB5,
+				Secondary: 0x09,
+				Data:      []byte{0x24},
+			},
+		},
+		{
+			Frame: protocol.Frame{
+				Source:    0x10,
+				Target:    DefaultVR90Address,
+				Primary:   0xB5,
+				Secondary: 0x06,
+				Data:      []byte{0x01, 0x00, 0x33},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("RunSequence() error = %v", err)
+	}
+	if len(responses) != 3 {
+		t.Fatalf("len(responses) = %d; want 3", len(responses))
+	}
+
+	identify := responses[0]
+	if identify.Rule != "identify" {
+		t.Fatalf("responses[0].Rule = %q; want identify", identify.Rule)
+	}
+	if gotID := string(identify.Frame.Data[1:6]); gotID != DefaultVR90DeviceID {
+		t.Fatalf("responses[0] DeviceID = %q; want %q", gotID, DefaultVR90DeviceID)
+	}
+
+	b509 := responses[1]
+	if b509.Rule != "vaillant-b509-scanid" {
+		t.Fatalf("responses[1].Rule = %q; want vaillant-b509-scanid", b509.Rule)
+	}
+	wantChunk, ok := vr90B509ScanIDChunk(profile.ScanID, 0x24)
+	if !ok {
+		t.Fatalf("vr90B509ScanIDChunk() ok = false")
+	}
+	if !bytes.Equal(b509.Frame.Data, wantChunk) {
+		t.Fatalf("responses[1] data = %x; want %x", b509.Frame.Data, wantChunk)
+	}
+
+	mapped := responses[2]
+	if mapped.Rule != "mapped-room-temp" {
+		t.Fatalf("responses[2].Rule = %q; want mapped-room-temp", mapped.Rule)
+	}
+	if mapped.Frame.Primary != 0xB5 || mapped.Frame.Secondary != 0x06 {
+		t.Fatalf("responses[2] PB/SB = 0x%02x/0x%02x; want 0xB5/0x06", mapped.Frame.Primary, mapped.Frame.Secondary)
+	}
+	wantMapped := []byte{0x00, 0x2A, 0x10}
+	if !bytes.Equal(mapped.Frame.Data, wantMapped) {
+		t.Fatalf("responses[2] data = %x; want %x", mapped.Frame.Data, wantMapped)
 	}
 
 	if err := ValidateResponseEnvelope(responses, ResponseEnvelope{

--- a/scripts/smoke-vr90-minimal.sh
+++ b/scripts/smoke-vr90-minimal.sh
@@ -4,4 +4,4 @@ set -euo pipefail
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$repo_root"
 
-go test ./emulation -run '^TestSmokeVR90(MinimalQuerySet|B509DiscoveryQuerySet)$' -count=1 -v "$@"
+go test ./emulation -run '^TestSmokeVR90(MinimalQuerySet|B509DiscoveryQuerySet|MappedCommandQuerySet)$' -count=1 -v "$@"


### PR DESCRIPTION
## Summary
- add optional `VR90Profile.MappedCommands` entries keyed by PB/SB plus payload matcher (exact or prefix)
- append mapped command rules with deterministic response bytes using existing profile response delay/timing envelope
- preserve identify and optional B509 behavior by keeping built-in rules ahead of mapped collisions
- add unit coverage for mapped command precedence, validation errors, and unknown fallback
- extend VR90 smoke script to run a mapped-command smoke case on top of identify + B509

## Validation
- go test ./emulation -count=1
- ./scripts/smoke-vr90-minimal.sh
- go test ./... -count=1

Closes #70