### PR TITLE
MCP-10-202: idempotency/retry support primitives

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 - eBUS transports (`transport/`) including ENH, ENS, ebusd-tcp, and loopback test transport.
 - Wire/protocol primitives (`protocol/`) including framing, CRC handling, and bus transaction behavior.
-- Reusable type codecs (`types/`) and error taxonomy/normalization primitives (`errors/`).
+- Reusable type codecs (`types/`), error taxonomy/normalization primitives (`errors/`), and deterministic invoke helpers (`determinism/`).
 - Deterministic target emulation helpers and smoke tests (`emulation/`, `scripts/`).
 
 ### What does not belong in this repo

--- a/determinism/idempotency.go
+++ b/determinism/idempotency.go
@@ -1,0 +1,129 @@
+package determinism
+
+import (
+	"errors"
+	"strings"
+	"sync"
+	"time"
+)
+
+var (
+	ErrIdempotencyConflict = errors.New("determinism: idempotency key reused with different fingerprint")
+	ErrInvalidKey          = errors.New("determinism: idempotency key must not be empty")
+	ErrInvalidFingerprint  = errors.New("determinism: idempotency fingerprint must not be empty")
+)
+
+const DefaultIdempotencyTTL = 30 * time.Second
+
+type idempotencyEntry struct {
+	fingerprint string
+	value       []byte
+	expiresAt   time.Time
+}
+
+// IdempotencyStore keeps mutate results keyed by idempotency key and payload fingerprint.
+// The store is concurrency-safe and evicts expired entries lazily on access.
+type IdempotencyStore struct {
+	mu      sync.Mutex
+	ttl     time.Duration
+	now     func() time.Time
+	entries map[string]idempotencyEntry
+}
+
+func NewIdempotencyStore(ttl time.Duration) *IdempotencyStore {
+	if ttl <= 0 {
+		ttl = DefaultIdempotencyTTL
+	}
+	return &IdempotencyStore{
+		ttl:     ttl,
+		now:     time.Now,
+		entries: make(map[string]idempotencyEntry),
+	}
+}
+
+func (s *IdempotencyStore) Lookup(key string, fingerprint string) ([]byte, bool, error) {
+	key, fingerprint, err := normalizeLookupInputs(key, fingerprint)
+	if err != nil {
+		return nil, false, err
+	}
+
+	now := s.now()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.purgeExpiredLocked(now)
+
+	entry, ok := s.entries[key]
+	if !ok {
+		return nil, false, nil
+	}
+	if entry.fingerprint != fingerprint {
+		return nil, false, ErrIdempotencyConflict
+	}
+	return cloneBytes(entry.value), true, nil
+}
+
+func (s *IdempotencyStore) Store(key string, fingerprint string, value []byte) error {
+	key, fingerprint, err := normalizeLookupInputs(key, fingerprint)
+	if err != nil {
+		return err
+	}
+
+	now := s.now()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.purgeExpiredLocked(now)
+
+	s.entries[key] = idempotencyEntry{
+		fingerprint: fingerprint,
+		value:       cloneBytes(value),
+		expiresAt:   now.Add(s.ttl),
+	}
+	return nil
+}
+
+func (s *IdempotencyStore) Delete(key string) {
+	trimmed := strings.TrimSpace(key)
+	if trimmed == "" {
+		return
+	}
+	s.mu.Lock()
+	delete(s.entries, trimmed)
+	s.mu.Unlock()
+}
+
+func (s *IdempotencyStore) Len() int {
+	now := s.now()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.purgeExpiredLocked(now)
+	return len(s.entries)
+}
+
+func (s *IdempotencyStore) purgeExpiredLocked(now time.Time) {
+	for key, entry := range s.entries {
+		if now.After(entry.expiresAt) {
+			delete(s.entries, key)
+		}
+	}
+}
+
+func normalizeLookupInputs(key string, fingerprint string) (string, string, error) {
+	normalizedKey := strings.TrimSpace(key)
+	if normalizedKey == "" {
+		return "", "", ErrInvalidKey
+	}
+	normalizedFingerprint := strings.TrimSpace(fingerprint)
+	if normalizedFingerprint == "" {
+		return "", "", ErrInvalidFingerprint
+	}
+	return normalizedKey, normalizedFingerprint, nil
+}
+
+func cloneBytes(in []byte) []byte {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]byte, len(in))
+	copy(out, in)
+	return out
+}

