### PR TITLE
fix: ENH parser desync recovery — stop reconnect storm (#129)

### DIFF
--- a/transport/enh_transport.go
+++ b/transport/enh_transport.go
@@ -621,6 +621,16 @@ func (t *ENHTransport) fillPendingLocked() error {
 
 	msgs, err := t.parser.Parse(t.buffer[:bytesRead])
 	if err != nil {
+		if errors.Is(err, ebuserrors.ErrInvalidPayload) {
+			// Parser desync: orphan byte2 or missing byte2, typically caused
+			// by RESETTED handler destroying pending state mid-iteration, or
+			// by TCP fragmentation delivering partial ENH frames. Reset the
+			// parser to re-synchronize on the next valid byte1 (>= 0xC0).
+			// Any messages parsed before the desync point are lost — this is
+			// acceptable vs the alternative of a full TCP reconnect.
+			t.parser.Reset()
+			return nil
+		}
 		return err
 	}
 	for _, msg := range msgs {
@@ -636,17 +646,22 @@ func (t *ENHTransport) fillPendingLocked() error {
 			case ENHResFailed:
 				t.pendingEvents = append(t.pendingEvents, StreamEvent{Kind: StreamEventFailed, Data: msg.Data})
 			case ENHResResetted:
-				if reconnErr := t.reconnectLocked(); reconnErr != nil {
-					return fmt.Errorf("enh adapter reset during read, reconnect failed: %w", ebuserrors.ErrTransportClosed)
-				}
-				t.resets++ // signal ErrAdapterReset to ReadByte caller
 				if t.dialFunc != nil {
+					if reconnErr := t.reconnectLocked(); reconnErr != nil {
+						return fmt.Errorf("enh adapter reset during read, reconnect failed: %w", ebuserrors.ErrTransportClosed)
+					}
+					t.resets++
 					// Reconnected to fresh TCP — remaining msgs were
 					// parsed from the old stream and are stale.
 					return nil
 				}
-				// Parser-only reset (no dialFunc): continue processing
-				// remaining msgs from the same TCP stream.
+				// Adapter-direct mode (no dialFunc): do NOT call
+				// reconnectLocked/resetStateLocked here — parser.Reset()
+				// would destroy pending state for bytes that Parse()
+				// already consumed from the TCP buffer past the RESETTED
+				// frame. Just clear the event queue and signal the reset.
+				t.pendingEvents = nil
+				t.resets++
 			}
 		}
 	}

--- a/transport/enh_transport_test.go
+++ b/transport/enh_transport_test.go
@@ -1276,3 +1276,105 @@ func TestENHTransport_ReadByteIgnoresStartedFailed(t *testing.T) {
 		t.Fatalf("server error = %v", err)
 	}
 }
+
+func TestENHTransport_ReadEventRecoverFromParserDesync(t *testing.T) {
+	// Send an orphan byte2 (0x85, in range 0x80-0xBF) without a preceding
+	// byte1. This triggers ErrInvalidPayload in the parser. The transport
+	// should recover by resetting the parser, not propagate a fatal error.
+	// Subsequent bytes should be readable.
+	t.Parallel()
+
+	client, server := net.Pipe()
+	defer func() { _ = client.Close() }()
+	defer func() { _ = server.Close() }()
+
+	enh := transport.NewENHTransport(client, 200*time.Millisecond, 200*time.Millisecond)
+
+	serverErr := make(chan error, 1)
+	go func() {
+		defer close(serverErr)
+		// First write: orphan byte2 (triggers desync)
+		_, err := server.Write([]byte{0x85})
+		if err != nil {
+			serverErr <- err
+			return
+		}
+		// Second write: valid raw data byte (should be readable after recovery)
+		_, err = server.Write([]byte{0x42})
+		serverErr <- err
+	}()
+
+	reader, ok := interface{}(enh).(transport.StreamEventReader)
+	if !ok {
+		t.Fatal("ENH transport does not implement StreamEventReader")
+	}
+
+	// First ReadEvent: the orphan byte should be absorbed by recovery,
+	// not returned as an error.
+	event, err := reader.ReadEvent()
+	if err != nil {
+		t.Fatalf("ReadEvent after orphan byte error = %v; want recovery (no error)", err)
+	}
+	// The recovered read should deliver the 0x42 byte.
+	if event.Kind != transport.StreamEventByte || event.Byte != 0x42 {
+		t.Fatalf("ReadEvent after recovery = %+v; want StreamEventByte(0x42)", event)
+	}
+
+	if err := <-serverErr; err != nil {
+		t.Fatalf("server error = %v", err)
+	}
+}
+
+func TestENHTransport_ResetPreservesParserStateForTrailingFrame(t *testing.T) {
+	// Send [RESETTED, RECEIVED(0x33)] in one TCP segment. The RESETTED
+	// handler must NOT destroy parser state for the trailing RECEIVED frame.
+	// Before the fix, reconnectLocked() → parser.Reset() would clear pending
+	// byte1 state, making RECEIVED's byte2 appear as an orphan.
+	t.Parallel()
+
+	client, server := net.Pipe()
+	defer func() { _ = client.Close() }()
+	defer func() { _ = server.Close() }()
+
+	enh := transport.NewENHTransport(client, 200*time.Millisecond, 200*time.Millisecond)
+
+	serverErr := make(chan error, 1)
+	go func() {
+		defer close(serverErr)
+		reset := transport.EncodeENH(transport.ENHResResetted, 0x00)
+		received := transport.EncodeENH(transport.ENHResReceived, 0x33)
+		// Single TCP write: RESETTED followed immediately by RECEIVED
+		payload := append(reset[:], received[:]...)
+		_, err := server.Write(payload)
+		serverErr <- err
+	}()
+
+	reader, ok := interface{}(enh).(transport.StreamEventReader)
+	if !ok {
+		t.Fatal("ENH transport does not implement StreamEventReader")
+	}
+
+	// First event: RESETTED → StreamEventReset
+	event, err := reader.ReadEvent()
+	if err != nil {
+		t.Fatalf("ReadEvent error = %v", err)
+	}
+	if event.Kind != transport.StreamEventReset {
+		t.Fatalf("ReadEvent kind = %v; want StreamEventReset", event.Kind)
+	}
+
+	// Second event: RECEIVED(0x33) → StreamEventByte(0x33)
+	// This must work — the parser state for the RECEIVED frame must survive
+	// the RESETTED handler.
+	event, err = reader.ReadEvent()
+	if err != nil {
+		t.Fatalf("ReadEvent after RESETTED error = %v; want 0x33", err)
+	}
+	if event.Kind != transport.StreamEventByte || event.Byte != 0x33 {
+		t.Fatalf("ReadEvent after RESETTED = %+v; want StreamEventByte(0x33)", event)
+	}
+
+	if err := <-serverErr; err != nil {
+		t.Fatalf("server error = %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- Bug 1: Catch ErrInvalidPayload in fillPendingLocked, reset parser, return nil (recoverable, not fatal)
- Bug 2: RESETTED handler when dialFunc==nil: clear pendingEvents but preserve parser state (don't destroy pending byte1)

## Test plan
- [x] `go test -race -count=1 ./...` — all pass
- [x] TestENHTransport_ReadEventRecoverFromParserDesync — orphan byte absorbed
- [x] TestENHTransport_ResetPreservesParserStateForTrailingFrame — RESETTED + RECEIVED in one segment
- [ ] Deploy: reconnect storm should stop

Closes #129

🤖 Generated with [Claude Code](https://claude.com/claude-code)