### PR TITLE
feat(transport): extend Init return to (byte, error)

### DIFF
--- a/transport/enh_transport.go
+++ b/transport/enh_transport.go
@@ -90,28 +90,30 @@ func (t *ENHTransport) ArbitrationSendsSource() bool {
 // Init performs an ENH initialization handshake by sending ENHReqInit(features)
 // and waiting for ENHResResetted(features).
 //
+// Returns the adapter's confirmed features byte from the RESETTED response.
 // Any RESETTED frames observed later will reset the local parser and echo state.
-func (t *ENHTransport) Init(features byte) error {
+func (t *ENHTransport) Init(features byte) (byte, error) {
 	t.readMu.Lock()
 	defer t.readMu.Unlock()
 	return t.initLocked(features)
 }
 
 // initLocked performs the INIT handshake. Caller must hold readMu.
-func (t *ENHTransport) initLocked(features byte) error {
+// Returns the features byte from the adapter's RESETTED response.
+func (t *ENHTransport) initLocked(features byte) (byte, error) {
 	t.writeMu.Lock()
 	seq := EncodeENH(ENHReqInit, features)
 	written := 0
 	for written < len(seq) {
 		if err := t.setWriteDeadline(); err != nil {
 			t.writeMu.Unlock()
-			return t.mapWriteError(err)
+			return 0, t.mapWriteError(err)
 		}
 		n, err := t.conn.Write(seq[written:])
 		written += n
 		if err != nil {
 			t.writeMu.Unlock()
-			return t.mapWriteError(err)
+			return 0, t.mapWriteError(err)
 		}
 		if n == 0 {
 			break
@@ -119,7 +121,7 @@ func (t *ENHTransport) initLocked(features byte) error {
 	}
 	t.writeMu.Unlock()
 	if written != len(seq) {
-		return ebuserrors.ErrInvalidPayload
+		return 0, ebuserrors.ErrInvalidPayload
 	}
 
 	maxWait := t.readTimeout
@@ -131,22 +133,22 @@ func (t *ENHTransport) initLocked(features byte) error {
 	for {
 		remaining := maxWait - time.Since(start)
 		if remaining <= 0 {
-			return nil
+			return 0, nil
 		}
 		if t.readTimeout <= 0 || remaining < t.readTimeout {
 			if err := t.conn.SetReadDeadline(time.Now().Add(remaining)); err != nil {
-				return t.mapReadError(err)
+				return 0, t.mapReadError(err)
 			}
 		} else if err := t.setReadDeadline(); err != nil {
-			return t.mapReadError(err)
+			return 0, t.mapReadError(err)
 		}
 
 		n, err := t.conn.Read(t.buffer)
 		if err != nil {
 			if isTimeout(err) {
-				return nil
+				return 0, nil
 			}
-			return t.mapReadError(err)
+			return 0, t.mapReadError(err)
 		}
 		if n == 0 {
 			continue
@@ -154,7 +156,7 @@ func (t *ENHTransport) initLocked(features byte) error {
 
 		msgs, err := t.parser.Parse(t.buffer[:n])
 		if err != nil {
-			return err
+			return 0, err
 		}
 		for _, msg := range msgs {
 			switch msg.Kind {
@@ -166,13 +168,13 @@ func (t *ENHTransport) initLocked(features byte) error {
 					t.pending = append(t.pending, msg.Data)
 				case ENHResResetted:
 					t.resetStateLocked()
-					return nil
+					return msg.Data, nil
 				case ENHResInfo:
 					// Ignore info responses for now; leave any received bytes queued.
 				case ENHResErrorEBUS:
-					return fmt.Errorf("enh init ebus error 0x%02x: %w", msg.Data, ebuserrors.ErrInvalidPayload)
+					return 0, fmt.Errorf("enh init ebus error 0x%02x: %w", msg.Data, ebuserrors.ErrInvalidPayload)
 				case ENHResErrorHost:
-					return fmt.Errorf("enh init host error 0x%02x: %w", msg.Data, ebuserrors.ErrInvalidPayload)
+					return 0, fmt.Errorf("enh init host error 0x%02x: %w", msg.Data, ebuserrors.ErrInvalidPayload)
 				}
 			}
 		}
@@ -203,7 +205,7 @@ func (t *ENHTransport) reconnectLocked() error {
 	}
 	t.conn = newConn
 	t.resetStateLocked()
-	if err := t.initLocked(0x01); err != nil {
+	if _, err := t.initLocked(0x01); err != nil {
 		_ = t.conn.Close()
 		return fmt.Errorf("enh reconnect init: %v: %w", err, ebuserrors.ErrTransportClosed)
 	}

--- a/transport/enh_transport_test.go
+++ b/transport/enh_transport_test.go
@@ -76,8 +76,55 @@ func TestENHTransport_InitHandshake(t *testing.T) {
 		serverErr <- err
 	}()
 
-	if err := enh.Init(0x00); err != nil {
+	features, err := enh.Init(0x00)
+	if err != nil {
 		t.Fatalf("Init error = %v", err)
+	}
+	if features != 0x00 {
+		t.Fatalf("Init features = 0x%02x; want 0x00", features)
+	}
+	if err := <-serverErr; err != nil {
+		t.Fatalf("server error = %v", err)
+	}
+}
+
+func TestENHTransport_InitReturnsAdapterFeatures(t *testing.T) {
+	t.Parallel()
+
+	client, server := net.Pipe()
+	defer func() { _ = client.Close() }()
+	defer func() { _ = server.Close() }()
+
+	enh := transport.NewENHTransport(client, 200*time.Millisecond, 200*time.Millisecond)
+
+	serverErr := make(chan error, 1)
+	go func() {
+		defer close(serverErr)
+
+		buf := make([]byte, 2)
+		if _, err := io.ReadFull(server, buf); err != nil {
+			serverErr <- err
+			return
+		}
+
+		want := transport.EncodeENH(transport.ENHReqInit, 0x01)
+		if buf[0] != want[0] || buf[1] != want[1] {
+			serverErr <- errors.New("unexpected init bytes")
+			return
+		}
+
+		// Adapter confirms with different features byte (e.g. 0x03).
+		resp := transport.EncodeENH(transport.ENHResResetted, 0x03)
+		_, err := server.Write(resp[:])
+		serverErr <- err
+	}()
+
+	features, err := enh.Init(0x01)
+	if err != nil {
+		t.Fatalf("Init error = %v", err)
+	}
+	if features != 0x03 {
+		t.Fatalf("Init features = 0x%02x; want 0x03", features)
 	}
 	if err := <-serverErr; err != nil {
 		t.Fatalf("server error = %v", err)


### PR DESCRIPTION
## Summary
- `Init(byte)` now returns `(byte, error)` instead of `error`, propagating the adapter's confirmed features byte from the RESETTED response
- `initLocked` updated to return `msg.Data` on RESETTED and `0` on all error paths
- `reconnectLocked` updated to discard the features byte with `_, err :=`
- New test `TestENHTransport_InitReturnsAdapterFeatures` validates non-zero features round-trip

## Breaking change
`Init(byte) error` signature changes to `Init(byte) (byte, error)`. Any downstream code using `interface{ Init(byte) error }` type assertions will need updating.

## Test plan
- [x] `go test ./transport/... -v -count=1 -race` — all 55 tests pass
- [x] `go vet ./...` — clean