### PR TITLE
transport: drain ebusd follow-up lines after first hex/done

### DIFF
--- a/transport/ebusd_tcp.go
+++ b/transport/ebusd_tcp.go
@@ -309,6 +309,19 @@ func readResponseLines(conn net.Conn, reader *bufio.Reader, readTimeout time.Dur
 	}
 
 	followupDeadlineSet := false
+	setFollowupDeadline := func() {
+		if conn == nil || followupDeadlineSet {
+			return
+		}
+		followup := ebusdFollowupWindow
+		if readTimeout > 0 && readTimeout < followup {
+			followup = readTimeout
+		}
+		if followup > 0 {
+			_ = conn.SetReadDeadline(time.Now().Add(followup))
+			followupDeadlineSet = true
+		}
+	}
 
 	for {
 		line, err := reader.ReadString('\n')
@@ -368,19 +381,14 @@ func readResponseLines(conn net.Conn, reader *bufio.Reader, readTimeout time.Dur
 		lines = append(lines, trimmed)
 
 		if looksLikeHexResponseLine(trimmed) || strings.HasPrefix(lower, "done") {
-			break
+			setFollowupDeadline()
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			continue
 		}
 
-		if conn != nil && !followupDeadlineSet {
-			followup := ebusdFollowupWindow
-			if readTimeout > 0 && readTimeout < followup {
-				followup = readTimeout
-			}
-			if followup > 0 {
-				_ = conn.SetReadDeadline(time.Now().Add(followup))
-				followupDeadlineSet = true
-			}
-		}
+		setFollowupDeadline()
 
 		if errors.Is(err, io.EOF) {
 			break

--- a/transport/ebusd_tcp_test.go
+++ b/transport/ebusd_tcp_test.go
@@ -686,6 +686,75 @@ func TestEbusdTCPTransport_SendHexCommand_HandlesNoiseBeforeHex(t *testing.T) {
 	}
 }
 
+func TestEbusdTCPTransport_SendHexCommand_DrainsTrailingLinesBeforeNextCommand(t *testing.T) {
+	t.Parallel()
+
+	client, server := net.Pipe()
+	defer func() { _ = client.Close() }()
+	defer func() { _ = server.Close() }()
+
+	tr := NewEbusdTCPTransport(client, 500*time.Millisecond, 0)
+
+	serverErr := make(chan error, 1)
+	go func() {
+		reader := bufio.NewReader(server)
+
+		first, err := reader.ReadString('\n')
+		if err != nil {
+			serverErr <- err
+			return
+		}
+		if first != "hex -s 31 15070400\n" {
+			serverErr <- fmt.Errorf("first command = %q; want %q", first, "hex -s 31 15070400\n")
+			return
+		}
+		if _, err := server.Write([]byte("01aa\n")); err != nil {
+			serverErr <- err
+			return
+		}
+		if _, err := server.Write([]byte("ERR: invalid numeric argument\n\n")); err != nil {
+			serverErr <- err
+			return
+		}
+
+		second, err := reader.ReadString('\n')
+		if err != nil {
+			serverErr <- err
+			return
+		}
+		if second != "hex -s 31 15070401\n" {
+			serverErr <- fmt.Errorf("second command = %q; want %q", second, "hex -s 31 15070401\n")
+			return
+		}
+		if _, err := server.Write([]byte("01bb\n\n")); err != nil {
+			serverErr <- err
+			return
+		}
+
+		serverErr <- nil
+	}()
+
+	gotFirst, err := tr.sendHexCommand(0x31, []byte{0x15, 0x07, 0x04, 0x00})
+	if err != nil {
+		t.Fatalf("first sendHexCommand error = %v", err)
+	}
+	if !bytes.Equal(gotFirst, []byte{0xAA}) {
+		t.Fatalf("first sendHexCommand = %x; want aa", gotFirst)
+	}
+
+	gotSecond, err := tr.sendHexCommand(0x31, []byte{0x15, 0x07, 0x04, 0x01})
+	if err != nil {
+		t.Fatalf("second sendHexCommand error = %v", err)
+	}
+	if !bytes.Equal(gotSecond, []byte{0xBB}) {
+		t.Fatalf("second sendHexCommand = %x; want bb", gotSecond)
+	}
+
+	if err := <-serverErr; err != nil {
+		t.Fatalf("server error = %v", err)
+	}
+}
+
 func TestEbusdTCPTransport_Write_SerializesConcurrentHexCommands(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- keep reading for a short follow-up window after first hex/done line instead of breaking immediately
- drain trailing non-empty lines so they cannot leak into the next request/response cycle
- add a regression test for two back-to-back commands where the first response includes trailing `ERR:` after hex

## Validation
- `go test ./transport -run 'EbusdTCPTransport_SendHexCommand_(HandlesNoiseBeforeHex|DrainsTrailingLinesBeforeNextCommand)'`
- `./scripts/ci_local.sh`
