### PR TITLE
protocol: add initiator joiner library (META-06.1)

### DIFF
--- a/protocol/join.go
+++ b/protocol/join.go
@@ -130,6 +130,9 @@ func (j *Joiner) Join(ctx context.Context) (JoinResult, error) {
 	if j == nil || j.bus == nil {
 		return JoinResult{}, fmt.Errorf("ebus: joiner bus is nil")
 	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	cfg := normalizeJoinConfig(j.cfg)
 
 	observation := newJoinObservation()
@@ -148,6 +151,10 @@ func (j *Joiner) Join(ctx context.Context) (JoinResult, error) {
 			}
 			after := len(observation.observedInitiators)
 			j.markInquiryResult(cfg, after > before)
+		} else if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return JoinResult{}, err
+		} else if ctx.Err() != nil {
+			return JoinResult{}, ctx.Err()
 		}
 	}
 

--- a/protocol/join_test.go
+++ b/protocol/join_test.go
@@ -48,6 +48,10 @@ type memoryJoinStateStore struct {
 	saves     []byte
 }
 
+func nilContext() context.Context {
+	return nil
+}
+
 func (s *memoryJoinStateStore) LoadInitiator(context.Context) (byte, error) {
 	return s.loadValue, s.loadErr
 }
@@ -233,5 +237,39 @@ func TestJoiner_PersistedInitiatorFallsBackWhenOccupied(t *testing.T) {
 	}
 	if result.Initiator != 0xFF {
 		t.Fatalf("Initiator = 0x%02x; want 0xff", result.Initiator)
+	}
+}
+
+func TestJoiner_NilContextDefaultsToBackground(t *testing.T) {
+	t.Parallel()
+
+	joiner := NewJoiner(&scriptedJoinBus{}, nil, JoinConfig{
+		ListenWarmup:  2 * time.Millisecond,
+		PreferHighest: true,
+	})
+
+	result, err := joiner.Join(nilContext())
+	if err != nil {
+		t.Fatalf("Join error = %v", err)
+	}
+	if result.Initiator != 0xFF {
+		t.Fatalf("Initiator = 0x%02x; want 0xff", result.Initiator)
+	}
+}
+
+func TestJoiner_PropagatesInquiryCancellation(t *testing.T) {
+	t.Parallel()
+
+	bus := &scriptedJoinBus{inquiryErr: context.Canceled}
+	joiner := NewJoiner(bus, nil, JoinConfig{
+		ListenWarmup:       2 * time.Millisecond,
+		PreferHighest:      true,
+		InquiryEnabled:     true,
+		InquiryMaxAttempts: 1,
+	})
+
+	_, err := joiner.Join(context.Background())
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Join error = %v; want context.Canceled", err)
 	}
 }


### PR DESCRIPTION
## Summary
- add `protocol.Joiner` with passive listen warmup and optional bounded inquiry
- implement initiator address selection with companion-target occupancy heuristics and rich metrics
- add best-effort persisted last-good initiator support and explicit `ErrNoFreeInitiatorAddress`
- include deterministic unit tests for no-traffic selection, occupied address filtering, heuristic rejection, fully-occupied bus, and persistence fallback

## Notes
- repository terminology guard requires `initiator/target` naming; this PR maps the same behavior with inclusive naming

## Validation
- `go test ./protocol -run 'Joiner|NoFreeInitiatorAddress'`
- `./scripts/ci_local.sh`

Closes #84
