### PR TITLE
META-05.1: harden ebusd-tcp transport noise handling and concurrency

### DIFF
--- a/transport/ebusd_tcp.go
+++ b/transport/ebusd_tcp.go
@@ -18,11 +18,11 @@ import (
 )
 
 const (
-	ebusSymbolEscape = byte(0xA9)
-	ebusSymbolSyn    = byte(0xAA)
-	ebusSymbolAck    = byte(0x00)
-	ebusBroadcast    = byte(0xFE)
-	ebusdDrainWindow = 10 * time.Millisecond
+	ebusSymbolEscape    = byte(0xA9)
+	ebusSymbolSyn       = byte(0xAA)
+	ebusSymbolAck       = byte(0x00)
+	ebusBroadcast       = byte(0xFE)
+	ebusdFollowupWindow = 150 * time.Millisecond
 )
 
 var errNoHexPayload = errors.New("ebusd: no hex payload")
@@ -36,6 +36,7 @@ type EbusdTCPTransport struct {
 
 	mu         sync.Mutex
 	cond       *sync.Cond
+	writeMu    sync.Mutex
 	closed     bool
 	pending    []byte
 	pendingErr error
@@ -93,6 +94,9 @@ func (t *EbusdTCPTransport) ReadByte() (byte, error) {
 }
 
 func (t *EbusdTCPTransport) Write(payload []byte) (int, error) {
+	t.writeMu.Lock()
+	defer t.writeMu.Unlock()
+
 	t.mu.Lock()
 
 	if t.closed {
@@ -286,15 +290,9 @@ func (t *EbusdTCPTransport) sendHexCommand(src byte, payload []byte) ([]byte, er
 	if t.conn != nil && t.readTimeout > 0 {
 		_ = t.conn.SetReadDeadline(time.Now().Add(t.readTimeout))
 	}
-	lines, err := readResponseLines(t.conn, t.reader)
+	lines, err := readResponseLines(t.conn, t.reader, t.readTimeout)
 	if err != nil {
-		if t.conn != nil {
-			_ = t.conn.SetReadDeadline(time.Time{})
-		}
 		return nil, err
-	}
-	if t.conn != nil {
-		_ = t.conn.SetReadDeadline(time.Time{})
 	}
 	resp, err := parseHexResponseLines(lines)
 	if err != nil {
@@ -303,66 +301,125 @@ func (t *EbusdTCPTransport) sendHexCommand(src byte, payload []byte) ([]byte, er
 	return stripLengthPrefix(resp), nil
 }
 
-func readResponseLines(conn net.Conn, reader *bufio.Reader) ([]string, error) {
+func readResponseLines(conn net.Conn, reader *bufio.Reader, readTimeout time.Duration) ([]string, error) {
 	var lines []string
+
+	if conn != nil && readTimeout > 0 {
+		_ = conn.SetReadDeadline(time.Now().Add(readTimeout))
+	}
+
+	followupDeadlineSet := false
+
 	for {
 		line, err := reader.ReadString('\n')
 		if err != nil && !errors.Is(err, io.EOF) {
 			if isTimeout(err) {
+				if conn != nil {
+					_ = conn.SetReadDeadline(time.Time{})
+				}
+				if len(lines) > 0 {
+					return lines, nil
+				}
 				return lines, ebuserrors.ErrTimeout
 			}
 			if isClosed(err) {
+				if conn != nil {
+					_ = conn.SetReadDeadline(time.Time{})
+				}
+				if len(lines) > 0 {
+					return lines, nil
+				}
 				return lines, ebuserrors.ErrTransportClosed
+			}
+			if conn != nil {
+				_ = conn.SetReadDeadline(time.Time{})
 			}
 			return lines, ebuserrors.ErrTransportClosed
 		}
 
-		line = strings.TrimRight(line, "\r\n")
-		if strings.TrimSpace(line) == "" {
-			if len(lines) > 0 {
-				break
-			}
+		trimmed := strings.TrimSpace(strings.TrimRight(line, "\r\n"))
+		if trimmed == "" {
 			if errors.Is(err, io.EOF) {
+				if conn != nil {
+					_ = conn.SetReadDeadline(time.Time{})
+				}
+				if len(lines) > 0 {
+					return lines, nil
+				}
 				return lines, ebuserrors.ErrTransportClosed
 			}
 			continue
 		}
-		lines = append(lines, line)
-		if errors.Is(err, io.EOF) {
-			return lines, nil
-		}
-		break
-	}
 
-	if len(lines) == 0 {
-		return lines, ebuserrors.ErrTimeout
-	}
-
-	if conn != nil {
-		_ = conn.SetReadDeadline(time.Now().Add(ebusdDrainWindow))
-	}
-	for {
-		line, err := reader.ReadString('\n')
-		if err != nil {
-			if isTimeout(err) || errors.Is(err, io.EOF) || isClosed(err) {
-				break
+		lower := strings.ToLower(trimmed)
+		if isIgnorableResponseLine(lower) {
+			if errors.Is(err, io.EOF) {
+				if conn != nil {
+					_ = conn.SetReadDeadline(time.Time{})
+				}
+				if len(lines) > 0 {
+					return lines, nil
+				}
+				return lines, ebuserrors.ErrTransportClosed
 			}
-			break
-		}
-		line = strings.TrimRight(line, "\r\n")
-		if line == "" {
-			break
-		}
-		if strings.TrimSpace(line) == "" {
 			continue
 		}
-		lines = append(lines, line)
+
+		lines = append(lines, trimmed)
+
+		if looksLikeHexResponseLine(trimmed) || strings.HasPrefix(lower, "done") {
+			break
+		}
+
+		if conn != nil && !followupDeadlineSet {
+			followup := ebusdFollowupWindow
+			if readTimeout > 0 && readTimeout < followup {
+				followup = readTimeout
+			}
+			if followup > 0 {
+				_ = conn.SetReadDeadline(time.Now().Add(followup))
+				followupDeadlineSet = true
+			}
+		}
+
+		if errors.Is(err, io.EOF) {
+			break
+		}
 	}
+
 	if conn != nil {
 		_ = conn.SetReadDeadline(time.Time{})
 	}
-
+	if len(lines) == 0 {
+		return lines, ebuserrors.ErrTimeout
+	}
 	return lines, nil
+}
+
+func isIgnorableResponseLine(lower string) bool {
+	return strings.Contains(lower, "dump enabled") ||
+		strings.Contains(lower, "dump disabled")
+}
+
+func looksLikeHexResponseLine(line string) bool {
+	trimmed := strings.TrimSpace(line)
+	if strings.HasPrefix(strings.ToLower(trimmed), "0x") {
+		trimmed = strings.TrimSpace(trimmed[2:])
+	}
+	hexText := stripHexSpaces(trimmed)
+	if hexText == "" || len(hexText)%2 != 0 {
+		return false
+	}
+	for _, r := range hexText {
+		switch {
+		case r >= '0' && r <= '9':
+		case r >= 'a' && r <= 'f':
+		case r >= 'A' && r <= 'F':
+		default:
+			return false
+		}
+	}
+	return true
 }
 
 func parseHexResponseLines(lines []string) ([]byte, error) {

--- a/transport/ebusd_tcp_test.go
+++ b/transport/ebusd_tcp_test.go
@@ -629,3 +629,140 @@ func TestEbusdTCPTransport_Write_AllowsEchoDrainWhileWaitingForEbusd(t *testing.
 		t.Fatalf("server did not complete within timeout")
 	}
 }
+
+func TestEbusdTCPTransport_SendHexCommand_HandlesNoiseBeforeHex(t *testing.T) {
+	t.Parallel()
+
+	client, server := net.Pipe()
+	defer func() { _ = client.Close() }()
+	defer func() { _ = server.Close() }()
+
+	tr := NewEbusdTCPTransport(client, 500*time.Millisecond, 0)
+	wantCommand := "hex -s 31 feb5240100\n"
+
+	serverErr := make(chan error, 1)
+	go func() {
+		reader := bufio.NewReader(server)
+		line, err := reader.ReadString('\n')
+		if err != nil {
+			serverErr <- err
+			return
+		}
+		if line != wantCommand {
+			serverErr <- fmt.Errorf("command = %q; want %q", line, wantCommand)
+			return
+		}
+
+		if _, err := server.Write([]byte("\n")); err != nil {
+			serverErr <- err
+			return
+		}
+		if _, err := server.Write([]byte("dump enabled\n")); err != nil {
+			serverErr <- err
+			return
+		}
+		if _, err := server.Write([]byte("ERR: invalid numeric argument\n")); err != nil {
+			serverErr <- err
+			return
+		}
+		time.Sleep(40 * time.Millisecond)
+		if _, err := server.Write([]byte("0400004040\n\n")); err != nil {
+			serverErr <- err
+			return
+		}
+		serverErr <- nil
+	}()
+
+	got, err := tr.sendHexCommand(0x31, []byte{0xFE, 0xB5, 0x24, 0x01, 0x00})
+	if err != nil {
+		t.Fatalf("sendHexCommand error = %v", err)
+	}
+	want := []byte{0x00, 0x00, 0x40, 0x40}
+	if !bytes.Equal(got, want) {
+		t.Fatalf("sendHexCommand = %x; want %x", got, want)
+	}
+	if err := <-serverErr; err != nil {
+		t.Fatalf("server error = %v", err)
+	}
+}
+
+func TestEbusdTCPTransport_Write_SerializesConcurrentHexCommands(t *testing.T) {
+	t.Parallel()
+
+	client, server := net.Pipe()
+	defer func() { _ = client.Close() }()
+	defer func() { _ = server.Close() }()
+
+	tr := NewEbusdTCPTransport(client, 500*time.Millisecond, 0)
+
+	telegramA := []byte{0x31, 0xFE, 0x07, 0xFE, 0x00}
+	telegramA = append(telegramA, crcValue(telegramA))
+	commandA := "hex -s 31 fe07fe00\n"
+
+	telegramB := []byte{0x10, 0xFE, 0xB5, 0x16, 0x01, 0x01}
+	telegramB = append(telegramB, crcValue(telegramB))
+	commandB := "hex -s 10 feb5160101\n"
+
+	serverErr := make(chan error, 1)
+	go func() {
+		reader := bufio.NewReader(server)
+		first, err := reader.ReadString('\n')
+		if err != nil {
+			serverErr <- err
+			return
+		}
+
+		_ = server.SetReadDeadline(time.Now().Add(60 * time.Millisecond))
+		secondEarly, err := reader.ReadString('\n')
+		if err == nil {
+			serverErr <- fmt.Errorf("second command arrived before first response: %q", secondEarly)
+			return
+		}
+		if !isTimeout(err) {
+			serverErr <- fmt.Errorf("unexpected pre-response read error: %v", err)
+			return
+		}
+		_ = server.SetReadDeadline(time.Time{})
+
+		if _, err := server.Write([]byte("done broadcast\n\n")); err != nil {
+			serverErr <- err
+			return
+		}
+
+		second, err := reader.ReadString('\n')
+		if err != nil {
+			serverErr <- err
+			return
+		}
+		if _, err := server.Write([]byte("done broadcast\n\n")); err != nil {
+			serverErr <- err
+			return
+		}
+
+		if (first != commandA || second != commandB) && (first != commandB || second != commandA) {
+			serverErr <- fmt.Errorf("commands = [%q, %q]; want permutations of [%q, %q]", first, second, commandA, commandB)
+			return
+		}
+
+		serverErr <- nil
+	}()
+
+	writeErr := make(chan error, 2)
+	go func() {
+		_, err := tr.Write(telegramA)
+		writeErr <- err
+	}()
+	go func() {
+		_, err := tr.Write(telegramB)
+		writeErr <- err
+	}()
+
+	for index := 0; index < 2; index++ {
+		if err := <-writeErr; err != nil {
+			t.Fatalf("Write #%d error = %v", index+1, err)
+		}
+	}
+	if err := <-serverErr; err != nil {
+		t.Fatalf("server error = %v", err)
+	}
+}


### PR DESCRIPTION
Closes #83

## Summary
- serialize `Write` calls to prevent command interleaving on shared ebusd-tcp sockets
- harden response reader against noisy lines (`dump enabled/disabled`, blank separators, mixed `ERR:` + delayed hex)
- preserve deterministic request/response correlation with a bounded follow-up read window
- add regression tests for noisy response streams and concurrent command serialization

## Validation
- `./scripts/ci_local.sh` (pass)
