### PR TITLE
emulation: add VR92 profile (Vaillant VR_92)

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,11 @@ profile := emulation.PresetVR90IdentifyOnlyProfile()
 target, err := emulation.NewIdentifyOnlyTarget(profile)
 ```
 
+```go
+profile := emulation.PresetVR92IdentifyOnlyProfile()
+target, err := emulation.NewIdentifyOnlyTarget(profile)
+```
+
 ### VR90 extended discovery + mapped-command example
 
 ```go

--- a/emulation/identify_only.go
+++ b/emulation/identify_only.go
@@ -50,6 +50,19 @@ func PresetVR90IdentifyOnlyProfile() IdentifyOnlyProfile {
 	}
 }
 
+func PresetVR92IdentifyOnlyProfile() IdentifyOnlyProfile {
+	return IdentifyOnlyProfile{
+		Name:          fmt.Sprintf("vr92-minimal-0x%02x", DefaultVR92Address),
+		Address:       DefaultVR92Address,
+		Manufacturer:  DefaultVR92Manufacturer,
+		DeviceID:      DefaultVR92DeviceID,
+		Software:      DefaultVR92Software,
+		Hardware:      DefaultVR92Hardware,
+		ResponseDelay: defaultVR92ResponseDelay,
+		Timing:        defaultVR92Timing,
+	}
+}
+
 func PresetVR71IdentifyOnlyProfile() IdentifyOnlyProfile {
 	return IdentifyOnlyProfile{
 		Name:          fmt.Sprintf("vr71-minimal-0x%02x", DefaultVR71Address),

--- a/emulation/identify_only_test.go
+++ b/emulation/identify_only_test.go
@@ -136,6 +136,15 @@ func TestIdentifyOnlyProfile_Presets(t *testing.T) {
 		t.Fatalf("VR90 preset mismatch: %+v", vr90)
 	}
 
+	vr92 := PresetVR92IdentifyOnlyProfile()
+	if vr92.Address != DefaultVR92Address ||
+		vr92.Manufacturer != DefaultVR92Manufacturer ||
+		vr92.DeviceID != DefaultVR92DeviceID ||
+		vr92.Software != DefaultVR92Software ||
+		vr92.Hardware != DefaultVR92Hardware {
+		t.Fatalf("VR92 preset mismatch: %+v", vr92)
+	}
+
 	vr71 := PresetVR71IdentifyOnlyProfile()
 	if vr71.Address != DefaultVR71Address ||
 		vr71.Manufacturer != DefaultVR71Manufacturer ||
@@ -196,6 +205,10 @@ func TestSmokeIdentifyOnlyProfileValidation(t *testing.T) {
 		{
 			name:    "vr90",
 			profile: PresetVR90IdentifyOnlyProfile(),
+		},
+		{
+			name:    "vr92",
+			profile: PresetVR92IdentifyOnlyProfile(),
 		},
 		{
 			name:    "vr_71",

--- a/emulation/vr92.go
+++ b/emulation/vr92.go
@@ -1,0 +1,109 @@
+package emulation
+
+import (
+	"fmt"
+	"strings"
+	"time"
+)
+
+const (
+	DefaultVR92Address      = byte(0x30)
+	DefaultVR92Manufacturer = byte(0xB5)
+	DefaultVR92DeviceID     = "VR_92"
+	DefaultVR92Software     = uint16(0x0514)
+	DefaultVR92Hardware     = uint16(0x1204)
+)
+
+var (
+	defaultVR92ResponseDelay = 8 * time.Millisecond
+	defaultVR92Timing        = TimingConstraints{
+		MinResponseDelay: 5 * time.Millisecond,
+		MaxResponseDelay: 30 * time.Millisecond,
+	}
+)
+
+type VR92MappedCommand = VR90MappedCommand
+
+type VR92Profile struct {
+	Address             byte
+	Manufacturer        byte
+	DeviceID            string
+	Software            uint16
+	Hardware            uint16
+	EnableB509Discovery bool
+	ScanID              string
+	MappedCommands      []VR92MappedCommand
+	ResponseDelay       time.Duration
+	Timing              TimingConstraints
+}
+
+func DefaultVR92Profile() VR92Profile {
+	return VR92Profile{
+		Address:       DefaultVR92Address,
+		Manufacturer:  DefaultVR92Manufacturer,
+		DeviceID:      DefaultVR92DeviceID,
+		Software:      DefaultVR92Software,
+		Hardware:      DefaultVR92Hardware,
+		ResponseDelay: defaultVR92ResponseDelay,
+		Timing:        defaultVR92Timing,
+	}
+}
+
+func NewVR92Target(profile VR92Profile) (*Target, error) {
+	normalized, err := normalizeVR92Profile(profile)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewVR90Target(VR90Profile(normalized))
+}
+
+func normalizeVR92Profile(profile VR92Profile) (VR92Profile, error) {
+	hasIdentityOverrides := profile.Manufacturer != 0 ||
+		strings.TrimSpace(profile.DeviceID) != "" ||
+		profile.Software != 0 ||
+		profile.Hardware != 0
+
+	if profile.Address == 0 {
+		profile.Address = DefaultVR92Address
+	}
+	if profile.Manufacturer == 0 {
+		profile.Manufacturer = DefaultVR92Manufacturer
+	}
+	if strings.TrimSpace(profile.DeviceID) == "" {
+		profile.DeviceID = DefaultVR92DeviceID
+	}
+	if !hasIdentityOverrides {
+		profile.Software = DefaultVR92Software
+		profile.Hardware = DefaultVR92Hardware
+	}
+	if profile.ResponseDelay <= 0 {
+		profile.ResponseDelay = defaultVR92ResponseDelay
+	}
+	if !profile.Timing.active() {
+		profile.Timing = defaultVR92Timing
+	}
+	if err := profile.Timing.validate(profile.ResponseDelay); err != nil {
+		return VR92Profile{}, err
+	}
+
+	trimmed := strings.TrimSpace(profile.DeviceID)
+	if trimmed == "" {
+		return VR92Profile{}, fmt.Errorf("vr92 profile empty device id: %w", ErrInvalidConfiguration)
+	}
+	if len(trimmed) > identifyOnlyDeviceIDLength {
+		trimmed = trimmed[:identifyOnlyDeviceIDLength]
+	}
+	profile.DeviceID = trimmed
+
+	if profile.EnableB509Discovery && strings.TrimSpace(profile.ScanID) == "" {
+		return VR92Profile{}, fmt.Errorf("vr92 profile empty scan id with b509 enabled: %w", ErrInvalidConfiguration)
+	}
+
+	normalizedCommands, err := normalizeVR90MappedCommands(profile.MappedCommands)
+	if err != nil {
+		return VR92Profile{}, err
+	}
+	profile.MappedCommands = normalizedCommands
+	return profile, nil
+}

--- a/emulation/vr92_test.go
+++ b/emulation/vr92_test.go
@@ -1,0 +1,99 @@
+package emulation
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/d3vi1/helianthus-ebusgo/protocol"
+)
+
+func TestDefaultVR92Profile(t *testing.T) {
+	t.Parallel()
+
+	profile := DefaultVR92Profile()
+	if profile.Address != DefaultVR92Address ||
+		profile.Manufacturer != DefaultVR92Manufacturer ||
+		profile.DeviceID != DefaultVR92DeviceID ||
+		profile.Software != DefaultVR92Software ||
+		profile.Hardware != DefaultVR92Hardware {
+		t.Fatalf("DefaultVR92Profile() mismatch: %+v", profile)
+	}
+}
+
+func TestNewVR92Target_IdentifyResponseUsesObservedIdentity(t *testing.T) {
+	t.Parallel()
+
+	target, err := NewVR92Target(VR92Profile{})
+	if err != nil {
+		t.Fatalf("NewVR92Target() error = %v", err)
+	}
+
+	response, err := target.Emulate(RequestEvent{
+		At: 12 * time.Millisecond,
+		Frame: protocol.Frame{
+			Source:    0x10,
+			Target:    DefaultVR92Address,
+			Primary:   0x07,
+			Secondary: 0x04,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Emulate() error = %v", err)
+	}
+
+	wantData := []byte{
+		DefaultVR92Manufacturer,
+		'V', 'R', '_', '9', '2',
+		0x05, 0x14,
+		0x12, 0x04,
+	}
+	if !bytes.Equal(response.Frame.Data, wantData) {
+		t.Fatalf("Frame data = %x; want %x", response.Frame.Data, wantData)
+	}
+}
+
+func TestNewVR92Target_B509RequiresScanID(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewVR92Target(VR92Profile{
+		EnableB509Discovery: true,
+	})
+	if !errors.Is(err, ErrInvalidConfiguration) {
+		t.Fatalf("NewVR92Target() error = %v; want %v", err, ErrInvalidConfiguration)
+	}
+}
+
+func TestVR92Target_B509SelectorBehavior(t *testing.T) {
+	t.Parallel()
+
+	profile := DefaultVR92Profile()
+	profile.EnableB509Discovery = true
+	profile.ScanID = "21223400202621480082014267N7"
+
+	target, err := NewVR92Target(profile)
+	if err != nil {
+		t.Fatalf("NewVR92Target() error = %v", err)
+	}
+
+	response, err := target.Emulate(RequestEvent{
+		Frame: protocol.Frame{
+			Source:    0x10,
+			Target:    DefaultVR92Address,
+			Primary:   0xB5,
+			Secondary: 0x09,
+			Data:      []byte{0x24},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Emulate() error = %v", err)
+	}
+	wantChunk, ok := vr90B509ScanIDChunk(profile.ScanID, 0x24)
+	if !ok {
+		t.Fatalf("vr90B509ScanIDChunk() ok = false")
+	}
+	if !bytes.Equal(response.Frame.Data, wantChunk) {
+		t.Fatalf("Frame data = %x; want %x", response.Frame.Data, wantChunk)
+	}
+}


### PR DESCRIPTION
Fixes #76

## What
- add `DefaultVR92Profile` + `NewVR92Target` with observed VR92 identity (`VR_92`, SW `0x0514`, HW `0x1204`)
- add `PresetVR92IdentifyOnlyProfile` for identify-only emulation flow
- add VR92 coverage tests for identify payload defaults and optional B509 selector behavior
- document VR92 identify-only preset usage in README

## Validation
- `go test ./...`
- `go vet ./...`
- `golangci-lint run ./...`