### PR TITLE
fix(protocol): parse full response telegram

### DIFF
--- a/protocol/bus.go
+++ b/protocol/bus.go
@@ -399,12 +399,48 @@ func (b *Bus) sendTransaction(runCtx, reqCtx context.Context, frame Frame) (*Fra
 
 	var data []byte
 	for respAttempt := 0; respAttempt < 2; respAttempt++ {
+		respSource, err := decoder.readSymbol(b, runCtx, reqCtx)
+		if err != nil {
+			return nil, err
+		}
+		if respSource == SymbolSyn {
+			return nil, fmt.Errorf("syn while waiting for response: %w", ebuserrors.ErrTimeout)
+		}
+
+		respTarget, err := decoder.readSymbol(b, runCtx, reqCtx)
+		if err != nil {
+			return nil, err
+		}
+		if respTarget == SymbolSyn {
+			return nil, fmt.Errorf("syn while waiting for response dst: %w", ebuserrors.ErrTimeout)
+		}
+
+		respPrimary, err := decoder.readSymbol(b, runCtx, reqCtx)
+		if err != nil {
+			return nil, err
+		}
+		if respPrimary == SymbolSyn {
+			return nil, fmt.Errorf("syn while waiting for response pb: %w", ebuserrors.ErrTimeout)
+		}
+
+		respSecondary, err := decoder.readSymbol(b, runCtx, reqCtx)
+		if err != nil {
+			return nil, err
+		}
+		if respSecondary == SymbolSyn {
+			return nil, fmt.Errorf("syn while waiting for response sb: %w", ebuserrors.ErrTimeout)
+		}
+
+		if respSource != frame.Target || respTarget != frame.Source || respPrimary != frame.Primary || respSecondary != frame.Secondary {
+			return nil, fmt.Errorf("unexpected response header (src 0x%02x dst 0x%02x pb 0x%02x sb 0x%02x): %w", respSource, respTarget, respPrimary, respSecondary, ebuserrors.ErrBusCollision)
+		}
+
 		lengthSym, err := decoder.readSymbol(b, runCtx, reqCtx)
 		if err != nil {
 			return nil, err
 		}
 		if lengthSym == SymbolSyn {
-			return nil, fmt.Errorf("syn while waiting for response: %w", ebuserrors.ErrTimeout)
+			return nil, fmt.Errorf("syn while waiting for response length: %w", ebuserrors.ErrTimeout)
 		}
 
 		length := int(lengthSym)
@@ -428,7 +464,9 @@ func (b *Bus) sendTransaction(runCtx, reqCtx context.Context, frame Frame) (*Fra
 			return nil, fmt.Errorf("syn while waiting for response crc: %w", ebuserrors.ErrTimeout)
 		}
 
-		segment := append([]byte{lengthSym}, data...)
+		segment := make([]byte, 0, 5+len(data))
+		segment = append(segment, respSource, respTarget, respPrimary, respSecondary, lengthSym)
+		segment = append(segment, data...)
 		if CRC(segment) != crcValue {
 			if err := b.sendSymbolWithEcho(runCtx, reqCtx, SymbolNack, true); err != nil {
 				return nil, err
@@ -448,10 +486,10 @@ func (b *Bus) sendTransaction(runCtx, reqCtx context.Context, frame Frame) (*Fra
 		}
 
 		return &Frame{
-			Source:    frame.Target,
-			Target:    frame.Source,
-			Primary:   frame.Primary,
-			Secondary: frame.Secondary,
+			Source:    respSource,
+			Target:    respTarget,
+			Primary:   respPrimary,
+			Secondary: respSecondary,
 			Data:      data,
 		}, nil
 	}

--- a/protocol/bus_test.go
+++ b/protocol/bus_test.go
@@ -223,15 +223,23 @@ func TestBus_ResponseCRCMismatch(t *testing.T) {
 	}
 
 	data := byte(0x10)
-	length := byte(0x01)
-	badCRC := protocol.CRC([]byte{length, data}) ^ 0xFF
+	responseSegment := []byte{frame.Target, frame.Source, frame.Primary, frame.Secondary, 0x01, data}
+	badCRC := protocol.CRC(responseSegment) ^ 0xFF
 	tr := &scriptedTransport{
 		inbound: []readEvent{
 			{value: protocol.SymbolAck},
-			{value: length},
+			{value: frame.Target},
+			{value: frame.Source},
+			{value: frame.Primary},
+			{value: frame.Secondary},
+			{value: 0x01},
 			{value: data},
 			{value: badCRC},
-			{value: length},
+			{value: frame.Target},
+			{value: frame.Source},
+			{value: frame.Primary},
+			{value: frame.Secondary},
+			{value: 0x01},
 			{value: data},
 			{value: badCRC},
 		},
@@ -255,8 +263,8 @@ func TestBus_ResponseCRCMismatch(t *testing.T) {
 	if !errors.Is(err, ebuserrors.ErrCRCMismatch) {
 		t.Fatalf("Send error = %v; want ErrCRCMismatch", err)
 	}
-	if tr.inboundReadsConsumed() != 7 {
-		t.Fatalf("inbound reads = %d; want 7", tr.inboundReadsConsumed())
+	if tr.inboundReadsConsumed() != 15 {
+		t.Fatalf("inbound reads = %d; want 15", tr.inboundReadsConsumed())
 	}
 }
 
@@ -272,15 +280,24 @@ func TestBus_RetryOnCRCMismatch(t *testing.T) {
 	}
 
 	data := byte(0x10)
-	goodCRC := protocol.CRC([]byte{0x01, data})
+	responseSegment := []byte{frame.Target, frame.Source, frame.Primary, frame.Secondary, 0x01, data}
+	goodCRC := protocol.CRC(responseSegment)
 	badCRC := goodCRC ^ 0xFF
 
 	tr := &scriptedTransport{
 		inbound: []readEvent{
 			{value: protocol.SymbolAck},
+			{value: frame.Target},
+			{value: frame.Source},
+			{value: frame.Primary},
+			{value: frame.Secondary},
 			{value: 0x01},
 			{value: data},
 			{value: badCRC},
+			{value: frame.Target},
+			{value: frame.Source},
+			{value: frame.Primary},
+			{value: frame.Secondary},
 			{value: 0x01},
 			{value: data},
 			{value: goodCRC},
@@ -308,8 +325,8 @@ func TestBus_RetryOnCRCMismatch(t *testing.T) {
 	if resp == nil || len(resp.Data) != 1 || resp.Data[0] != data {
 		t.Fatalf("response = %+v; want data [0x10]", resp)
 	}
-	if tr.inboundReadsConsumed() != 7 {
-		t.Fatalf("inbound reads = %d; want 7", tr.inboundReadsConsumed())
+	if tr.inboundReadsConsumed() != 15 {
+		t.Fatalf("inbound reads = %d; want 15", tr.inboundReadsConsumed())
 	}
 }
 
@@ -324,12 +341,17 @@ func TestBus_RetryOnTimeout(t *testing.T) {
 		Data:      []byte{0x03},
 	}
 	data := byte(0x10)
-	respCRC := protocol.CRC([]byte{0x01, data})
+	responseSegment := []byte{frame.Target, frame.Source, frame.Primary, frame.Secondary, 0x01, data}
+	respCRC := protocol.CRC(responseSegment)
 
 	tr := &scriptedTransport{
 		inbound: []readEvent{
 			{err: ebuserrors.ErrTimeout},
 			{value: protocol.SymbolAck},
+			{value: frame.Target},
+			{value: frame.Source},
+			{value: frame.Primary},
+			{value: frame.Secondary},
 			{value: 0x01},
 			{value: data},
 			{value: respCRC},
@@ -380,12 +402,17 @@ func TestBus_RetryOnNACK(t *testing.T) {
 		Data:      []byte{0x03},
 	}
 	data := byte(0x20)
-	respCRC := protocol.CRC([]byte{0x01, data})
+	responseSegment := []byte{frame.Target, frame.Source, frame.Primary, frame.Secondary, 0x01, data}
+	respCRC := protocol.CRC(responseSegment)
 
 	tr := &scriptedTransport{
 		inbound: []readEvent{
 			{value: protocol.SymbolNack},
 			{value: protocol.SymbolAck},
+			{value: frame.Target},
+			{value: frame.Source},
+			{value: frame.Primary},
+			{value: frame.Secondary},
 			{value: 0x01},
 			{value: data},
 			{value: respCRC},
@@ -674,13 +701,18 @@ func TestBus_RetryOnCollisionDuringWriteWaitsForSyn(t *testing.T) {
 	}
 
 	data := byte(0x10)
-	respCRC := protocol.CRC([]byte{0x01, data})
+	responseSegment := []byte{frame.Target, frame.Source, frame.Primary, frame.Secondary, 0x01, data}
+	respCRC := protocol.CRC(responseSegment)
 	tr := &collisionOnceTransport{
 		collideOnFirstEcho: true,
 		inbound: []readEvent{
 			{value: protocol.SymbolSyn},
 			{value: protocol.SymbolSyn},
 			{value: protocol.SymbolAck},
+			{value: frame.Target},
+			{value: frame.Source},
+			{value: frame.Primary},
+			{value: frame.Secondary},
 			{value: 0x01},
 			{value: data},
 			{value: respCRC},
@@ -712,8 +744,8 @@ func TestBus_RetryOnCollisionDuringWriteWaitsForSyn(t *testing.T) {
 	tr.mu.Lock()
 	inReads := tr.inboundReads
 	tr.mu.Unlock()
-	if inReads != 6 {
-		t.Fatalf("inbound reads = %d; want 6", inReads)
+	if inReads != 10 {
+		t.Fatalf("inbound reads = %d; want 10", inReads)
 	}
 }
 
@@ -728,13 +760,18 @@ func TestBus_RetryOnCollisionDoesNotConsumeTimeoutRetries(t *testing.T) {
 	}
 
 	data := byte(0x10)
-	respCRC := protocol.CRC([]byte{0x01, data})
+	responseSegment := []byte{frame.Target, frame.Source, frame.Primary, frame.Secondary, 0x01, data}
+	respCRC := protocol.CRC(responseSegment)
 	tr := &collisionOnceTransport{
 		collideOnFirstEcho: true,
 		inbound: []readEvent{
 			{value: protocol.SymbolSyn},
 			{value: protocol.SymbolSyn},
 			{value: protocol.SymbolAck},
+			{value: frame.Target},
+			{value: frame.Source},
+			{value: frame.Primary},
+			{value: frame.Secondary},
 			{value: 0x01},
 			{value: data},
 			{value: respCRC},
@@ -775,13 +812,18 @@ func TestBus_CollisionRetryRespectsTimeoutRetriesWithoutDeadline(t *testing.T) {
 	}
 
 	data := byte(0x10)
-	respCRC := protocol.CRC([]byte{0x01, data})
+	responseSegment := []byte{frame.Target, frame.Source, frame.Primary, frame.Secondary, 0x01, data}
+	respCRC := protocol.CRC(responseSegment)
 	tr := &collisionOnceTransport{
 		collideOnFirstEcho: true,
 		inbound: []readEvent{
 			{value: protocol.SymbolSyn},
 			{value: protocol.SymbolSyn},
 			{value: protocol.SymbolAck},
+			{value: frame.Target},
+			{value: frame.Source},
+			{value: frame.Primary},
+			{value: frame.Secondary},
 			{value: 0x01},
 			{value: data},
 			{value: respCRC},


### PR DESCRIPTION
Fix initiator-target response parsing to match real eBUS wire format.

**What changed**
- Parse target response as a full telegram: `SRC DST PB SB LEN DATA... CRC`.
- CRC is now validated over `SRC DST PB SB LEN DATA`.
- Unexpected response headers are treated as a bus-collision/resync condition.
- Updated `protocol/bus_test.go` to model full response telegrams.

**Why**
ENH/ENS transports expose raw bus bytes. The previous code assumed the first byte of the response was `LEN`, which breaks CRC validation and can cause scans to report no devices.

**Testing**
- `go test ./...`

Fixes #74.
