### PR TITLE
fix(transport): align ebusd-tcp synthetic response with slave format

### DIFF
--- a/transport/ebusd_tcp.go
+++ b/transport/ebusd_tcp.go
@@ -155,8 +155,10 @@ func (t *EbusdTCPTransport) Write(payload []byte) (int, error) {
 			continue
 		}
 
-		response := make([]byte, 0, 6+len(respPayload))
-		response = append(response, dispatch.dst, dispatch.src, dispatch.pb, dispatch.sb, byte(len(respPayload)))
+		// Slave response on the wire: NN DB1..DBn CRC (no header —
+		// QQ/ZZ/PB/SB are inferred by the bus layer from the request).
+		response := make([]byte, 0, 2+len(respPayload))
+		response = append(response, byte(len(respPayload)))
 		response = append(response, respPayload...)
 		response = append(response, crcValue(response))
 

--- a/transport/ebusd_tcp_test.go
+++ b/transport/ebusd_tcp_test.go
@@ -487,7 +487,7 @@ func TestEbusdTCPTransport_Write_CommandInjectsAckAndResponse(t *testing.T) {
 	}
 
 	respData := []byte{0x11, 0x22, 0x33}
-	respTelegram := []byte{dst, src, pb, sb, byte(len(respData))}
+	respTelegram := []byte{byte(len(respData))}
 	respTelegram = append(respTelegram, respData...)
 	respTelegram = append(respTelegram, crcValue(respTelegram))
 


### PR DESCRIPTION
## Summary

- Remove synthetic header bytes (dst, src, pb, sb) from EbusdTCPTransport slave response
- Response now [NN, DATA, CRC_over(NN+DATA)] matching bus.go expectations after #105
- Test updated to match new format

## Context

Caught by Codex adversarial code review of PR #105. The ebusd-tcp transport was synthesizing responses with header bytes that bus.go no longer reads after the slave response format fix.

## Test Evidence

```
go test -race -count=1 ./transport/...
ok  github.com/d3vi1/helianthus-ebusgo/transport  1.377s
```

Fixes #111