### PR TITLE
fix(protocol): remove phantom header reads from slave response

### DIFF
--- a/protocol/bus.go
+++ b/protocol/bus.go
@@ -404,44 +404,10 @@ func (b *Bus) sendTransaction(runCtx, reqCtx context.Context, frame Frame) (*Fra
 		return nil, fmt.Errorf("bus send unknown frame type: %w", ebuserrors.ErrInvalidPayload)
 	}
 
+	// eBUS slave response: NN DB1..DBn CRC (no header — QQ/ZZ/PB/SB are
+	// inferred from the initiator telegram).
 	var data []byte
 	for respAttempt := 0; respAttempt < 2; respAttempt++ {
-		respSource, err := decoder.readSymbol(b, runCtx, reqCtx)
-		if err != nil {
-			return nil, err
-		}
-		if respSource == SymbolSyn {
-			return nil, fmt.Errorf("syn while waiting for response: %w", ebuserrors.ErrTimeout)
-		}
-
-		respTarget, err := decoder.readSymbol(b, runCtx, reqCtx)
-		if err != nil {
-			return nil, err
-		}
-		if respTarget == SymbolSyn {
-			return nil, fmt.Errorf("syn while waiting for response dst: %w", ebuserrors.ErrTimeout)
-		}
-
-		respPrimary, err := decoder.readSymbol(b, runCtx, reqCtx)
-		if err != nil {
-			return nil, err
-		}
-		if respPrimary == SymbolSyn {
-			return nil, fmt.Errorf("syn while waiting for response pb: %w", ebuserrors.ErrTimeout)
-		}
-
-		respSecondary, err := decoder.readSymbol(b, runCtx, reqCtx)
-		if err != nil {
-			return nil, err
-		}
-		if respSecondary == SymbolSyn {
-			return nil, fmt.Errorf("syn while waiting for response sb: %w", ebuserrors.ErrTimeout)
-		}
-
-		if respSource != frame.Target || respTarget != frame.Source || respPrimary != frame.Primary || respSecondary != frame.Secondary {
-			return nil, fmt.Errorf("unexpected response header (src 0x%02x dst 0x%02x pb 0x%02x sb 0x%02x): %w", respSource, respTarget, respPrimary, respSecondary, ebuserrors.ErrBusCollision)
-		}
-
 		lengthSym, err := decoder.readSymbol(b, runCtx, reqCtx)
 		if err != nil {
 			return nil, err
@@ -471,8 +437,8 @@ func (b *Bus) sendTransaction(runCtx, reqCtx context.Context, frame Frame) (*Fra
 			return nil, fmt.Errorf("syn while waiting for response crc: %w", ebuserrors.ErrTimeout)
 		}
 
-		segment := make([]byte, 0, 5+len(data))
-		segment = append(segment, respSource, respTarget, respPrimary, respSecondary, lengthSym)
+		segment := make([]byte, 0, 1+len(data))
+		segment = append(segment, lengthSym)
 		segment = append(segment, data...)
 		if CRC(segment) != crcValue {
 			if err := b.sendSymbolWithEcho(runCtx, reqCtx, SymbolNack, true); err != nil {
@@ -493,10 +459,10 @@ func (b *Bus) sendTransaction(runCtx, reqCtx context.Context, frame Frame) (*Fra
 		}
 
 		return &Frame{
-			Source:    respSource,
-			Target:    respTarget,
-			Primary:   respPrimary,
-			Secondary: respSecondary,
+			Source:    frame.Target,
+			Target:    frame.Source,
+			Primary:   frame.Primary,
+			Secondary: frame.Secondary,
 			Data:      data,
 		}, nil
 	}

--- a/protocol/bus_test.go
+++ b/protocol/bus_test.go
@@ -223,22 +223,14 @@ func TestBus_ResponseCRCMismatch(t *testing.T) {
 	}
 
 	data := byte(0x10)
-	responseSegment := []byte{frame.Target, frame.Source, frame.Primary, frame.Secondary, 0x01, data}
+	responseSegment := []byte{0x01, data}
 	badCRC := protocol.CRC(responseSegment) ^ 0xFF
 	tr := &scriptedTransport{
 		inbound: []readEvent{
 			{value: protocol.SymbolAck},
-			{value: frame.Target},
-			{value: frame.Source},
-			{value: frame.Primary},
-			{value: frame.Secondary},
 			{value: 0x01},
 			{value: data},
 			{value: badCRC},
-			{value: frame.Target},
-			{value: frame.Source},
-			{value: frame.Primary},
-			{value: frame.Secondary},
 			{value: 0x01},
 			{value: data},
 			{value: badCRC},
@@ -263,8 +255,8 @@ func TestBus_ResponseCRCMismatch(t *testing.T) {
 	if !errors.Is(err, ebuserrors.ErrCRCMismatch) {
 		t.Fatalf("Send error = %v; want ErrCRCMismatch", err)
 	}
-	if tr.inboundReadsConsumed() != 15 {
-		t.Fatalf("inbound reads = %d; want 15", tr.inboundReadsConsumed())
+	if tr.inboundReadsConsumed() != 7 {
+		t.Fatalf("inbound reads = %d; want 7", tr.inboundReadsConsumed())
 	}
 }
 
@@ -280,24 +272,16 @@ func TestBus_RetryOnCRCMismatch(t *testing.T) {
 	}
 
 	data := byte(0x10)
-	responseSegment := []byte{frame.Target, frame.Source, frame.Primary, frame.Secondary, 0x01, data}
+	responseSegment := []byte{0x01, data}
 	goodCRC := protocol.CRC(responseSegment)
 	badCRC := goodCRC ^ 0xFF
 
 	tr := &scriptedTransport{
 		inbound: []readEvent{
 			{value: protocol.SymbolAck},
-			{value: frame.Target},
-			{value: frame.Source},
-			{value: frame.Primary},
-			{value: frame.Secondary},
 			{value: 0x01},
 			{value: data},
 			{value: badCRC},
-			{value: frame.Target},
-			{value: frame.Source},
-			{value: frame.Primary},
-			{value: frame.Secondary},
 			{value: 0x01},
 			{value: data},
 			{value: goodCRC},
@@ -325,8 +309,8 @@ func TestBus_RetryOnCRCMismatch(t *testing.T) {
 	if resp == nil || len(resp.Data) != 1 || resp.Data[0] != data {
 		t.Fatalf("response = %+v; want data [0x10]", resp)
 	}
-	if tr.inboundReadsConsumed() != 15 {
-		t.Fatalf("inbound reads = %d; want 15", tr.inboundReadsConsumed())
+	if tr.inboundReadsConsumed() != 7 {
+		t.Fatalf("inbound reads = %d; want 7", tr.inboundReadsConsumed())
 	}
 }
 
@@ -341,17 +325,13 @@ func TestBus_RetryOnTimeout(t *testing.T) {
 		Data:      []byte{0x03},
 	}
 	data := byte(0x10)
-	responseSegment := []byte{frame.Target, frame.Source, frame.Primary, frame.Secondary, 0x01, data}
+	responseSegment := []byte{0x01, data}
 	respCRC := protocol.CRC(responseSegment)
 
 	tr := &scriptedTransport{
 		inbound: []readEvent{
 			{err: ebuserrors.ErrTimeout},
 			{value: protocol.SymbolAck},
-			{value: frame.Target},
-			{value: frame.Source},
-			{value: frame.Primary},
-			{value: frame.Secondary},
 			{value: 0x01},
 			{value: data},
 			{value: respCRC},
@@ -402,17 +382,13 @@ func TestBus_RetryOnNACK(t *testing.T) {
 		Data:      []byte{0x03},
 	}
 	data := byte(0x20)
-	responseSegment := []byte{frame.Target, frame.Source, frame.Primary, frame.Secondary, 0x01, data}
+	responseSegment := []byte{0x01, data}
 	respCRC := protocol.CRC(responseSegment)
 
 	tr := &scriptedTransport{
 		inbound: []readEvent{
 			{value: protocol.SymbolNack},
 			{value: protocol.SymbolAck},
-			{value: frame.Target},
-			{value: frame.Source},
-			{value: frame.Primary},
-			{value: frame.Secondary},
 			{value: 0x01},
 			{value: data},
 			{value: respCRC},
@@ -774,7 +750,7 @@ func TestBus_RetryOnCollisionDuringWriteWaitsForSyn(t *testing.T) {
 	}
 
 	data := byte(0x10)
-	responseSegment := []byte{frame.Target, frame.Source, frame.Primary, frame.Secondary, 0x01, data}
+	responseSegment := []byte{0x01, data}
 	respCRC := protocol.CRC(responseSegment)
 	tr := &collisionOnceTransport{
 		collideOnFirstEcho: true,
@@ -782,10 +758,6 @@ func TestBus_RetryOnCollisionDuringWriteWaitsForSyn(t *testing.T) {
 			{value: protocol.SymbolSyn},
 			{value: protocol.SymbolSyn},
 			{value: protocol.SymbolAck},
-			{value: frame.Target},
-			{value: frame.Source},
-			{value: frame.Primary},
-			{value: frame.Secondary},
 			{value: 0x01},
 			{value: data},
 			{value: respCRC},
@@ -817,8 +789,8 @@ func TestBus_RetryOnCollisionDuringWriteWaitsForSyn(t *testing.T) {
 	tr.mu.Lock()
 	inReads := tr.inboundReads
 	tr.mu.Unlock()
-	if inReads != 10 {
-		t.Fatalf("inbound reads = %d; want 10", inReads)
+	if inReads != 6 {
+		t.Fatalf("inbound reads = %d; want 6", inReads)
 	}
 }
 
@@ -833,7 +805,7 @@ func TestBus_RetryOnCollisionDoesNotConsumeTimeoutRetries(t *testing.T) {
 	}
 
 	data := byte(0x10)
-	responseSegment := []byte{frame.Target, frame.Source, frame.Primary, frame.Secondary, 0x01, data}
+	responseSegment := []byte{0x01, data}
 	respCRC := protocol.CRC(responseSegment)
 	tr := &collisionOnceTransport{
 		collideOnFirstEcho: true,
@@ -841,10 +813,6 @@ func TestBus_RetryOnCollisionDoesNotConsumeTimeoutRetries(t *testing.T) {
 			{value: protocol.SymbolSyn},
 			{value: protocol.SymbolSyn},
 			{value: protocol.SymbolAck},
-			{value: frame.Target},
-			{value: frame.Source},
-			{value: frame.Primary},
-			{value: frame.Secondary},
 			{value: 0x01},
 			{value: data},
 			{value: respCRC},
@@ -885,7 +853,7 @@ func TestBus_CollisionRetryRespectsTimeoutRetriesWithoutDeadline(t *testing.T) {
 	}
 
 	data := byte(0x10)
-	responseSegment := []byte{frame.Target, frame.Source, frame.Primary, frame.Secondary, 0x01, data}
+	responseSegment := []byte{0x01, data}
 	respCRC := protocol.CRC(responseSegment)
 	tr := &collisionOnceTransport{
 		collideOnFirstEcho: true,
@@ -893,10 +861,6 @@ func TestBus_CollisionRetryRespectsTimeoutRetriesWithoutDeadline(t *testing.T) {
 			{value: protocol.SymbolSyn},
 			{value: protocol.SymbolSyn},
 			{value: protocol.SymbolAck},
-			{value: frame.Target},
-			{value: frame.Source},
-			{value: frame.Primary},
-			{value: frame.Secondary},
 			{value: 0x01},
 			{value: data},
 			{value: respCRC},


### PR DESCRIPTION
## Summary

- Remove 4 phantom QQ/ZZ/PB/SB reads from `sendTransaction()` slave response path
- CRC segment now `[NN, DATA]` instead of `[QQ, ZZ, PB, SB, NN, DATA]` per eBUS spec §4.3
- Response Frame infers Source/Target/Primary/Secondary from initiator request
- 7 tests updated to match correct slave response format

## Root Cause

Commit aaea4f9 incorrectly added header reads to the slave response path. Per the eBUS specification, a slave response on the wire is `[NN, DB1..DBn, CRC]` — no header bytes. The phantom reads consumed the first 4 data bytes, corrupting all subsequent parsing and causing scan=0.

## Test Evidence

```
go test -race -count=5 ./protocol/...
ok  github.com/d3vi1/helianthus-ebusgo/protocol  1.030s
```

## Transport-gate owner override

Pre-existing matrix baseline; regression fix restoring correct behavior broken by commit aaea4f9. Targeted `go test -race` evidence per PR; full T01-T88 deferred to matrix runner availability.

Fixes #104