### PR TITLE
fix(transport): reset parser state after arbitration + correct ENS delegation

### DIFF
--- a/transport/enh_transport.go
+++ b/transport/enh_transport.go
@@ -45,12 +45,11 @@ func NewENHTransport(conn net.Conn, readTimeout, writeTimeout time.Duration) *EN
 
 // NewENSTransport creates an ENS transport over ENH framing.
 //
-// ENS still uses START arbitration, but callers must include the source byte in
-// the outgoing telegram payload.
+// ENS uses START arbitration and the adapter transmits the source byte on the
+// wire during arbitration, same as ENH. Callers must NOT include the source
+// byte in the outgoing telegram payload.
 func NewENSTransport(conn net.Conn, readTimeout, writeTimeout time.Duration) *ENHTransport {
-	transport := NewENHTransport(conn, readTimeout, writeTimeout)
-	transport.arbitrationSendsSource = false
-	return transport
+	return NewENHTransport(conn, readTimeout, writeTimeout)
 }
 
 // ArbitrationSendsSource reports whether START arbitration already placed the
@@ -308,6 +307,15 @@ func (t *ENHTransport) StartArbitration(initiator byte) error {
 		}
 
 		if arbitrationDone {
+			// Reset parser and pending queue so that ReadByte starts with a
+			// clean state. TCP fragmentation can leave the parser with a
+			// pending byte1 from a partially-received frame that arrived
+			// alongside the STARTED/FAILED response. Without this reset,
+			// the stale byte1 combines with the first byte of the next
+			// RECEIVED echo to produce a wrong value, causing
+			// sendSymbolWithEcho to detect an echo mismatch.
+			t.parser.Reset()
+			t.pending = t.pending[:0]
 			return arbitrationErr
 		}
 	}

--- a/transport/enh_transport_test.go
+++ b/transport/enh_transport_test.go
@@ -425,7 +425,7 @@ func TestENSTransport_ArbitrationSourceInjectionFlag(t *testing.T) {
 	defer func() { _ = clientEns.Close() }()
 	defer func() { _ = serverEns.Close() }()
 	ens := transport.NewENSTransport(clientEns, 200*time.Millisecond, 200*time.Millisecond)
-	if ens.ArbitrationSendsSource() {
-		t.Fatalf("ENS transport ArbitrationSendsSource = true; want false")
+	if !ens.ArbitrationSendsSource() {
+		t.Fatalf("ENS transport ArbitrationSendsSource = false; want true")
 	}
 }


### PR DESCRIPTION
## Summary

- Reset ENH parser and pending queue after arbitration STARTED/FAILED
- ENS now delegates to ENH constructor (both modes send source during arbitration)
- Test updated to expect ArbitrationSendsSource()=true for ENS

## Root Cause

### Bug 1: Parser state leak
TCP fragmentation could deliver extra bytes alongside the STARTED/FAILED response. The parser accumulated a stale byte1 from a partially-received RECEIVED frame. Without reset, subsequent ReadByte calls combined the stale byte1 with new data, causing echo mismatches.

### Bug 2: Double source byte
NewENSTransport set arbitrationSendsSource=false, causing callers to include the source byte in the payload. But the ENS adapter (like ENH) already transmits the source byte during START arbitration, resulting in a duplicate.

## Test Evidence

```
go test -race -count=5 ./protocol/... ./transport/...
ok  github.com/d3vi1/helianthus-ebusgo/protocol  1.031s
ok  github.com/d3vi1/helianthus-ebusgo/transport  2.859s
```

## Transport-gate owner override

Pre-existing matrix baseline; regression fix restoring correct behavior. Targeted cross-layer `go test -race` evidence (protocol + transport); full T01-T88 deferred to matrix runner availability.

Depends on #104 (merged) and #111 (merged).
Fixes #113