### PR TITLE
Export IsInitiatorCapableAddress

### DIFF
--- a/protocol/initiator_address_test.go
+++ b/protocol/initiator_address_test.go
@@ -1,0 +1,42 @@
+package protocol
+
+import "testing"
+
+func TestIsInitiatorCapableAddress(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		addr byte
+		want bool
+	}{
+		{"0x00", 0x00, true},
+		{"0x01", 0x01, true},
+		{"0x03", 0x03, true},
+		{"0x07", 0x07, true},
+		{"0x0F", 0x0F, true},
+		{"0x10", 0x10, true},
+		{"0x70", 0x70, true},
+		{"0xF0", 0xF0, true},
+		{"0xF7", 0xF7, true},
+		{"0xFF", 0xFF, true},
+		{"0x37", 0x37, true},
+		{"0x15 (slave)", 0x15, false},
+		{"0x1C (slave)", 0x1C, false},
+		{"0x75 (slave)", 0x75, false},
+		{"0x50 (not in table)", 0x50, false},
+		{"0xFE (not in table)", 0xFE, false},
+		{"0xA9 (SymbolEscape)", SymbolEscape, false},
+		{"0xAA (SymbolSyn)", SymbolSyn, false},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := IsInitiatorCapableAddress(tc.addr); got != tc.want {
+				t.Fatalf("IsInitiatorCapableAddress(0x%02x) = %v; want %v", tc.addr, got, tc.want)
+			}
+		})
+	}
+}

--- a/protocol/join.go
+++ b/protocol/join.go
@@ -174,7 +174,7 @@ func (j *Joiner) Join(ctx context.Context) (JoinResult, error) {
 
 	var persistedCandidate *byte
 	if cfg.PersistLastGood && j.store != nil {
-		if persisted, loadErr := j.store.LoadInitiator(ctx); loadErr == nil && isInitiatorCapableAddress(persisted) {
+		if persisted, loadErr := j.store.LoadInitiator(ctx); loadErr == nil && IsInitiatorCapableAddress(persisted) {
 			persistedCandidate = &persisted
 		}
 	}
@@ -335,7 +335,7 @@ func companionTargetRejectionReasons(observation *joinObservation, initiator byt
 	companionTarget := initiator + 0x05
 	reasons := make([]string, 0, 2)
 
-	if !isInitiatorCapableAddress(companionTarget) && observation.sourceCount[companionTarget] >= defaultLikelyTargetSourceMin {
+	if !IsInitiatorCapableAddress(companionTarget) && observation.sourceCount[companionTarget] >= defaultLikelyTargetSourceMin {
 		reasons = append(reasons, "companion-target-seen-as-probable-target-source")
 	}
 	if observation.targetCount[companionTarget] >= defaultLikelyTargetDestinationMin {
@@ -395,7 +395,7 @@ func (o *joinObservation) addFrame(frame Frame) {
 	o.sourceCount[frame.Source]++
 	o.targetCount[frame.Target]++
 	o.observedSources[frame.Source] = struct{}{}
-	if isInitiatorCapableAddress(frame.Source) {
+	if IsInitiatorCapableAddress(frame.Source) {
 		o.observedInitiators[frame.Source] = struct{}{}
 		return
 	}

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -41,7 +41,7 @@ func FrameTypeForTarget(target byte) FrameType {
 	if !isValidAddress(target) {
 		return FrameTypeUnknown
 	}
-	if isInitiatorCapableAddress(target) {
+	if IsInitiatorCapableAddress(target) {
 		return FrameTypeInitiatorInitiator
 	}
 	return FrameTypeInitiatorTarget
@@ -69,7 +69,9 @@ func isValidAddress(addr byte) bool {
 	return addr != SymbolEscape && addr != SymbolSyn
 }
 
-func isInitiatorCapableAddress(addr byte) bool {
+// IsInitiatorCapableAddress reports whether addr is a valid eBUS initiator
+// (master) address according to the eBUS address table.
+func IsInitiatorCapableAddress(addr byte) bool {
 	return initiatorPartIndex(addr&0x0F) > 0 && initiatorPartIndex((addr&0xF0)>>4) > 0
 }
 


### PR DESCRIPTION
## Summary
- Rename unexported `isInitiatorCapableAddress` → exported `IsInitiatorCapableAddress`
- Update all internal call sites (protocol.go, join.go)
- Add table-driven tests: 11 initiator addresses (true), 5 non-initiators including SymbolEscape/SymbolSyn (false)

Fixes #108

## Test plan
- [x] `go test -race -count=1 ./protocol/...` — all green
- [x] 18 test cases in `TestIsInitiatorCapableAddress`

🤖 Generated with [Claude Code](https://claude.com/claude-code)