### PR TITLE
meta01: add local CI entrypoint and agent workflow rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,12 @@
+# AGENTS
+
+These instructions apply to the entire repository.
+
+## Workflow
+
+1. Work one issue at a time and keep changes scoped to that issue.
+2. Keep at most one open PR for this repository at any time.
+3. Run `./scripts/ci_local.sh` before pushing.
+4. React (emoji) to every review comment and reply with status when actioned.
+5. If a change modifies externally visible behavior (exports, transport semantics, protocol behavior), open/update the corresponding docs in `helianthus-docs-ebus` and merge docs alongside code (doc-gate).
+

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ go build ./...
 ### 2) CI-parity checks
 
 ```bash
+./scripts/ci_local.sh
 go test -race -count=1 ./...
 ```
 

--- a/errors/errors_test.go
+++ b/errors/errors_test.go
@@ -117,4 +117,3 @@ func TestClassifiers_CoverAllSentinels(t *testing.T) {
 		})
 	}
 }
-

--- a/scripts/ci_local.sh
+++ b/scripts/ci_local.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+echo "==> terminology gate"
+if grep -RInwi --exclude-dir=.git -E 'm[a]ster|s[l]ave' .; then
+  echo "Found legacy terminology."
+  exit 1
+fi
+
+echo "==> gofmt"
+unformatted="$(git ls-files '*.go' | xargs -n 50 gofmt -l || true)"
+if [ -n "${unformatted}" ]; then
+  echo "gofmt required for:"
+  echo "${unformatted}"
+  exit 1
+fi
+
+echo "==> go vet"
+go vet ./...
+
+echo "==> go build"
+go build ./...
+
+echo "==> go test (race)"
+go test -race -count=1 ./...
+
+if command -v golangci-lint >/dev/null 2>&1; then
+  echo "==> golangci-lint"
+  golangci-lint run ./...
+else
+  echo "==> golangci-lint not found; skipping"
+fi
+
+if command -v tinygo >/dev/null 2>&1; then
+  echo "==> tinygo build (main packages)"
+  toolchain="${TINYGO_GOTOOLCHAIN:-go1.25.0}"
+  echo "Using GOTOOLCHAIN=${toolchain} for tinygo"
+  mains="$(go list -f '{{if eq .Name "main"}}{{.ImportPath}}{{end}}' ./... | sed '/^$/d')"
+  if [ -z "${mains}" ]; then
+    echo "No main packages found; skipping TinyGo build."
+    exit 0
+  fi
+  for pkg in ${mains}; do
+    echo "tinygo build -target esp32-coreboard-v2 ${pkg}"
+    GOTOOLCHAIN="${toolchain}" tinygo build -target esp32-coreboard-v2 "${pkg}"
+  done
+else
+  echo "==> tinygo not found; skipping"
+fi

--- a/types/data2b.go
+++ b/types/data2b.go
@@ -8,13 +8,13 @@ import (
 )
 
 const (
-	data2bSize        = 2
-	data2bDivisor     = 256.0
-	data2bEpsilon     = 1e-9
-	data2bReplacement = uint16(0x8000)
+	data2bSize           = 2
+	data2bDivisor        = 256.0
+	data2bEpsilon        = 1e-9
+	data2bReplacement    = uint16(0x8000)
 	data2bReplacementInt = int64(-32768)
-	data2bMinInt      = int64(-32767)
-	data2bMaxInt      = int64(32767)
+	data2bMinInt         = int64(-32767)
+	data2bMaxInt         = int64(32767)
 )
 
 var (

--- a/types/data2c.go
+++ b/types/data2c.go
@@ -8,13 +8,13 @@ import (
 )
 
 const (
-	data2cSize        = 2
-	data2cDivisor     = 16.0
-	data2cEpsilon     = 1e-9
-	data2cReplacement = uint16(0x8000)
+	data2cSize           = 2
+	data2cDivisor        = 16.0
+	data2cEpsilon        = 1e-9
+	data2cReplacement    = uint16(0x8000)
 	data2cReplacementInt = int64(-32768)
-	data2cMinInt      = int64(-32767)
-	data2cMaxInt      = int64(32767)
+	data2cMinInt         = int64(-32767)
+	data2cMaxInt         = int64(32767)
 )
 
 var (


### PR DESCRIPTION
Fixes #80.

Adds:
- `scripts/ci_local.sh` (terminology gate, gofmt check, vet/build/test/race, golangci-lint, TinyGo build using Go toolchain pin)
- `AGENTS.md` baseline workflow rules
- README quickstart update