--- a/determinism/idempotency_test.go
+++ b/determinism/idempotency_test.go
@@ -1,0 +1,119 @@
+package determinism
+
+import (
+	"errors"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestIdempotencyStore_LookupStoreAndConflict(t *testing.T) {
+	t.Parallel()
+
+	store := NewIdempotencyStore(time.Minute)
+	if err := store.Store("req-1", "sig-1", []byte(`{"ok":true}`)); err != nil {
+		t.Fatalf("Store error = %v", err)
+	}
+
+	got, ok, err := store.Lookup("req-1", "sig-1")
+	if err != nil {
+		t.Fatalf("Lookup error = %v", err)
+	}
+	if !ok {
+		t.Fatalf("Lookup ok = false; want true")
+	}
+	if string(got) != `{"ok":true}` {
+		t.Fatalf("Lookup value = %q; want payload", got)
+	}
+
+	got[0] = '{'
+	again, ok, err := store.Lookup("req-1", "sig-1")
+	if err != nil || !ok {
+		t.Fatalf("Lookup(second) = (%v, %v); want hit,nil", ok, err)
+	}
+	if string(again) != `{"ok":true}` {
+		t.Fatalf("Lookup(second) value = %q; want immutable copy", again)
+	}
+
+	_, _, err = store.Lookup("req-1", "sig-other")
+	if !errors.Is(err, ErrIdempotencyConflict) {
+		t.Fatalf("Lookup(conflict) error = %v; want ErrIdempotencyConflict", err)
+	}
+}
+
+func TestIdempotencyStore_Validation(t *testing.T) {
+	t.Parallel()
+
+	store := NewIdempotencyStore(time.Minute)
+	if err := store.Store("  ", "sig", []byte("x")); !errors.Is(err, ErrInvalidKey) {
+		t.Fatalf("Store(empty key) error = %v; want ErrInvalidKey", err)
+	}
+	if err := store.Store("k", "  ", []byte("x")); !errors.Is(err, ErrInvalidFingerprint) {
+		t.Fatalf("Store(empty fingerprint) error = %v; want ErrInvalidFingerprint", err)
+	}
+
+	if _, _, err := store.Lookup("", "sig"); !errors.Is(err, ErrInvalidKey) {
+		t.Fatalf("Lookup(empty key) error = %v; want ErrInvalidKey", err)
+	}
+	if _, _, err := store.Lookup("k", ""); !errors.Is(err, ErrInvalidFingerprint) {
+		t.Fatalf("Lookup(empty fingerprint) error = %v; want ErrInvalidFingerprint", err)
+	}
+}
+
+func TestIdempotencyStore_ExpiryAndLen(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 2, 23, 22, 0, 0, 0, time.UTC)
+	store := NewIdempotencyStore(10 * time.Second)
+	store.now = func() time.Time { return now }
+
+	if err := store.Store("req-1", "sig-1", []byte("a")); err != nil {
+		t.Fatalf("Store(req-1) error = %v", err)
+	}
+	if err := store.Store("req-2", "sig-2", []byte("b")); err != nil {
+		t.Fatalf("Store(req-2) error = %v", err)
+	}
+	if got := store.Len(); got != 2 {
+		t.Fatalf("Len(before expiry) = %d; want 2", got)
+	}
+
+	now = now.Add(11 * time.Second)
+	if got := store.Len(); got != 0 {
+		t.Fatalf("Len(after expiry) = %d; want 0", got)
+	}
+
+	if _, ok, err := store.Lookup("req-1", "sig-1"); err != nil || ok {
+		t.Fatalf("Lookup(expired) = (%v, %v); want false,nil", ok, err)
+	}
+}
+
+func TestIdempotencyStore_ConcurrentAccess(t *testing.T) {
+	t.Parallel()
+
+	store := NewIdempotencyStore(time.Minute)
+
+	const workers = 16
+	const iterations = 40
+	var wg sync.WaitGroup
+	wg.Add(workers)
+
+	for worker := 0; worker < workers; worker++ {
+		worker := worker
+		go func() {
+			defer wg.Done()
+			for i := 0; i < iterations; i++ {
+				key := "k-" + string(rune('a'+worker%4))
+				if err := store.Store(key, "sig", []byte("ok")); err != nil {
+					t.Errorf("Store error = %v", err)
+					return
+				}
+				if _, _, err := store.Lookup(key, "sig"); err != nil {
+					t.Errorf("Lookup error = %v", err)
+					return
+				}
+			}
+		}()
+	}
+
+	wg.Wait()
+}

