### PR TITLE
fix(transport): process INIT parse results before handling error

### DIFF
--- a/transport/enh_transport.go
+++ b/transport/enh_transport.go
@@ -167,10 +167,10 @@ func (t *ENHTransport) initRecvLocked() (byte, error) {
 			continue
 		}
 
-		msgs, err := t.parser.Parse(t.buffer[:n])
-		if err != nil {
-			return 0, err
-		}
+		msgs, parseErr := t.parser.Parse(t.buffer[:n])
+
+		// Process valid messages before handling parse error — a valid
+		// RESETTED followed by a corrupt trailing byte should succeed.
 		for _, msg := range msgs {
 			switch msg.Command {
 			case ENHResReceived:
@@ -185,6 +185,10 @@ func (t *ENHTransport) initRecvLocked() (byte, error) {
 			case ENHResErrorHost:
 				return 0, fmt.Errorf("enh init host error 0x%02x: %w", msg.Data, ebuserrors.ErrAdapterHostError)
 			}
+		}
+		if parseErr != nil {
+			t.parser.Reset()
+			return 0, parseErr
 		}
 	}
 }

--- a/transport/enh_transport_test.go
+++ b/transport/enh_transport_test.go
@@ -91,6 +91,43 @@ func TestENHTransport_InitHandshake(t *testing.T) {
 	}
 }
 
+func TestENHTransport_InitSucceedsWithTrailingCorruptByte(t *testing.T) {
+	t.Parallel()
+
+	client, server := net.Pipe()
+	defer func() { _ = client.Close() }()
+	defer func() { _ = server.Close() }()
+
+	enh := transport.NewENHTransport(client, 200*time.Millisecond, 200*time.Millisecond)
+
+	serverErr := make(chan error, 1)
+	go func() {
+		defer close(serverErr)
+		buf := make([]byte, 2)
+		if _, err := io.ReadFull(server, buf); err != nil {
+			serverErr <- err
+			return
+		}
+		// Send valid RESETTED frame followed by a corrupt trailing byte
+		// in the same TCP segment. Init must succeed despite the parse error.
+		resp := transport.EncodeENH(transport.ENHResResetted, 0x01)
+		payload := append(resp[:], 0x85) // 0x85 = orphan ENH byte2 (corrupt)
+		_, err := server.Write(payload)
+		serverErr <- err
+	}()
+
+	features, err := enh.Init(0x00)
+	if err != nil {
+		t.Fatalf("Init error = %v; want success (RESETTED was valid, trailing byte corrupt)", err)
+	}
+	if features != 0x01 {
+		t.Fatalf("Init features = 0x%02x; want 0x01", features)
+	}
+	if err := <-serverErr; err != nil {
+		t.Fatalf("server error = %v", err)
+	}
+}
+
 func TestENHTransport_InitReturnsAdapterFeatures(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Copilot P1 on PR #131 (comment 3084145838): `initRecvLocked` aborted on `Parse` error before consuming valid messages. A TCP buffer containing a valid `ENHResResetted` followed by a corrupt trailing byte would fail `Init()`/`Reconnect()` even though the INIT handshake acknowledgment was present.

Now processes valid messages first, then handles `parseErr` with parser reset — consistent with `StartArbitration`, `RequestInfo`, and `fillPendingLocked` which were already fixed in PR #131.

## Test plan
- [x] All existing tests pass with `-race`
- [x] `ci_local.sh` passes
- [x] Pattern is identical to the already-tested StartArbitration/RequestInfo/fillPendingLocked fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)