### PR TITLE
feat(transport): StreamEvent extension + RequestStart

### DIFF
--- a/transport/enh_transport.go
+++ b/transport/enh_transport.go
@@ -42,10 +42,10 @@ type ENHTransport struct {
 	readMu  sync.Mutex
 	writeMu sync.Mutex
 
-	parser  ENHParser
-	pending []byte
-	resets  int
-	buffer  []byte
+	parser        ENHParser
+	pendingEvents []StreamEvent
+	resets        int
+	buffer        []byte
 }
 
 // NewENHTransport creates a new ENH transport with read/write timeouts.
@@ -161,11 +161,11 @@ func (t *ENHTransport) initLocked(features byte) (byte, error) {
 		for _, msg := range msgs {
 			switch msg.Kind {
 			case ENHMessageData:
-				t.pending = append(t.pending, msg.Byte)
+				t.pendingEvents = append(t.pendingEvents, StreamEvent{Kind: StreamEventByte, Byte: msg.Byte})
 			case ENHMessageFrame:
 				switch msg.Command {
 				case ENHResReceived:
-					t.pending = append(t.pending, msg.Data)
+					t.pendingEvents = append(t.pendingEvents, StreamEvent{Kind: StreamEventByte, Byte: msg.Data})
 				case ENHResResetted:
 					t.resetStateLocked()
 					return msg.Data, nil
@@ -236,23 +236,30 @@ func (t *ENHTransport) ReadByte() (byte, error) {
 			return 0, ebuserrors.ErrAdapterReset
 		}
 
-		if len(t.pending) > 0 {
-			value := t.pending[0]
-			t.pending = t.pending[1:]
-			return value, nil
+		// Drain pendingEvents, returning only Byte events. Non-byte events
+		// (STARTED, FAILED) are silently skipped so ReadByte callers never
+		// see them.
+		for len(t.pendingEvents) > 0 {
+			ev := t.pendingEvents[0]
+			t.pendingEvents = t.pendingEvents[1:]
+			if ev.Kind == StreamEventByte {
+				return ev.Byte, nil
+			}
+			// Skip non-byte events (StreamEventStarted, StreamEventFailed).
 		}
 
 		if err := t.fillPendingLocked(); err != nil {
 			return 0, err
 		}
-		if t.resets == 0 && len(t.pending) == 0 {
+		if t.resets == 0 && len(t.pendingEvents) == 0 {
 			continue
 		}
 	}
 }
 
-// ReadEvent surfaces optional reset boundaries to passive consumers while
-// preserving ReadByte compatibility for active callers.
+// ReadEvent surfaces non-byte transport events (reset, arbitration
+// started/failed) to passive consumers while preserving ReadByte
+// compatibility for active callers.
 func (t *ENHTransport) ReadEvent() (StreamEvent, error) {
 	t.readMu.Lock()
 	defer t.readMu.Unlock()
@@ -263,16 +270,16 @@ func (t *ENHTransport) ReadEvent() (StreamEvent, error) {
 			return StreamEvent{Kind: StreamEventReset}, nil
 		}
 
-		if len(t.pending) > 0 {
-			value := t.pending[0]
-			t.pending = t.pending[1:]
-			return StreamEvent{Kind: StreamEventByte, Byte: value}, nil
+		if len(t.pendingEvents) > 0 {
+			ev := t.pendingEvents[0]
+			t.pendingEvents = t.pendingEvents[1:]
+			return ev, nil
 		}
 
 		if err := t.fillPendingLocked(); err != nil {
 			return StreamEvent{}, err
 		}
-		if t.resets == 0 && len(t.pending) == 0 {
+		if t.resets == 0 && len(t.pendingEvents) == 0 {
 			continue
 		}
 	}
@@ -370,7 +377,7 @@ func (t *ENHTransport) StartArbitration(initiator byte) error {
 		for _, msg := range msgs {
 			switch msg.Kind {
 			case ENHMessageData:
-				t.pending = append(t.pending, msg.Byte)
+				t.pendingEvents = append(t.pendingEvents, StreamEvent{Kind: StreamEventByte, Byte: msg.Byte})
 			case ENHMessageFrame:
 				switch msg.Command {
 				case ENHResReceived:
@@ -410,10 +417,34 @@ func (t *ENHTransport) StartArbitration(initiator byte) error {
 			// RECEIVED echo to produce a wrong value, causing
 			// sendSymbolWithEcho to detect an echo mismatch.
 			t.parser.Reset()
-			t.pending = t.pending[:0]
+			t.pendingEvents = t.pendingEvents[:0]
 			return arbitrationErr
 		}
 	}
+}
+
+// RequestStart sends a non-blocking START arbitration request for the given
+// initiator address. It writes the ENH START frame and returns immediately
+// without waiting for the adapter response.
+//
+// The adapter's STARTED or FAILED response will arrive asynchronously and
+// can be consumed via ReadEvent (as StreamEventStarted or StreamEventFailed).
+// ReadByte automatically skips these events.
+//
+// Only writeMu is held; readMu is NOT acquired so a concurrent ReadEvent
+// loop can consume the response without deadlock.
+func (t *ENHTransport) RequestStart(initiator byte) error {
+	t.writeMu.Lock()
+	defer t.writeMu.Unlock()
+	seq := EncodeENH(ENHReqStart, initiator)
+	if err := t.conn.SetWriteDeadline(time.Now().Add(t.writeTimeout)); err != nil {
+		return t.mapWriteError(err)
+	}
+	_, err := t.conn.Write(seq[:])
+	if err != nil {
+		return t.mapWriteError(err)
+	}
+	return nil
 }
 
 // RequestInfo sends an INFO request for the given ID and returns the raw
@@ -431,12 +462,12 @@ func (t *ENHTransport) RequestInfo(id AdapterInfoID) ([]byte, error) {
 	defer func() {
 		if err != nil {
 			t.parser.Reset()
-			// Preserve buffered bus bytes on timeout/error so they are not
+			// Preserve buffered events on timeout/error so they are not
 			// silently dropped. Clear pending on fatal transport errors and
-			// adapter resets where the parser state is unrecoverable or bytes
+			// adapter resets where the parser state is unrecoverable or events
 			// from the same TCP segment after RESETTED would be stale.
 			if errors.Is(err, ebuserrors.ErrTransportClosed) || errors.Is(err, ebuserrors.ErrAdapterReset) {
-				t.pending = nil
+				t.pendingEvents = nil
 			}
 		}
 	}()
@@ -513,7 +544,7 @@ func (t *ENHTransport) RequestInfo(id AdapterInfoID) ([]byte, error) {
 			switch msg.Kind {
 			case ENHMessageData:
 				// Bus byte received during INFO exchange — queue it.
-				t.pending = append(t.pending, msg.Byte)
+				t.pendingEvents = append(t.pendingEvents, StreamEvent{Kind: StreamEventByte, Byte: msg.Byte})
 			case ENHMessageFrame:
 				switch msg.Command {
 				case ENHResInfo:
@@ -537,7 +568,7 @@ func (t *ENHTransport) RequestInfo(id AdapterInfoID) ([]byte, error) {
 					}
 				case ENHResReceived:
 					// Bus byte received during INFO — queue it.
-					t.pending = append(t.pending, msg.Data)
+					t.pendingEvents = append(t.pendingEvents, StreamEvent{Kind: StreamEventByte, Byte: msg.Data})
 				case ENHResResetted:
 					t.surfaceResetLocked()
 					if !payloadComplete {
@@ -567,7 +598,7 @@ func (t *ENHTransport) Close() error {
 
 func (t *ENHTransport) resetStateLocked() {
 	t.parser.Reset()
-	t.pending = nil
+	t.pendingEvents = nil
 }
 
 func (t *ENHTransport) surfaceResetLocked() {
@@ -595,11 +626,15 @@ func (t *ENHTransport) fillPendingLocked() error {
 	for _, msg := range msgs {
 		switch msg.Kind {
 		case ENHMessageData:
-			t.pending = append(t.pending, msg.Byte)
+			t.pendingEvents = append(t.pendingEvents, StreamEvent{Kind: StreamEventByte, Byte: msg.Byte})
 		case ENHMessageFrame:
 			switch msg.Command {
 			case ENHResReceived:
-				t.pending = append(t.pending, msg.Data)
+				t.pendingEvents = append(t.pendingEvents, StreamEvent{Kind: StreamEventByte, Byte: msg.Data})
+			case ENHResStarted:
+				t.pendingEvents = append(t.pendingEvents, StreamEvent{Kind: StreamEventStarted, Data: msg.Data})
+			case ENHResFailed:
+				t.pendingEvents = append(t.pendingEvents, StreamEvent{Kind: StreamEventFailed, Data: msg.Data})
 			case ENHResResetted:
 				if reconnErr := t.reconnectLocked(); reconnErr != nil {
 					return fmt.Errorf("enh adapter reset during read, reconnect failed: %w", ebuserrors.ErrTransportClosed)

--- a/transport/enh_transport.go
+++ b/transport/enh_transport.go
@@ -437,7 +437,7 @@ func (t *ENHTransport) RequestStart(initiator byte) error {
 	t.writeMu.Lock()
 	defer t.writeMu.Unlock()
 	seq := EncodeENH(ENHReqStart, initiator)
-	if err := t.conn.SetWriteDeadline(time.Now().Add(t.writeTimeout)); err != nil {
+	if err := t.setWriteDeadline(); err != nil {
 		return t.mapWriteError(err)
 	}
 	_, err := t.conn.Write(seq[:])

--- a/transport/enh_transport_test.go
+++ b/transport/enh_transport_test.go
@@ -1115,3 +1115,164 @@ func TestENHTransport_ReconnectImplementsReconnectable(t *testing.T) {
 		t.Fatalf("Reconnect error = %v", err)
 	}
 }
+
+func TestENHTransport_RequestStartSurfacesStarted(t *testing.T) {
+	t.Parallel()
+
+	client, server := net.Pipe()
+	defer func() { _ = client.Close() }()
+	defer func() { _ = server.Close() }()
+
+	enh := transport.NewENHTransport(client, 200*time.Millisecond, 200*time.Millisecond)
+	initiator := byte(0x10)
+
+	serverErr := make(chan error, 1)
+	go func() {
+		defer close(serverErr)
+
+		// Read the START request from the client.
+		buf := make([]byte, 2)
+		if _, err := io.ReadFull(server, buf); err != nil {
+			serverErr <- err
+			return
+		}
+		want := transport.EncodeENH(transport.ENHReqStart, initiator)
+		if buf[0] != want[0] || buf[1] != want[1] {
+			serverErr <- errors.New("unexpected start request")
+			return
+		}
+
+		// Respond with STARTED.
+		started := transport.EncodeENH(transport.ENHResStarted, initiator)
+		_, err := server.Write(started[:])
+		serverErr <- err
+	}()
+
+	if err := enh.RequestStart(initiator); err != nil {
+		t.Fatalf("RequestStart error = %v", err)
+	}
+
+	reader, ok := interface{}(enh).(transport.StreamEventReader)
+	if !ok {
+		t.Fatal("ENH transport does not implement StreamEventReader")
+	}
+
+	event, err := reader.ReadEvent()
+	if err != nil {
+		t.Fatalf("ReadEvent error = %v", err)
+	}
+	if event.Kind != transport.StreamEventStarted {
+		t.Fatalf("ReadEvent kind = %v; want StreamEventStarted", event.Kind)
+	}
+	if event.Data != initiator {
+		t.Fatalf("ReadEvent data = 0x%02x; want 0x%02x", event.Data, initiator)
+	}
+
+	if err := <-serverErr; err != nil {
+		t.Fatalf("server error = %v", err)
+	}
+}
+
+func TestENHTransport_RequestStartSurfacesFailed(t *testing.T) {
+	t.Parallel()
+
+	client, server := net.Pipe()
+	defer func() { _ = client.Close() }()
+	defer func() { _ = server.Close() }()
+
+	enh := transport.NewENHTransport(client, 200*time.Millisecond, 200*time.Millisecond)
+	initiator := byte(0x10)
+	winner := byte(0x30)
+
+	serverErr := make(chan error, 1)
+	go func() {
+		defer close(serverErr)
+
+		buf := make([]byte, 2)
+		if _, err := io.ReadFull(server, buf); err != nil {
+			serverErr <- err
+			return
+		}
+		want := transport.EncodeENH(transport.ENHReqStart, initiator)
+		if buf[0] != want[0] || buf[1] != want[1] {
+			serverErr <- errors.New("unexpected start request")
+			return
+		}
+
+		// Respond with FAILED.
+		failed := transport.EncodeENH(transport.ENHResFailed, winner)
+		_, err := server.Write(failed[:])
+		serverErr <- err
+	}()
+
+	if err := enh.RequestStart(initiator); err != nil {
+		t.Fatalf("RequestStart error = %v", err)
+	}
+
+	reader, ok := interface{}(enh).(transport.StreamEventReader)
+	if !ok {
+		t.Fatal("ENH transport does not implement StreamEventReader")
+	}
+
+	event, err := reader.ReadEvent()
+	if err != nil {
+		t.Fatalf("ReadEvent error = %v", err)
+	}
+	if event.Kind != transport.StreamEventFailed {
+		t.Fatalf("ReadEvent kind = %v; want StreamEventFailed", event.Kind)
+	}
+	if event.Data != winner {
+		t.Fatalf("ReadEvent data = 0x%02x; want 0x%02x", event.Data, winner)
+	}
+
+	if err := <-serverErr; err != nil {
+		t.Fatalf("server error = %v", err)
+	}
+}
+
+func TestENHTransport_ReadByteIgnoresStartedFailed(t *testing.T) {
+	t.Parallel()
+
+	client, server := net.Pipe()
+	defer func() { _ = client.Close() }()
+	defer func() { _ = server.Close() }()
+
+	enh := transport.NewENHTransport(client, 200*time.Millisecond, 200*time.Millisecond)
+	initiator := byte(0x10)
+
+	serverErr := make(chan error, 1)
+	go func() {
+		defer close(serverErr)
+
+		// Read the START request.
+		buf := make([]byte, 2)
+		if _, err := io.ReadFull(server, buf); err != nil {
+			serverErr <- err
+			return
+		}
+
+		// Send STARTED then a RECEIVED byte. ReadByte must skip STARTED
+		// and return only the RECEIVED byte.
+		started := transport.EncodeENH(transport.ENHResStarted, initiator)
+		received := transport.EncodeENH(transport.ENHResReceived, 0x42)
+		payload := append(started[:], received[:]...)
+		_, err := server.Write(payload)
+		serverErr <- err
+	}()
+
+	if err := enh.RequestStart(initiator); err != nil {
+		t.Fatalf("RequestStart error = %v", err)
+	}
+
+	got, err := enh.ReadByte()
+	if err != nil {
+		t.Fatalf("ReadByte error = %v", err)
+	}
+	if got != 0x42 {
+		t.Fatalf("ReadByte = 0x%02x; want 0x42 (should skip STARTED)", got)
+	}
+
+	if err := <-serverErr; err != nil {
+		t.Fatalf("server error = %v", err)
+	}
+}

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -20,15 +20,19 @@ type RawTransport interface {
 type StreamEventKind uint8
 
 const (
-	StreamEventByte StreamEventKind = iota + 1
+	StreamEventByte    StreamEventKind = iota + 1
 	StreamEventReset
+	StreamEventStarted // adapter confirmed START arbitration
+	StreamEventFailed  // adapter rejected START arbitration
 )
 
-// StreamEvent is a transport-stream item. Byte is only valid for
-// StreamEventByte.
+// StreamEvent is a transport-stream item. Byte is valid for
+// StreamEventByte. Data is valid for StreamEventStarted (confirmed
+// initiator address) and StreamEventFailed (winner address).
 type StreamEvent struct {
 	Kind StreamEventKind
-	Byte byte
+	Byte byte // valid for StreamEventByte
+	Data byte // valid for StreamEventStarted, StreamEventFailed
 }
 
 // StreamEventReader is an optional extension implemented by transports that


### PR DESCRIPTION
## Summary
- Add `StreamEventStarted` and `StreamEventFailed` event kinds plus a `Data byte` field to `StreamEvent` for carrying initiator/winner addresses during arbitration
- Refactor `ENHTransport` internal queue from `pending []byte` to `pendingEvents []StreamEvent` so `fillPendingLocked` can surface STARTED/FAILED responses via `ReadEvent` while `ReadByte` automatically skips non-byte events
- Add `RequestStart(byte) error` method for fire-and-forget START arbitration that only holds `writeMu`, enabling a concurrent `ReadEvent` loop to consume the response without deadlock

## Test plan
- [x] `TestENHTransport_RequestStartSurfacesStarted` -- send RequestStart, mock adapter responds STARTED, verify ReadEvent returns StreamEventStarted with correct Data
- [x] `TestENHTransport_RequestStartSurfacesFailed` -- same flow but FAILED, verify ReadEvent returns StreamEventFailed with winner address
- [x] `TestENHTransport_ReadByteIgnoresStartedFailed` -- send RequestStart, adapter responds STARTED then RECEIVED, verify ReadByte skips STARTED and returns only the RECEIVED byte
- [x] All 31 existing transport tests pass (race detector enabled)
- [x] `go vet ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)