### PR TITLE
test: fix errcheck on transport close defers

### DIFF
--- a/transport/ebusd_tcp_test.go
+++ b/transport/ebusd_tcp_test.go
@@ -225,8 +225,8 @@ func TestEbusdTCPTransport_SendHexCommand_StripsLengthPrefix(t *testing.T) {
 			t.Parallel()
 
 			client, server := net.Pipe()
-			defer client.Close()
-			defer server.Close()
+			defer func() { _ = client.Close() }()
+			defer func() { _ = server.Close() }()
 
 			tr := NewEbusdTCPTransport(client)
 
@@ -267,8 +267,8 @@ func TestEbusdTCPTransport_SendHexCommand_CommandFormatting(t *testing.T) {
 	t.Parallel()
 
 	client, server := net.Pipe()
-	defer client.Close()
-	defer server.Close()
+	defer func() { _ = client.Close() }()
+	defer func() { _ = server.Close() }()
 
 	tr := NewEbusdTCPTransport(client)
 
@@ -338,8 +338,8 @@ func TestEbusdTCPTransport_SendHexCommand_ErrLines(t *testing.T) {
 			t.Parallel()
 
 			client, server := net.Pipe()
-			defer client.Close()
-			defer server.Close()
+			defer func() { _ = client.Close() }()
+			defer func() { _ = server.Close() }()
 
 			tr := NewEbusdTCPTransport(client)
 			wantCommand := "hex -s 08 01\n"
@@ -377,8 +377,8 @@ func TestEbusdTCPTransport_Write_BroadcastDone(t *testing.T) {
 	t.Parallel()
 
 	client, server := net.Pipe()
-	defer client.Close()
-	defer server.Close()
+	defer func() { _ = client.Close() }()
+	defer func() { _ = server.Close() }()
 
 	tr := NewEbusdTCPTransport(client)
 

--- a/transport/enh_transport_test.go
+++ b/transport/enh_transport_test.go
@@ -15,8 +15,8 @@ func TestENHTransport_ReadByteDecodesFrames(t *testing.T) {
 	t.Parallel()
 
 	client, server := net.Pipe()
-	defer client.Close()
-	defer server.Close()
+	defer func() { _ = client.Close() }()
+	defer func() { _ = server.Close() }()
 
 	enh := transport.NewENHTransport(client, 200*time.Millisecond, 200*time.Millisecond)
 	seqReceived := transport.EncodeENH(transport.ENHResReceived, 0x22)
@@ -50,8 +50,8 @@ func TestENHTransport_InitHandshake(t *testing.T) {
 	t.Parallel()
 
 	client, server := net.Pipe()
-	defer client.Close()
-	defer server.Close()
+	defer func() { _ = client.Close() }()
+	defer func() { _ = server.Close() }()
 
 	enh := transport.NewENHTransport(client, 200*time.Millisecond, 200*time.Millisecond)
 
@@ -88,8 +88,8 @@ func TestENHTransport_ResetClearsEchoSuppression(t *testing.T) {
 	t.Parallel()
 
 	client, server := net.Pipe()
-	defer client.Close()
-	defer server.Close()
+	defer func() { _ = client.Close() }()
+	defer func() { _ = server.Close() }()
 
 	enh := transport.NewENHTransport(client, 200*time.Millisecond, 200*time.Millisecond)
 
@@ -128,8 +128,8 @@ func TestENHTransport_WriteEncodesFrames(t *testing.T) {
 	t.Parallel()
 
 	client, server := net.Pipe()
-	defer client.Close()
-	defer server.Close()
+	defer func() { _ = client.Close() }()
+	defer func() { _ = server.Close() }()
 
 	enh := transport.NewENHTransport(client, 200*time.Millisecond, 200*time.Millisecond)
 
@@ -175,8 +175,8 @@ func TestENHTransport_ReadTimeout(t *testing.T) {
 	t.Parallel()
 
 	client, server := net.Pipe()
-	defer client.Close()
-	defer server.Close()
+	defer func() { _ = client.Close() }()
+	defer func() { _ = server.Close() }()
 
 	enh := transport.NewENHTransport(client, 50*time.Millisecond, 200*time.Millisecond)
 	_, err := enh.ReadByte()
@@ -189,7 +189,7 @@ func TestENHTransport_ReadClosed(t *testing.T) {
 	t.Parallel()
 
 	client, server := net.Pipe()
-	defer client.Close()
+	defer func() { _ = client.Close() }()
 	_ = server.Close()
 
 	enh := transport.NewENHTransport(client, 200*time.Millisecond, 200*time.Millisecond)
@@ -203,8 +203,8 @@ func TestENHTransport_ForwardsEchoedBytes(t *testing.T) {
 	t.Parallel()
 
 	client, server := net.Pipe()
-	defer client.Close()
-	defer server.Close()
+	defer func() { _ = client.Close() }()
+	defer func() { _ = server.Close() }()
 
 	enh := transport.NewENHTransport(client, 200*time.Millisecond, 200*time.Millisecond)
 
@@ -250,8 +250,8 @@ func TestENHTransport_StartArbitrationStartedDiscardsReceivedBytes(t *testing.T)
 	t.Parallel()
 
 	client, server := net.Pipe()
-	defer client.Close()
-	defer server.Close()
+	defer func() { _ = client.Close() }()
+	defer func() { _ = server.Close() }()
 
 	enh := transport.NewENHTransport(client, 200*time.Millisecond, 200*time.Millisecond)
 	initiator := byte(0x10)
@@ -294,8 +294,8 @@ func TestENHTransport_StartArbitrationFailedDiscardsReceivedBytes(t *testing.T) 
 	t.Parallel()
 
 	client, server := net.Pipe()
-	defer client.Close()
-	defer server.Close()
+	defer func() { _ = client.Close() }()
+	defer func() { _ = server.Close() }()
 
 	enh := transport.NewENHTransport(client, 200*time.Millisecond, 200*time.Millisecond)
 	initiator := byte(0x10)

--- a/transport/ens_transport_test.go
+++ b/transport/ens_transport_test.go
@@ -15,8 +15,8 @@ func TestENSTransport_ReadByteDecodesEscapes(t *testing.T) {
 	t.Parallel()
 
 	client, server := net.Pipe()
-	defer client.Close()
-	defer server.Close()
+	defer func() { _ = client.Close() }()
+	defer func() { _ = server.Close() }()
 
 	ens := transport.NewENSTransport(client, 200*time.Millisecond, 200*time.Millisecond)
 	raw := []byte{0x10, 0xA9, 0xAA, 0x20}
@@ -47,8 +47,8 @@ func TestENSTransport_WriteEncodesEscapes(t *testing.T) {
 	t.Parallel()
 
 	client, server := net.Pipe()
-	defer client.Close()
-	defer server.Close()
+	defer func() { _ = client.Close() }()
+	defer func() { _ = server.Close() }()
 
 	ens := transport.NewENSTransport(client, 200*time.Millisecond, 200*time.Millisecond)
 
@@ -93,8 +93,8 @@ func TestENSTransport_ReadTimeout(t *testing.T) {
 	t.Parallel()
 
 	client, server := net.Pipe()
-	defer client.Close()
-	defer server.Close()
+	defer func() { _ = client.Close() }()
+	defer func() { _ = server.Close() }()
 
 	ens := transport.NewENSTransport(client, 50*time.Millisecond, 200*time.Millisecond)
 	_, err := ens.ReadByte()
@@ -107,7 +107,7 @@ func TestENSTransport_ReadClosed(t *testing.T) {
 	t.Parallel()
 
 	client, server := net.Pipe()
-	defer client.Close()
+	defer func() { _ = client.Close() }()
 	_ = server.Close()
 
 	ens := transport.NewENSTransport(client, 200*time.Millisecond, 200*time.Millisecond)

--- a/transport/loopback_test.go
+++ b/transport/loopback_test.go
@@ -13,7 +13,7 @@ func TestLoopback_ReadWrite(t *testing.T) {
 	t.Parallel()
 
 	lb := transport.NewLoopback()
-	defer lb.Close()
+	defer func() { _ = lb.Close() }()
 
 	payload := []byte{0x01, 0x02, 0x03}
 	n, err := lb.Write(payload)
@@ -39,7 +39,7 @@ func TestLoopback_BlockingReadUnblocksOnWrite(t *testing.T) {
 	t.Parallel()
 
 	lb := transport.NewLoopback()
-	defer lb.Close()
+	defer func() { _ = lb.Close() }()
 
 	readCh := make(chan byte, 1)
 	errCh := make(chan error, 1)


### PR DESCRIPTION
## What
Fixes local CI lint failures (`errcheck`) in transport tests by checking/ignoring close errors explicitly in deferred closes.

## Why
`golangci-lint` flags unchecked close errors in tests. This keeps CI lint green once Actions runners are available again.

## Validation
- `go test ./...`
- `golangci-lint run ./...`