--- a/determinism/retry.go
+++ b/determinism/retry.go
@@ -1,0 +1,105 @@
+package determinism
+
+import (
+	"errors"
+	"time"
+
+	ebuserrors "github.com/d3vi1/helianthus-ebusgo/errors"
+)
+
+var (
+	ErrInvalidRetryCount  = errors.New("determinism: retry count must be >= 0")
+	ErrInvalidRetryDelay  = errors.New("determinism: retry delay must be >= 0")
+	ErrInvalidRetryFactor = errors.New("determinism: retry factor must be >= 1")
+)
+
+// RetrySchedule is an immutable, deterministic retry-delay sequence.
+type RetrySchedule struct {
+	delays []time.Duration
+}
+
+func NewRetrySchedule(delays []time.Duration) (RetrySchedule, error) {
+	out := make([]time.Duration, len(delays))
+	for index, delay := range delays {
+		if delay < 0 {
+			return RetrySchedule{}, ErrInvalidRetryDelay
+		}
+		out[index] = delay
+	}
+	return RetrySchedule{delays: out}, nil
+}
+
+func FixedRetrySchedule(retries int, delay time.Duration) (RetrySchedule, error) {
+	if retries < 0 {
+		return RetrySchedule{}, ErrInvalidRetryCount
+	}
+	if delay < 0 {
+		return RetrySchedule{}, ErrInvalidRetryDelay
+	}
+	delays := make([]time.Duration, retries)
+	for index := range delays {
+		delays[index] = delay
+	}
+	return RetrySchedule{delays: delays}, nil
+}
+
+func ExponentialRetrySchedule(retries int, baseDelay time.Duration, factor int, maxDelay time.Duration) (RetrySchedule, error) {
+	if retries < 0 {
+		return RetrySchedule{}, ErrInvalidRetryCount
+	}
+	if baseDelay < 0 || maxDelay < 0 {
+		return RetrySchedule{}, ErrInvalidRetryDelay
+	}
+	if factor < 1 {
+		return RetrySchedule{}, ErrInvalidRetryFactor
+	}
+
+	delays := make([]time.Duration, retries)
+	current := baseDelay
+	for index := 0; index < retries; index++ {
+		if maxDelay > 0 && current > maxDelay {
+			delays[index] = maxDelay
+		} else {
+			delays[index] = current
+		}
+
+		if factor == 1 {
+			continue
+		}
+		if current > 0 && current > time.Duration((1<<63-1)/factor) {
+			current = time.Duration(1<<63 - 1)
+			continue
+		}
+		current *= time.Duration(factor)
+	}
+
+	return RetrySchedule{delays: delays}, nil
+}
+
+func (schedule RetrySchedule) Retries() int {
+	return len(schedule.delays)
+}
+
+func (schedule RetrySchedule) Delays() []time.Duration {
+	out := make([]time.Duration, len(schedule.delays))
+	copy(out, schedule.delays)
+	return out
+}
+
+// Delay returns the delay for the zero-based retry index.
+// retryIndex 0 is the delay before the second attempt.
+func (schedule RetrySchedule) Delay(retryIndex int) (time.Duration, bool) {
+	if retryIndex < 0 || retryIndex >= len(schedule.delays) {
+		return 0, false
+	}
+	return schedule.delays[retryIndex], true
+}
+
+// NextRetry returns whether an error is retriable and, if it is, which delay
+// should be applied before the next attempt.
+func (schedule RetrySchedule) NextRetry(err error, retryIndex int) (time.Duration, bool) {
+	if !ebuserrors.NormalizeErrorMapping(err, "").Retriable {
+		return 0, false
+	}
+	return schedule.Delay(retryIndex)
+}

