### PR TITLE
protocol: add collision monitor library (META-06.2)

### DIFF
--- a/protocol/collision_monitor.go
+++ b/protocol/collision_monitor.go
@@ -168,8 +168,7 @@ func (m *CollisionMonitor) LastEvent() *EventCollisionDetected {
 	if m.lastEvent == nil {
 		return nil
 	}
-	event := *m.lastEvent
-	return &event
+	return cloneCollisionEvent(m.lastEvent)
 }
 
 func (m *CollisionMonitor) activateCollision(now time.Time, frame Frame, reason CollisionReason) *EventCollisionDetected {
@@ -181,7 +180,7 @@ func (m *CollisionMonitor) activateCollision(now time.Time, frame Frame, reason 
 		Reason:    reason,
 	}
 	m.lastEvent = event
-	return event
+	return cloneCollisionEvent(event)
 }
 
 func (m *CollisionMonitor) matchesRecentTX(frame Frame, now time.Time) bool {
@@ -223,6 +222,15 @@ func cloneFrame(frame Frame) Frame {
 	cloned := frame
 	cloned.Data = append([]byte(nil), frame.Data...)
 	return cloned
+}
+
+func cloneCollisionEvent(event *EventCollisionDetected) *EventCollisionDetected {
+	if event == nil {
+		return nil
+	}
+	cloned := *event
+	cloned.Frame = cloneFrame(event.Frame)
+	return &cloned
 }
 
 func framesEqual(left, right Frame) bool {

--- a/protocol/collision_monitor_test.go
+++ b/protocol/collision_monitor_test.go
@@ -185,3 +185,63 @@ func TestCollisionMonitor_IsErrArbitrationFailed(t *testing.T) {
 		t.Fatalf("IsErrArbitrationFailed(ErrArbitrationFailed) = false; want true")
 	}
 }
+
+func TestCollisionMonitor_ObserveRXReturnsDefensiveEventCopy(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 2, 19, 17, 0, 0, 0, time.UTC)
+	monitor := NewCollisionMonitor(CollisionMonitorConfig{})
+	monitor.now = func() time.Time { return now }
+	monitor.SetInitiator(0x31)
+
+	event := monitor.ObserveRX(Frame{
+		Source:    0x31,
+		Target:    0x15,
+		Primary:   0xB5,
+		Secondary: 0x24,
+		Data:      []byte{0x01, 0x02},
+	})
+	if event == nil {
+		t.Fatalf("ObserveRX returned nil event; want collision")
+	}
+
+	event.Frame.Data[0] = 0xAA
+	stored := monitor.LastEvent()
+	if stored == nil {
+		t.Fatalf("LastEvent returned nil; want event")
+	}
+	if stored.Frame.Data[0] == 0xAA {
+		t.Fatalf("LastEvent data mutated via ObserveRX return value")
+	}
+}
+
+func TestCollisionMonitor_LastEventReturnsDefensiveFrameCopy(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 2, 19, 17, 0, 0, 0, time.UTC)
+	monitor := NewCollisionMonitor(CollisionMonitorConfig{})
+	monitor.now = func() time.Time { return now }
+	monitor.SetInitiator(0x31)
+
+	_ = monitor.ObserveRX(Frame{
+		Source:    0x31,
+		Target:    0x15,
+		Primary:   0xB5,
+		Secondary: 0x24,
+		Data:      []byte{0x03, 0x04},
+	})
+
+	first := monitor.LastEvent()
+	if first == nil {
+		t.Fatalf("LastEvent returned nil; want event")
+	}
+	first.Frame.Data[0] = 0xBB
+
+	second := monitor.LastEvent()
+	if second == nil {
+		t.Fatalf("LastEvent returned nil on second read; want event")
+	}
+	if second.Frame.Data[0] == 0xBB {
+		t.Fatalf("LastEvent data mutated via caller-owned snapshot")
+	}
+}


### PR DESCRIPTION
## Summary
- add `protocol.CollisionMonitor` to detect foreign same-source frames for the active initiator
- keep bounded TX history with echo-window matching to distinguish own echo from foreign traffic
- add fail-fast transmit guard via `ErrArbitrationFailed` (wrapping `ErrBusCollision`)
- implement muted-mode detection and rejoin grace handling for previous initiator address
- include deterministic unit tests for collision detection, echo pass-through, muted behavior, fail-fast transmit, and grace behavior

## Validation
- `go test ./protocol -run 'CollisionMonitor|ErrArbitrationFailed'`
- `./scripts/ci_local.sh`

Closes #85