--- a/determinism/retry_test.go
+++ b/determinism/retry_test.go
@@ -1,0 +1,103 @@
+package determinism
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+
+	ebuserrors "github.com/d3vi1/helianthus-ebusgo/errors"
+)
+
+func TestNewRetrySchedule(t *testing.T) {
+	t.Parallel()
+
+	schedule, err := NewRetrySchedule([]time.Duration{0, 25 * time.Millisecond, time.Second})
+	if err != nil {
+		t.Fatalf("NewRetrySchedule error = %v", err)
+	}
+	if got := schedule.Retries(); got != 3 {
+		t.Fatalf("Retries = %d; want 3", got)
+	}
+	if got := schedule.Delays(); !reflect.DeepEqual(got, []time.Duration{0, 25 * time.Millisecond, time.Second}) {
+		t.Fatalf("Delays = %v; want exact sequence", got)
+	}
+
+	gotCopy := schedule.Delays()
+	gotCopy[0] = time.Hour
+	if got := schedule.Delays()[0]; got != 0 {
+		t.Fatalf("Delays copy mutated original; got %s", got)
+	}
+
+	if _, err := NewRetrySchedule([]time.Duration{-1}); !errors.Is(err, ErrInvalidRetryDelay) {
+		t.Fatalf("NewRetrySchedule(negative) error = %v; want ErrInvalidRetryDelay", err)
+	}
+}
+
+func TestFixedRetrySchedule(t *testing.T) {
+	t.Parallel()
+
+	schedule, err := FixedRetrySchedule(3, 200*time.Millisecond)
+	if err != nil {
+		t.Fatalf("FixedRetrySchedule error = %v", err)
+	}
+	if got := schedule.Delays(); !reflect.DeepEqual(got, []time.Duration{200 * time.Millisecond, 200 * time.Millisecond, 200 * time.Millisecond}) {
+		t.Fatalf("Delays = %v; want fixed sequence", got)
+	}
+
+	if _, err := FixedRetrySchedule(-1, time.Second); !errors.Is(err, ErrInvalidRetryCount) {
+		t.Fatalf("FixedRetrySchedule(negative retries) error = %v; want ErrInvalidRetryCount", err)
+	}
+	if _, err := FixedRetrySchedule(1, -time.Second); !errors.Is(err, ErrInvalidRetryDelay) {
+		t.Fatalf("FixedRetrySchedule(negative delay) error = %v; want ErrInvalidRetryDelay", err)
+	}
+}
+
+func TestExponentialRetrySchedule(t *testing.T) {
+	t.Parallel()
+
+	schedule, err := ExponentialRetrySchedule(4, 100*time.Millisecond, 2, 350*time.Millisecond)
+	if err != nil {
+		t.Fatalf("ExponentialRetrySchedule error = %v", err)
+	}
+	want := []time.Duration{100 * time.Millisecond, 200 * time.Millisecond, 350 * time.Millisecond, 350 * time.Millisecond}
+	if got := schedule.Delays(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("Delays = %v; want %v", got, want)
+	}
+
+	if _, err := ExponentialRetrySchedule(-1, time.Millisecond, 2, 0); !errors.Is(err, ErrInvalidRetryCount) {
+		t.Fatalf("ExponentialRetrySchedule(negative retries) error = %v; want ErrInvalidRetryCount", err)
+	}
+	if _, err := ExponentialRetrySchedule(1, -time.Millisecond, 2, 0); !errors.Is(err, ErrInvalidRetryDelay) {
+		t.Fatalf("ExponentialRetrySchedule(negative delay) error = %v; want ErrInvalidRetryDelay", err)
+	}
+	if _, err := ExponentialRetrySchedule(1, time.Millisecond, 0, 0); !errors.Is(err, ErrInvalidRetryFactor) {
+		t.Fatalf("ExponentialRetrySchedule(invalid factor) error = %v; want ErrInvalidRetryFactor", err)
+	}
+}
+
+func TestRetrySchedule_DelayAndNextRetry(t *testing.T) {
+	t.Parallel()
+
+	schedule, err := NewRetrySchedule([]time.Duration{10 * time.Millisecond, 20 * time.Millisecond})
+	if err != nil {
+		t.Fatalf("NewRetrySchedule error = %v", err)
+	}
+
+	if delay, ok := schedule.Delay(-1); ok || delay != 0 {
+		t.Fatalf("Delay(-1) = (%s, %v); want (0,false)", delay, ok)
+	}
+	if delay, ok := schedule.Delay(2); ok || delay != 0 {
+		t.Fatalf("Delay(out-of-range) = (%s, %v); want (0,false)", delay, ok)
+	}
+
+	if delay, ok := schedule.NextRetry(ebuserrors.ErrTimeout, 0); !ok || delay != 10*time.Millisecond {
+		t.Fatalf("NextRetry(timeout,0) = (%s,%v); want (10ms,true)", delay, ok)
+	}
+	if delay, ok := schedule.NextRetry(ebuserrors.ErrTimeout, 3); ok || delay != 0 {
+		t.Fatalf("NextRetry(timeout,exhausted) = (%s,%v); want (0,false)", delay, ok)
+	}
+	if delay, ok := schedule.NextRetry(ebuserrors.ErrNoSuchDevice, 0); ok || delay != 0 {
+		t.Fatalf("NextRetry(definitive,0) = (%s,%v); want (0,false)", delay, ok)
+	}
+}


### PR DESCRIPTION
## Summary
- add new `determinism` package with idempotency cache primitives (TTL, conflict detection, immutable payload copies)
- add deterministic retry schedule primitives (fixed/custom/exponential + retriable decision helper)
- cover behavior with focused unit tests and update README scope line

## Validation
- `GOWORK=off go test ./... -count=1`
- `GOWORK=off ./scripts/ci_local.sh`

Fixes #93