### PR TITLE
M1_TYPES: ebus_standard L7 primitive types (BYTE/CHAR/DATA1c/raw/BCD/length-selector) (meta #14)

### DIFF
--- a/protocol/ebus_standard/types/bcd.go
+++ b/protocol/ebus_standard/types/bcd.go
@@ -1,0 +1,41 @@
+package types
+
+// BCD is the single-byte packed BCD primitive, 02-l7-types.md §"Composite BCD"
+// single-byte rules. 0xFF is the primitive replacement sentinel.
+type BCD struct{}
+
+// Size returns the fixed width.
+func (BCD) Size() int { return 1 }
+
+// Decode parses one BCD byte; invalid nibbles surface InvalidNibble.
+func (BCD) Decode(payload []byte) Value {
+	panic("ebus_standard/types.BCD.Decode: not implemented")
+}
+
+// Encode serialises an integer in [0,99].
+func (BCD) Encode(value any) ([]byte, *DecodeError) {
+	panic("ebus_standard/types.BCD.Encode: not implemented")
+}
+
+// BCDComposite is an ordered sequence of BCD bytes that decode independently.
+// Components is informational and intended for composite date/time or
+// base-100-chunk counters (see 02-l7-types.md §"Composite BCD" composite
+// rules).
+type BCDComposite struct {
+	Components []string // field-level component labels (informational)
+}
+
+// Size returns the total byte width.
+func (c BCDComposite) Size() int { return len(c.Components) }
+
+// Decode validates each component; any invalid or replacement component
+// prevents emitting an aggregate value. The per-component diagnostics live in
+// the returned Value under the Value.Value field as a []Value.
+func (c BCDComposite) Decode(payload []byte) Value {
+	panic("ebus_standard/types.BCDComposite.Decode: not implemented")
+}
+
+// Encode serialises a []int ordered per Components.
+func (c BCDComposite) Encode(value any) ([]byte, *DecodeError) {
+	panic("ebus_standard/types.BCDComposite.Encode: not implemented")
+}

--- a/protocol/ebus_standard/types/bcd.go
+++ b/protocol/ebus_standard/types/bcd.go
@@ -9,18 +9,46 @@ func (BCD) Size() int { return 1 }
 
 // Decode parses one BCD byte; invalid nibbles surface InvalidNibble.
 func (BCD) Decode(payload []byte) Value {
-	panic("ebus_standard/types.BCD.Decode: not implemented")
+	if len(payload) == 0 {
+		return Value{Err: newDecodeError(ErrCodeTruncatedPayload, "BCD requires 1 byte")}
+	}
+	if len(payload) > 1 {
+		return Value{Raw: cloneBytes(payload), Err: newDecodeError(ErrCodeOverlongPayload, "BCD consumes exactly 1 byte")}
+	}
+	return decodeSingleBCD(payload[0], cloneBytes(payload))
+}
+
+// decodeSingleBCD decodes exactly one BCD byte with the supplied Raw slice.
+// Shared between BCD and BCDComposite.
+func decodeSingleBCD(b byte, raw []byte) Value {
+	if b == 0xFF {
+		return Value{Raw: raw, Replacement: true}
+	}
+	tens := b >> 4
+	ones := b & 0x0F
+	if tens > 9 || ones > 9 {
+		return Value{Raw: raw, Err: newDecodeError(ErrCodeInvalidNibble, "BCD nibble greater than 9")}
+	}
+	return Value{
+		Raw:   raw,
+		Value: int(tens)*10 + int(ones),
+		Valid: true,
+	}
 }
 
 // Encode serialises an integer in [0,99].
 func (BCD) Encode(value any) ([]byte, *DecodeError) {
-	panic("ebus_standard/types.BCD.Encode: not implemented")
+	i, ok := toInt64(value)
+	if !ok {
+		return nil, newDecodeError(ErrCodeInvalidArgument, "BCD.Encode requires an integer")
+	}
+	if i < 0 || i > 99 {
+		return nil, newDecodeError(ErrCodeOutOfRange, "BCD value must be in [0,99]")
+	}
+	return []byte{byte(i/10)<<4 | byte(i%10)}, nil
 }
 
 // BCDComposite is an ordered sequence of BCD bytes that decode independently.
-// Components is informational and intended for composite date/time or
-// base-100-chunk counters (see 02-l7-types.md §"Composite BCD" composite
-// rules).
 type BCDComposite struct {
 	Components []string // field-level component labels (informational)
 }
@@ -29,13 +57,63 @@ type BCDComposite struct {
 func (c BCDComposite) Size() int { return len(c.Components) }
 
 // Decode validates each component; any invalid or replacement component
-// prevents emitting an aggregate value. The per-component diagnostics live in
-// the returned Value under the Value.Value field as a []Value.
+// prevents emitting an aggregate value.
 func (c BCDComposite) Decode(payload []byte) Value {
-	panic("ebus_standard/types.BCDComposite.Decode: not implemented")
+	width := len(c.Components)
+	if len(payload) < width {
+		return Value{Raw: cloneBytes(payload), Err: newDecodeError(ErrCodeTruncatedPayload, "BCDComposite payload shorter than Components")}
+	}
+	if len(payload) > width {
+		return Value{Raw: cloneBytes(payload), Err: newDecodeError(ErrCodeOverlongPayload, "BCDComposite payload longer than Components")}
+	}
+	raw := cloneBytes(payload)
+	parts := make([]Value, width)
+	var (
+		firstErr        *DecodeError
+		anyReplacement  bool
+		anyInvalid      bool
+	)
+	for i := 0; i < width; i++ {
+		partRaw := []byte{raw[i]}
+		parts[i] = decodeSingleBCD(raw[i], partRaw)
+		if parts[i].Err != nil {
+			anyInvalid = true
+			if firstErr == nil {
+				firstErr = parts[i].Err
+			}
+		}
+		if parts[i].Replacement {
+			anyReplacement = true
+		}
+	}
+	out := Value{Raw: raw, Value: parts}
+	if anyInvalid {
+		out.Err = firstErr
+		return out
+	}
+	if anyReplacement {
+		out.Replacement = true
+		return out
+	}
+	out.Valid = true
+	return out
 }
 
 // Encode serialises a []int ordered per Components.
 func (c BCDComposite) Encode(value any) ([]byte, *DecodeError) {
-	panic("ebus_standard/types.BCDComposite.Encode: not implemented")
+	ints, ok := value.([]int)
+	if !ok {
+		return nil, newDecodeError(ErrCodeInvalidArgument, "BCDComposite.Encode requires []int")
+	}
+	if len(ints) != len(c.Components) {
+		return nil, newDecodeError(ErrCodeInvalidArgument, "BCDComposite.Encode arity does not match Components")
+	}
+	out := make([]byte, len(ints))
+	for i, v := range ints {
+		if v < 0 || v > 99 {
+			return nil, newDecodeError(ErrCodeOutOfRange, "BCDComposite component out of [0,99]")
+		}
+		out[i] = byte(v/10)<<4 | byte(v%10)
+	}
+	return out, nil
 }

--- a/protocol/ebus_standard/types/bcd.go
+++ b/protocol/ebus_standard/types/bcd.go
@@ -69,9 +69,9 @@ func (c BCDComposite) Decode(payload []byte) Value {
 	raw := cloneBytes(payload)
 	parts := make([]Value, width)
 	var (
-		firstErr        *DecodeError
-		anyReplacement  bool
-		anyInvalid      bool
+		firstErr       *DecodeError
+		anyReplacement bool
+		anyInvalid     bool
 	)
 	for i := 0; i < width; i++ {
 		partRaw := []byte{raw[i]}

--- a/protocol/ebus_standard/types/bcd_test.go
+++ b/protocol/ebus_standard/types/bcd_test.go
@@ -1,0 +1,184 @@
+package types
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestBCD_DecodePositive(t *testing.T) {
+	cases := []struct {
+		in   byte
+		want int
+	}{
+		{0x00, 0},
+		{0x09, 9},
+		{0x42, 42},
+		{0x99, 99},
+	}
+	for _, tc := range cases {
+		got := BCD{}.Decode([]byte{tc.in})
+		if !got.Valid {
+			t.Fatalf("0x%02X invalid: %+v", tc.in, got)
+		}
+		v, ok := got.Value.(int)
+		if !ok {
+			t.Fatalf("want int, got %T", got.Value)
+		}
+		if v != tc.want {
+			t.Fatalf("0x%02X: got %d want %d", tc.in, v, tc.want)
+		}
+	}
+}
+
+func TestBCD_DecodeReplacement(t *testing.T) {
+	got := BCD{}.Decode([]byte{0xFF})
+	if got.Valid {
+		t.Fatalf("replacement must not be Valid")
+	}
+	if !got.Replacement {
+		t.Fatalf("want Replacement=true")
+	}
+	if got.Err != nil {
+		t.Fatalf("replacement must not produce err, got %+v", got.Err)
+	}
+}
+
+func TestBCD_DecodeInvalidNibble(t *testing.T) {
+	// High nibble invalid
+	got := BCD{}.Decode([]byte{0xA0})
+	if got.Err == nil || got.Err.Code != ErrCodeInvalidNibble {
+		t.Fatalf("want invalid_nibble, got %+v", got.Err)
+	}
+	// Low nibble invalid
+	got = BCD{}.Decode([]byte{0x0B})
+	if got.Err == nil || got.Err.Code != ErrCodeInvalidNibble {
+		t.Fatalf("want invalid_nibble, got %+v", got.Err)
+	}
+}
+
+func TestBCD_DecodeTruncated(t *testing.T) {
+	got := BCD{}.Decode(nil)
+	if got.Err == nil || got.Err.Code != ErrCodeTruncatedPayload {
+		t.Fatalf("want truncated, got %+v", got.Err)
+	}
+}
+
+func TestBCD_DecodeOverlong(t *testing.T) {
+	got := BCD{}.Decode([]byte{0x01, 0x02})
+	if got.Err == nil || got.Err.Code != ErrCodeOverlongPayload {
+		t.Fatalf("want overlong, got %+v", got.Err)
+	}
+}
+
+func TestBCD_Encode(t *testing.T) {
+	got, err := BCD{}.Encode(42)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if !bytes.Equal(got, []byte{0x42}) {
+		t.Fatalf("got %v", got)
+	}
+	codec := BCD{}
+	if _, err := codec.Encode(100); err == nil || err.Code != ErrCodeOutOfRange {
+		t.Fatalf("want out_of_range, got %+v", err)
+	}
+	if _, err := codec.Encode(-1); err == nil || err.Code != ErrCodeOutOfRange {
+		t.Fatalf("want out_of_range, got %+v", err)
+	}
+}
+
+func TestBCDComposite_DecodeAllValid(t *testing.T) {
+	c := BCDComposite{Components: []string{"sec", "min", "hour"}}
+	got := c.Decode([]byte{0x30, 0x45, 0x12}) // 30 seconds, 45 minutes, 12 hours
+	if !got.Valid {
+		t.Fatalf("want valid: %+v", got)
+	}
+	parts, ok := got.Value.([]Value)
+	if !ok {
+		t.Fatalf("want []Value for composite, got %T", got.Value)
+	}
+	if len(parts) != 3 {
+		t.Fatalf("want 3 parts, got %d", len(parts))
+	}
+	want := []int{30, 45, 12}
+	for i, p := range parts {
+		if !p.Valid {
+			t.Fatalf("part %d invalid: %+v", i, p)
+		}
+		if v := p.Value.(int); v != want[i] {
+			t.Fatalf("part %d: got %d want %d", i, v, want[i])
+		}
+	}
+}
+
+func TestBCDComposite_DecodeComponentInvalidNibble(t *testing.T) {
+	c := BCDComposite{Components: []string{"sec", "min"}}
+	got := c.Decode([]byte{0xA0, 0x12}) // invalid first component
+	if got.Valid {
+		t.Fatalf("want composite invalid")
+	}
+	if got.Err == nil || got.Err.Code != ErrCodeInvalidNibble {
+		t.Fatalf("want invalid_nibble, got %+v", got.Err)
+	}
+	// Diagnostics should still expose both parts.
+	parts, ok := got.Value.([]Value)
+	if !ok {
+		t.Fatalf("want diagnostic []Value, got %T", got.Value)
+	}
+	if len(parts) != 2 {
+		t.Fatalf("want 2 diag parts, got %d", len(parts))
+	}
+	if parts[0].Valid {
+		t.Fatalf("part 0 must be invalid")
+	}
+	if !parts[1].Valid {
+		t.Fatalf("part 1 must remain valid in diagnostics")
+	}
+}
+
+func TestBCDComposite_DecodeReplacementPropagates(t *testing.T) {
+	c := BCDComposite{Components: []string{"sec", "min"}}
+	got := c.Decode([]byte{0x30, 0xFF})
+	if got.Valid {
+		t.Fatalf("any replacement must make composite invalid")
+	}
+	if !got.Replacement {
+		t.Fatalf("want Replacement=true")
+	}
+	if got.Err != nil {
+		t.Fatalf("replacement-caused invalidity must not set err, got %+v", got.Err)
+	}
+}
+
+func TestBCDComposite_DecodeTruncated(t *testing.T) {
+	c := BCDComposite{Components: []string{"a", "b", "c"}}
+	got := c.Decode([]byte{0x01, 0x02})
+	if got.Err == nil || got.Err.Code != ErrCodeTruncatedPayload {
+		t.Fatalf("want truncated, got %+v", got.Err)
+	}
+}
+
+func TestBCDComposite_DecodeOverlong(t *testing.T) {
+	c := BCDComposite{Components: []string{"a", "b"}}
+	got := c.Decode([]byte{0x01, 0x02, 0x03})
+	if got.Err == nil || got.Err.Code != ErrCodeOverlongPayload {
+		t.Fatalf("want overlong, got %+v", got.Err)
+	}
+}
+
+func TestBCDComposite_Encode(t *testing.T) {
+	c := BCDComposite{Components: []string{"a", "b"}}
+	got, err := c.Encode([]int{12, 34})
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if !bytes.Equal(got, []byte{0x12, 0x34}) {
+		t.Fatalf("got %v", got)
+	}
+	if _, err := c.Encode([]int{1}); err == nil || err.Code != ErrCodeInvalidArgument {
+		t.Fatalf("want invalid_argument (arity), got %+v", err)
+	}
+	if _, err := c.Encode([]int{100, 0}); err == nil || err.Code != ErrCodeOutOfRange {
+		t.Fatalf("want out_of_range (component), got %+v", err)
+	}
+}

--- a/protocol/ebus_standard/types/byte.go
+++ b/protocol/ebus_standard/types/byte.go
@@ -1,0 +1,21 @@
+package types
+
+// BYTE is the single-octet unsigned primitive defined in
+// 02-l7-types.md §"BYTE".
+//
+// The primitive itself has no replacement sentinel. Fields that want a
+// replacement byte MUST declare it at the catalog-field layer.
+type BYTE struct{}
+
+// Size returns the fixed width of a BYTE primitive.
+func (BYTE) Size() int { return 1 }
+
+// Decode parses a single unsigned byte.
+func (BYTE) Decode(payload []byte) Value {
+	panic("ebus_standard/types.BYTE.Decode: not implemented")
+}
+
+// Encode serialises an integer in [0,255] as a single byte.
+func (BYTE) Encode(value any) ([]byte, *DecodeError) {
+	panic("ebus_standard/types.BYTE.Encode: not implemented")
+}

--- a/protocol/ebus_standard/types/byte.go
+++ b/protocol/ebus_standard/types/byte.go
@@ -12,10 +12,27 @@ func (BYTE) Size() int { return 1 }
 
 // Decode parses a single unsigned byte.
 func (BYTE) Decode(payload []byte) Value {
-	panic("ebus_standard/types.BYTE.Decode: not implemented")
+	if len(payload) == 0 {
+		return Value{Raw: nil, Err: newDecodeError(ErrCodeTruncatedPayload, "BYTE requires 1 byte")}
+	}
+	if len(payload) > 1 {
+		return Value{Raw: cloneBytes(payload), Err: newDecodeError(ErrCodeOverlongPayload, "BYTE consumes exactly 1 byte")}
+	}
+	return Value{
+		Raw:   cloneBytes(payload),
+		Value: payload[0],
+		Valid: true,
+	}
 }
 
 // Encode serialises an integer in [0,255] as a single byte.
 func (BYTE) Encode(value any) ([]byte, *DecodeError) {
-	panic("ebus_standard/types.BYTE.Encode: not implemented")
+	i, ok := toInt64(value)
+	if !ok {
+		return nil, newDecodeError(ErrCodeInvalidArgument, "BYTE.Encode requires an integer")
+	}
+	if i < 0 || i > 255 {
+		return nil, newDecodeError(ErrCodeOutOfRange, "BYTE value must be in [0,255]")
+	}
+	return []byte{byte(i)}, nil
 }

--- a/protocol/ebus_standard/types/byte_test.go
+++ b/protocol/ebus_standard/types/byte_test.go
@@ -1,0 +1,113 @@
+package types
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestBYTE_DecodePositive(t *testing.T) {
+	cases := []struct {
+		name string
+		in   []byte
+		want uint8
+	}{
+		{"zero", []byte{0x00}, 0},
+		{"mid", []byte{0x7F}, 127},
+		{"high", []byte{0xFF}, 255},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := BYTE{}.Decode(tc.in)
+			if !got.Valid {
+				t.Fatalf("want Valid=true, got %+v", got)
+			}
+			if got.Replacement {
+				t.Fatalf("BYTE primitive has no replacement sentinel; got Replacement=true")
+			}
+			if got.Err != nil {
+				t.Fatalf("unexpected err: %v", got.Err)
+			}
+			if !bytes.Equal(got.Raw, tc.in) {
+				t.Fatalf("raw mismatch: got %v want %v", got.Raw, tc.in)
+			}
+			v, ok := got.Value.(uint8)
+			if !ok {
+				t.Fatalf("want uint8, got %T (%v)", got.Value, got.Value)
+			}
+			if v != tc.want {
+				t.Fatalf("value mismatch: got %d want %d", v, tc.want)
+			}
+		})
+	}
+}
+
+func TestBYTE_DecodeTruncated(t *testing.T) {
+	got := BYTE{}.Decode(nil)
+	if got.Valid {
+		t.Fatalf("want Valid=false on truncated input")
+	}
+	if got.Replacement {
+		t.Fatalf("truncated must not be replacement")
+	}
+	if got.Err == nil || got.Err.Code != ErrCodeTruncatedPayload {
+		t.Fatalf("want truncated_payload, got %+v", got.Err)
+	}
+}
+
+func TestBYTE_DecodeOverlong(t *testing.T) {
+	got := BYTE{}.Decode([]byte{0x10, 0x20})
+	if got.Valid {
+		t.Fatalf("want Valid=false on overlong input")
+	}
+	if got.Err == nil || got.Err.Code != ErrCodeOverlongPayload {
+		t.Fatalf("want overlong_payload, got %+v", got.Err)
+	}
+}
+
+func TestBYTE_EncodePositive(t *testing.T) {
+	cases := []struct {
+		in   any
+		want []byte
+	}{
+		{0, []byte{0x00}},
+		{255, []byte{0xFF}},
+		{uint8(42), []byte{0x2A}},
+	}
+	for _, tc := range cases {
+		got, err := BYTE{}.Encode(tc.in)
+		if err != nil {
+			t.Fatalf("unexpected err for %v: %v", tc.in, err)
+		}
+		if !bytes.Equal(got, tc.want) {
+			t.Fatalf("encode %v: got %v want %v", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestBYTE_EncodeOutOfRange(t *testing.T) {
+	for _, v := range []int{-1, 256, 1000} {
+		_, err := BYTE{}.Encode(v)
+		if err == nil || err.Code != ErrCodeOutOfRange {
+			t.Fatalf("want out_of_range for %d, got %+v", v, err)
+		}
+	}
+}
+
+func TestBYTE_EncodeWrongType(t *testing.T) {
+	_, err := BYTE{}.Encode("hello")
+	if err == nil || err.Code != ErrCodeInvalidArgument {
+		t.Fatalf("want invalid_argument, got %+v", err)
+	}
+}
+
+func TestBYTE_RawIsDefensiveCopy(t *testing.T) {
+	in := []byte{0x42}
+	got := BYTE{}.Decode(in)
+	if !got.Valid {
+		t.Fatalf("unexpected invalid")
+	}
+	in[0] = 0xAA
+	if got.Raw[0] != 0x42 {
+		t.Fatalf("Raw must be a defensive copy (got %#x)", got.Raw[0])
+	}
+}

--- a/protocol/ebus_standard/types/char.go
+++ b/protocol/ebus_standard/types/char.go
@@ -101,12 +101,24 @@ func (c CHARText) Decode(payload []byte) Value {
 	}
 	raw := cloneBytes(payload)
 
-	// Display: strip trailing 0x00 / 0x20 for display only; raw bytes remain
-	// authoritative. Non-printable bytes are escaped as \xHH so consumers can
-	// tell they were present.
+	// Display: strip trailing pad bytes for display only; raw bytes remain
+	// authoritative. Per 02-l7-types.md §CHAR rule 6, default padding is
+	// 0x00 / 0x20 when the catalog field does not declare a different pad.
+	// When c.Pad is explicitly set (e.g. 0xFF), that byte is ALSO treated as
+	// trailing padding for display purposes. Non-printable bytes not stripped
+	// as padding are escaped as \xHH so consumers can tell they were present.
 	end := len(raw)
-	for end > 0 && (raw[end-1] == 0x00 || raw[end-1] == 0x20) {
-		end--
+	for end > 0 {
+		b := raw[end-1]
+		if b == 0x00 || b == 0x20 {
+			end--
+			continue
+		}
+		if c.Pad != nil && b == *c.Pad {
+			end--
+			continue
+		}
+		break
 	}
 	var b strings.Builder
 	for _, by := range raw[:end] {

--- a/protocol/ebus_standard/types/char.go
+++ b/protocol/ebus_standard/types/char.go
@@ -104,17 +104,22 @@ func (c CHARText) Decode(payload []byte) Value {
 	// Display: strip trailing pad bytes for display only; raw bytes remain
 	// authoritative. Per 02-l7-types.md §CHAR rule 6, default padding is
 	// 0x00 / 0x20 when the catalog field does not declare a different pad.
-	// When c.Pad is explicitly set (e.g. 0xFF), that byte is ALSO treated as
-	// trailing padding for display purposes. Non-printable bytes not stripped
-	// as padding are escaped as \xHH so consumers can tell they were present.
+	// When c.Pad is explicitly set (e.g. 0xFF), the catalog field's declared
+	// pad byte is an OVERRIDE of the default — only that byte is treated as
+	// trailing padding, so genuine trailing 0x00 / 0x20 bytes remain visible
+	// in the display string. Non-printable bytes not stripped as padding are
+	// escaped as \xHH so consumers can tell they were present.
 	end := len(raw)
 	for end > 0 {
 		b := raw[end-1]
-		if b == 0x00 || b == 0x20 {
-			end--
-			continue
+		if c.Pad != nil {
+			if b == *c.Pad {
+				end--
+				continue
+			}
+			break
 		}
-		if c.Pad != nil && b == *c.Pad {
+		if b == 0x00 || b == 0x20 {
 			end--
 			continue
 		}

--- a/protocol/ebus_standard/types/char.go
+++ b/protocol/ebus_standard/types/char.go
@@ -1,0 +1,59 @@
+package types
+
+// CHAR is the single-octet CHAR primitive defined in 02-l7-types.md §"CHAR".
+//
+// Signedness, replacement bytes, and fixed-width text semantics are
+// catalog-field metadata. The primitive itself decodes one byte as unsigned
+// uint8 by default; callers that want signed/text semantics use CHARSigned or
+// CHARText.
+type CHAR struct{}
+
+// Size returns the fixed width of a CHAR primitive.
+func (CHAR) Size() int { return 1 }
+
+// Decode parses a single byte as unsigned uint8.
+func (CHAR) Decode(payload []byte) Value {
+	panic("ebus_standard/types.CHAR.Decode: not implemented")
+}
+
+// Encode serialises an unsigned byte.
+func (CHAR) Encode(value any) ([]byte, *DecodeError) {
+	panic("ebus_standard/types.CHAR.Encode: not implemented")
+}
+
+// CHARSigned is a CHAR field declared as signed int8 per catalog metadata.
+type CHARSigned struct{}
+
+// Size returns the fixed width of a signed CHAR primitive.
+func (CHARSigned) Size() int { return 1 }
+
+// Decode parses a single byte as two's-complement int8.
+func (CHARSigned) Decode(payload []byte) Value {
+	panic("ebus_standard/types.CHARSigned.Decode: not implemented")
+}
+
+// Encode serialises a signed int in [-128,127] as one byte.
+func (CHARSigned) Encode(value any) ([]byte, *DecodeError) {
+	panic("ebus_standard/types.CHARSigned.Encode: not implemented")
+}
+
+// CHARText decodes a fixed-width CHAR[n] text field. The Width MUST be > 0.
+// Pad defaults to 0x20 (ASCII space) when zero.
+type CHARText struct {
+	Width int
+	Pad   byte
+}
+
+// Size returns the fixed width in bytes.
+func (c CHARText) Size() int { return c.Width }
+
+// Decode copies a Width-byte slice into Value.Raw and exposes a display
+// string (trailing 0x00 and 0x20 stripped, non-printable bytes escaped).
+func (c CHARText) Decode(payload []byte) Value {
+	panic("ebus_standard/types.CHARText.Decode: not implemented")
+}
+
+// Encode pads the supplied string/bytes to exactly Width bytes using Pad.
+func (c CHARText) Encode(value any) ([]byte, *DecodeError) {
+	panic("ebus_standard/types.CHARText.Encode: not implemented")
+}

--- a/protocol/ebus_standard/types/char.go
+++ b/protocol/ebus_standard/types/char.go
@@ -1,5 +1,10 @@
 package types
 
+import (
+	"fmt"
+	"strings"
+)
+
 // CHAR is the single-octet CHAR primitive defined in 02-l7-types.md §"CHAR".
 //
 // Signedness, replacement bytes, and fixed-width text semantics are
@@ -13,12 +18,29 @@ func (CHAR) Size() int { return 1 }
 
 // Decode parses a single byte as unsigned uint8.
 func (CHAR) Decode(payload []byte) Value {
-	panic("ebus_standard/types.CHAR.Decode: not implemented")
+	if len(payload) == 0 {
+		return Value{Err: newDecodeError(ErrCodeTruncatedPayload, "CHAR requires 1 byte")}
+	}
+	if len(payload) > 1 {
+		return Value{Raw: cloneBytes(payload), Err: newDecodeError(ErrCodeOverlongPayload, "CHAR consumes exactly 1 byte")}
+	}
+	return Value{
+		Raw:   cloneBytes(payload),
+		Value: payload[0],
+		Valid: true,
+	}
 }
 
 // Encode serialises an unsigned byte.
 func (CHAR) Encode(value any) ([]byte, *DecodeError) {
-	panic("ebus_standard/types.CHAR.Encode: not implemented")
+	i, ok := toInt64(value)
+	if !ok {
+		return nil, newDecodeError(ErrCodeInvalidArgument, "CHAR.Encode requires an integer")
+	}
+	if i < 0 || i > 255 {
+		return nil, newDecodeError(ErrCodeOutOfRange, "CHAR value must be in [0,255]")
+	}
+	return []byte{byte(i)}, nil
 }
 
 // CHARSigned is a CHAR field declared as signed int8 per catalog metadata.
@@ -29,19 +51,37 @@ func (CHARSigned) Size() int { return 1 }
 
 // Decode parses a single byte as two's-complement int8.
 func (CHARSigned) Decode(payload []byte) Value {
-	panic("ebus_standard/types.CHARSigned.Decode: not implemented")
+	if len(payload) == 0 {
+		return Value{Err: newDecodeError(ErrCodeTruncatedPayload, "CHARSigned requires 1 byte")}
+	}
+	if len(payload) > 1 {
+		return Value{Raw: cloneBytes(payload), Err: newDecodeError(ErrCodeOverlongPayload, "CHARSigned consumes exactly 1 byte")}
+	}
+	return Value{
+		Raw:   cloneBytes(payload),
+		Value: int8(payload[0]),
+		Valid: true,
+	}
 }
 
 // Encode serialises a signed int in [-128,127] as one byte.
 func (CHARSigned) Encode(value any) ([]byte, *DecodeError) {
-	panic("ebus_standard/types.CHARSigned.Encode: not implemented")
+	i, ok := toInt64(value)
+	if !ok {
+		return nil, newDecodeError(ErrCodeInvalidArgument, "CHARSigned.Encode requires an integer")
+	}
+	if i < -128 || i > 127 {
+		return nil, newDecodeError(ErrCodeOutOfRange, "CHARSigned value must be in [-128,127]")
+	}
+	return []byte{byte(int8(i))}, nil
 }
 
 // CHARText decodes a fixed-width CHAR[n] text field. The Width MUST be > 0.
-// Pad defaults to 0x20 (ASCII space) when zero.
+// Pad defaults to 0x20 (ASCII space) when nil; callers override by setting
+// Pad to the literal pad byte the catalog field declares (0x00, 0xFF, ...).
 type CHARText struct {
 	Width int
-	Pad   byte
+	Pad   *byte
 }
 
 // Size returns the fixed width in bytes.
@@ -50,10 +90,64 @@ func (c CHARText) Size() int { return c.Width }
 // Decode copies a Width-byte slice into Value.Raw and exposes a display
 // string (trailing 0x00 and 0x20 stripped, non-printable bytes escaped).
 func (c CHARText) Decode(payload []byte) Value {
-	panic("ebus_standard/types.CHARText.Decode: not implemented")
+	if c.Width <= 0 {
+		return Value{Err: newDecodeError(ErrCodeInvalidArgument, "CHARText.Width must be > 0")}
+	}
+	if len(payload) < c.Width {
+		return Value{Raw: cloneBytes(payload), Err: newDecodeError(ErrCodeTruncatedPayload, "CHARText requires exactly Width bytes")}
+	}
+	if len(payload) > c.Width {
+		return Value{Raw: cloneBytes(payload), Err: newDecodeError(ErrCodeOverlongPayload, "CHARText consumes exactly Width bytes")}
+	}
+	raw := cloneBytes(payload)
+
+	// Display: strip trailing 0x00 / 0x20 for display only; raw bytes remain
+	// authoritative. Non-printable bytes are escaped as \xHH so consumers can
+	// tell they were present.
+	end := len(raw)
+	for end > 0 && (raw[end-1] == 0x00 || raw[end-1] == 0x20) {
+		end--
+	}
+	var b strings.Builder
+	for _, by := range raw[:end] {
+		if by >= 0x20 && by <= 0x7E {
+			b.WriteByte(by)
+		} else {
+			fmt.Fprintf(&b, "\\x%02X", by)
+		}
+	}
+	return Value{
+		Raw:   raw,
+		Value: b.String(),
+		Valid: true,
+	}
 }
 
 // Encode pads the supplied string/bytes to exactly Width bytes using Pad.
 func (c CHARText) Encode(value any) ([]byte, *DecodeError) {
-	panic("ebus_standard/types.CHARText.Encode: not implemented")
+	if c.Width <= 0 {
+		return nil, newDecodeError(ErrCodeInvalidArgument, "CHARText.Width must be > 0")
+	}
+	var data []byte
+	switch v := value.(type) {
+	case string:
+		data = []byte(v)
+	case []byte:
+		data = append([]byte(nil), v...)
+	default:
+		return nil, newDecodeError(ErrCodeInvalidArgument, "CHARText.Encode requires string or []byte")
+	}
+	if len(data) > c.Width {
+		return nil, newDecodeError(ErrCodeFixedWidthExceeded, "CHARText input longer than Width")
+	}
+	var pad byte = 0x20
+	if c.Pad != nil {
+		pad = *c.Pad
+	}
+	out := make([]byte, c.Width)
+	copy(out, data)
+	for i := len(data); i < c.Width; i++ {
+		out[i] = pad
+	}
+	return out, nil
 }

--- a/protocol/ebus_standard/types/char_test.go
+++ b/protocol/ebus_standard/types/char_test.go
@@ -1,0 +1,133 @@
+package types
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestCHAR_DecodeUnsigned(t *testing.T) {
+	got := CHAR{}.Decode([]byte{0xC8})
+	if !got.Valid {
+		t.Fatalf("want Valid=true, got %+v", got)
+	}
+	v, ok := got.Value.(uint8)
+	if !ok || v != 200 {
+		t.Fatalf("want uint8(200), got %T(%v)", got.Value, got.Value)
+	}
+}
+
+func TestCHAR_DecodeTruncated(t *testing.T) {
+	got := CHAR{}.Decode(nil)
+	if got.Err == nil || got.Err.Code != ErrCodeTruncatedPayload {
+		t.Fatalf("want truncated_payload, got %+v", got.Err)
+	}
+}
+
+func TestCHAR_DecodeOverlong(t *testing.T) {
+	got := CHAR{}.Decode([]byte{0x01, 0x02})
+	if got.Err == nil || got.Err.Code != ErrCodeOverlongPayload {
+		t.Fatalf("want overlong_payload, got %+v", got.Err)
+	}
+}
+
+func TestCHARSigned_DecodePositive(t *testing.T) {
+	got := CHARSigned{}.Decode([]byte{0x7F})
+	if !got.Valid {
+		t.Fatalf("unexpected invalid")
+	}
+	if v, _ := got.Value.(int8); v != 127 {
+		t.Fatalf("want 127, got %v", got.Value)
+	}
+}
+
+func TestCHARSigned_DecodeNegative(t *testing.T) {
+	got := CHARSigned{}.Decode([]byte{0xFF})
+	if !got.Valid {
+		t.Fatalf("unexpected invalid for -1")
+	}
+	if v, _ := got.Value.(int8); v != -1 {
+		t.Fatalf("want -1, got %v", got.Value)
+	}
+}
+
+func TestCHARSigned_EncodeRange(t *testing.T) {
+	b, err := CHARSigned{}.Encode(-128)
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if !bytes.Equal(b, []byte{0x80}) {
+		t.Fatalf("got %v", b)
+	}
+	codec := CHARSigned{}
+	if _, err := codec.Encode(128); err == nil || err.Code != ErrCodeOutOfRange {
+		t.Fatalf("want out_of_range, got %+v", err)
+	}
+	if _, err := codec.Encode(-129); err == nil || err.Code != ErrCodeOutOfRange {
+		t.Fatalf("want out_of_range, got %+v", err)
+	}
+}
+
+func TestCHARText_DecodePreservesRawAndTrimsDisplay(t *testing.T) {
+	// 6-byte slot "AB\x00 Z " -> display "AB" "Z" wise: trailing 0x00 and 0x20 stripped
+	raw := []byte{'A', 'B', 0x00, 'Z', 0x20, 0x20}
+	got := CHARText{Width: 6}.Decode(raw)
+	if !got.Valid {
+		t.Fatalf("unexpected invalid, err=%v", got.Err)
+	}
+	if !bytes.Equal(got.Raw, raw) {
+		t.Fatalf("raw mismatch: %v vs %v", got.Raw, raw)
+	}
+	// Display text lives under Value.
+	s, ok := got.Value.(string)
+	if !ok {
+		t.Fatalf("want string display, got %T", got.Value)
+	}
+	// Trailing 0x00/0x20 stripped; embedded 0x00 must be escaped, not dropped.
+	if s == "" {
+		t.Fatalf("display empty; raw %v", raw)
+	}
+	// Must NOT simply equal "ABZ" by silently dropping the embedded 0x00:
+	// the display MUST escape non-printable bytes so consumers can tell.
+	if s == "ABZ" {
+		t.Fatalf("display dropped the embedded 0x00 silently: %q", s)
+	}
+}
+
+func TestCHARText_DecodeWrongLength(t *testing.T) {
+	c := CHARText{Width: 4}
+	if got := c.Decode([]byte{1, 2, 3}); got.Err == nil || got.Err.Code != ErrCodeTruncatedPayload {
+		t.Fatalf("want truncated, got %+v", got.Err)
+	}
+	if got := c.Decode([]byte{1, 2, 3, 4, 5}); got.Err == nil || got.Err.Code != ErrCodeOverlongPayload {
+		t.Fatalf("want overlong, got %+v", got.Err)
+	}
+}
+
+func TestCHARText_EncodePadsRight(t *testing.T) {
+	c := CHARText{Width: 4}
+	got, err := c.Encode("Hi")
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if !bytes.Equal(got, []byte{'H', 'i', 0x20, 0x20}) {
+		t.Fatalf("got %v", got)
+	}
+}
+
+func TestCHARText_EncodeCustomPad(t *testing.T) {
+	c := CHARText{Width: 3, Pad: 0x00}
+	got, err := c.Encode("A")
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if !bytes.Equal(got, []byte{'A', 0x00, 0x00}) {
+		t.Fatalf("got %v", got)
+	}
+}
+
+func TestCHARText_EncodeOverflow(t *testing.T) {
+	c := CHARText{Width: 2}
+	if _, err := c.Encode("ABC"); err == nil || err.Code != ErrCodeFixedWidthExceeded {
+		t.Fatalf("want fixed_width_exceeded, got %+v", err)
+	}
+}

--- a/protocol/ebus_standard/types/char_test.go
+++ b/protocol/ebus_standard/types/char_test.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"bytes"
+	"math"
 	"testing"
 )
 
@@ -64,6 +65,26 @@ func TestCHARSigned_EncodeRange(t *testing.T) {
 	}
 	if _, err := codec.Encode(-129); err == nil || err.Code != ErrCodeOutOfRange {
 		t.Fatalf("want out_of_range, got %+v", err)
+	}
+}
+
+func TestCHARSigned_EncodeRejectsUintOverflow(t *testing.T) {
+	// uint values above math.MaxInt64 must not wrap through int64 to valid
+	// signed bytes. toInt64 must reject them, and CHARSigned.Encode must
+	// surface an invalid_argument error rather than emit bytes.
+	codec := CHARSigned{}
+	huge := uint(math.MaxInt64) + 1 // only meaningful on 64-bit; on 32-bit uint MaxInt64+1 overflows to 0, still rejected as out-of-range below
+	got, err := codec.Encode(huge)
+	if err == nil {
+		t.Fatalf("want error for uint > MaxInt64, got bytes %v", got)
+	}
+	if got != nil {
+		t.Fatalf("must not return bytes on overflow, got %v", got)
+	}
+	// Either invalid_argument (toInt64 rejects) or out_of_range (32-bit path)
+	// is acceptable; silently emitting a byte is not.
+	if err.Code != ErrCodeInvalidArgument && err.Code != ErrCodeOutOfRange {
+		t.Fatalf("want invalid_argument or out_of_range, got %+v", err)
 	}
 }
 

--- a/protocol/ebus_standard/types/char_test.go
+++ b/protocol/ebus_standard/types/char_test.go
@@ -3,6 +3,7 @@ package types
 import (
 	"bytes"
 	"math"
+	"strconv"
 	"testing"
 )
 
@@ -72,8 +73,21 @@ func TestCHARSigned_EncodeRejectsUintOverflow(t *testing.T) {
 	// uint values above math.MaxInt64 must not wrap through int64 to valid
 	// signed bytes. toInt64 must reject them, and CHARSigned.Encode must
 	// surface an invalid_argument error rather than emit bytes.
+	//
+	// On 32-bit targets `uint` is 32 bits and cannot exceed math.MaxInt64,
+	// so the overflow path being exercised here is unreachable. Skip rather
+	// than constructing a compile-time-constant expression that overflows
+	// `uint` on 32-bit builds (which would break `GOARCH=386` compilation).
+	if strconv.IntSize < 64 {
+		t.Skip("test requires 64-bit uint to construct a value > math.MaxInt64")
+	}
 	codec := CHARSigned{}
-	huge := uint(math.MaxInt64) + 1 // only meaningful on 64-bit; on 32-bit uint MaxInt64+1 overflows to 0, still rejected as out-of-range below
+	// Build the overflow value at runtime so the expression is not a
+	// compile-time constant evaluated against the target `uint` width
+	// (which would break `GOARCH=386` compilation).
+	hugeU64 := uint64(math.MaxInt64)
+	hugeU64++
+	huge := uint(hugeU64)
 	got, err := codec.Encode(huge)
 	if err == nil {
 		t.Fatalf("want error for uint > MaxInt64, got bytes %v", got)

--- a/protocol/ebus_standard/types/char_test.go
+++ b/protocol/ebus_standard/types/char_test.go
@@ -147,10 +147,13 @@ func TestCHARText_EncodeCustomPad(t *testing.T) {
 	}
 }
 
-// Regression for Codex r3105815894: when CHARText.Pad is explicitly set to a
-// non-default byte (e.g. 0xFF), the Decode display trim MUST also strip that
-// pad byte. Per 02-l7-types.md §CHAR rule 6/8, the catalog-declared pad byte
-// is padding and must not leak into the display string as escaped bytes.
+// Regression for Codex r3105815894 + r3106369841: when CHARText.Pad is
+// explicitly set to a non-default byte (e.g. 0xFF), the Decode display trim
+// MUST strip THAT pad byte and ONLY that pad byte (override, not additive).
+// Per 02-l7-types.md §CHAR rule 6, the catalog-declared pad byte overrides
+// the default — it is not combined with the default 0x00/0x20 set. A
+// trailing 0x20 under Pad=0xFF is a VALID SPACE, not padding, and must
+// remain visible in the display string.
 func TestCHARText_DecodeHonorsCustomPad(t *testing.T) {
 	ff := byte(0xFF)
 	c := CHARText{Width: 4, Pad: &ff}
@@ -168,6 +171,49 @@ func TestCHARText_DecodeHonorsCustomPad(t *testing.T) {
 	// Raw must remain authoritative regardless of display trim.
 	if !bytes.Equal(got.Raw, []byte{'A', 'B', 0xFF, 0xFF}) {
 		t.Fatalf("raw must be preserved, got %v", got.Raw)
+	}
+}
+
+// Regression for Codex r3106369841: when CHARText.Pad=0xFF is explicitly
+// declared, a trailing 0x20 (space) is a valid content byte under the
+// catalog's declared padding semantics, NOT padding. The display trim must
+// treat Pad as an override — strip 0xFF only, preserve the 0x20.
+func TestCHARText_DecodeCustomPadIsOverrideNotAdditive(t *testing.T) {
+	ff := byte(0xFF)
+	c := CHARText{Width: 5, Pad: &ff}
+	// payload: 'A','B', 0x20 (valid space), 0xFF, 0xFF (trailing pad)
+	got := c.Decode([]byte{'A', 'B', 0x20, 0xFF, 0xFF})
+	if !got.Valid {
+		t.Fatalf("unexpected invalid, err=%v", got.Err)
+	}
+	s, ok := got.Value.(string)
+	if !ok {
+		t.Fatalf("want string display, got %T", got.Value)
+	}
+	if s != "AB " {
+		t.Fatalf("Pad override: trailing 0x20 is valid content when Pad=0xFF; want %q, got %q", "AB ", s)
+	}
+	if !bytes.Equal(got.Raw, []byte{'A', 'B', 0x20, 0xFF, 0xFF}) {
+		t.Fatalf("raw must be preserved, got %v", got.Raw)
+	}
+}
+
+// Regression for Codex r3106369841: positive sanity — when Pad is NOT set,
+// the default behavior stripping trailing 0x00 and 0x20 bytes still holds.
+// This guards against over-correction of the override fix.
+func TestCHARText_DecodeDefaultPadStripsNullAndSpace(t *testing.T) {
+	c := CHARText{Width: 5}
+	// trailing 0x00 and 0x20 stripped by default.
+	got := c.Decode([]byte{'O', 'K', 0x20, 0x00, 0x20})
+	if !got.Valid {
+		t.Fatalf("unexpected invalid, err=%v", got.Err)
+	}
+	s, ok := got.Value.(string)
+	if !ok {
+		t.Fatalf("want string display, got %T", got.Value)
+	}
+	if s != "OK" {
+		t.Fatalf("want default trim %q, got %q", "OK", s)
 	}
 }
 

--- a/protocol/ebus_standard/types/char_test.go
+++ b/protocol/ebus_standard/types/char_test.go
@@ -115,7 +115,8 @@ func TestCHARText_EncodePadsRight(t *testing.T) {
 }
 
 func TestCHARText_EncodeCustomPad(t *testing.T) {
-	c := CHARText{Width: 3, Pad: 0x00}
+	nul := byte(0x00)
+	c := CHARText{Width: 3, Pad: &nul}
 	got, err := c.Encode("A")
 	if err != nil {
 		t.Fatalf("unexpected err: %v", err)

--- a/protocol/ebus_standard/types/char_test.go
+++ b/protocol/ebus_standard/types/char_test.go
@@ -147,6 +147,30 @@ func TestCHARText_EncodeCustomPad(t *testing.T) {
 	}
 }
 
+// Regression for Codex r3105815894: when CHARText.Pad is explicitly set to a
+// non-default byte (e.g. 0xFF), the Decode display trim MUST also strip that
+// pad byte. Per 02-l7-types.md §CHAR rule 6/8, the catalog-declared pad byte
+// is padding and must not leak into the display string as escaped bytes.
+func TestCHARText_DecodeHonorsCustomPad(t *testing.T) {
+	ff := byte(0xFF)
+	c := CHARText{Width: 4, Pad: &ff}
+	got := c.Decode([]byte{'A', 'B', 0xFF, 0xFF})
+	if !got.Valid {
+		t.Fatalf("unexpected invalid, err=%v", got.Err)
+	}
+	s, ok := got.Value.(string)
+	if !ok {
+		t.Fatalf("want string display, got %T", got.Value)
+	}
+	if s != "AB" {
+		t.Fatalf("want display %q (0xFF pad stripped), got %q", "AB", s)
+	}
+	// Raw must remain authoritative regardless of display trim.
+	if !bytes.Equal(got.Raw, []byte{'A', 'B', 0xFF, 0xFF}) {
+		t.Fatalf("raw must be preserved, got %v", got.Raw)
+	}
+}
+
 func TestCHARText_EncodeOverflow(t *testing.T) {
 	c := CHARText{Width: 2}
 	if _, err := c.Encode("ABC"); err == nil || err.Code != ErrCodeFixedWidthExceeded {

--- a/protocol/ebus_standard/types/data1c.go
+++ b/protocol/ebus_standard/types/data1c.go
@@ -1,5 +1,7 @@
 package types
 
+import "math"
+
 // DATA1c is the unsigned 0.5-resolution primitive with 0xFF replacement
 // sentinel, defined in 02-l7-types.md §"DATA1c".
 //
@@ -12,10 +14,52 @@ func (DATA1c) Size() int { return 1 }
 
 // Decode parses one byte; 0xFF is the replacement sentinel.
 func (DATA1c) Decode(payload []byte) Value {
-	panic("ebus_standard/types.DATA1c.Decode: not implemented")
+	if len(payload) == 0 {
+		return Value{Err: newDecodeError(ErrCodeTruncatedPayload, "DATA1c requires 1 byte")}
+	}
+	if len(payload) > 1 {
+		return Value{Raw: cloneBytes(payload), Err: newDecodeError(ErrCodeOverlongPayload, "DATA1c consumes exactly 1 byte")}
+	}
+	raw := payload[0]
+	if raw == 0xFF {
+		return Value{
+			Raw:         cloneBytes(payload),
+			Replacement: true,
+		}
+	}
+	return Value{
+		Raw:   cloneBytes(payload),
+		Value: float64(raw) / 2.0,
+		Valid: true,
+	}
 }
 
 // Encode serialises a half-unit value; see 02-l7-types.md for accepted ranges.
 func (DATA1c) Encode(value any) ([]byte, *DecodeError) {
-	panic("ebus_standard/types.DATA1c.Encode: not implemented")
+	f, ok := toFloat64(value)
+	if !ok {
+		return nil, newDecodeError(ErrCodeInvalidArgument, "DATA1c.Encode requires a numeric value")
+	}
+	if f < 0 {
+		return nil, newDecodeError(ErrCodeOutOfRange, "DATA1c value must be non-negative")
+	}
+	// Maximum representable non-replacement physical value is 0xFE/2 = 127.
+	if f > 127.0 {
+		// 127.5 would encode to 0xFF (replacement) — catch that specifically,
+		// everything strictly above is out of range.
+		if math.Abs(f-127.5) < 1e-9 {
+			return nil, newDecodeError(ErrCodeEncodesReplacement, "DATA1c 127.5 would encode to 0xFF replacement")
+		}
+		return nil, newDecodeError(ErrCodeOutOfRange, "DATA1c value must be <= 127 (or exactly 127.5 rejected as replacement)")
+	}
+	// Must round-trip exactly to a half-unit.
+	raw := f * 2.0
+	rounded := math.Round(raw)
+	if math.Abs(raw-rounded) > 1e-9 {
+		return nil, newDecodeError(ErrCodeInvalidRoundTrip, "DATA1c value does not align to a 0.5 half-unit")
+	}
+	if rounded == 0xFF {
+		return nil, newDecodeError(ErrCodeEncodesReplacement, "DATA1c encoded byte would be 0xFF replacement")
+	}
+	return []byte{byte(rounded)}, nil
 }

--- a/protocol/ebus_standard/types/data1c.go
+++ b/protocol/ebus_standard/types/data1c.go
@@ -1,0 +1,21 @@
+package types
+
+// DATA1c is the unsigned 0.5-resolution primitive with 0xFF replacement
+// sentinel, defined in 02-l7-types.md §"DATA1c".
+//
+// DATA1c is NOT two's-complement signed. Raw values 0x80..0xFE are positive
+// half-unit values.
+type DATA1c struct{}
+
+// Size returns the fixed width.
+func (DATA1c) Size() int { return 1 }
+
+// Decode parses one byte; 0xFF is the replacement sentinel.
+func (DATA1c) Decode(payload []byte) Value {
+	panic("ebus_standard/types.DATA1c.Decode: not implemented")
+}
+
+// Encode serialises a half-unit value; see 02-l7-types.md for accepted ranges.
+func (DATA1c) Encode(value any) ([]byte, *DecodeError) {
+	panic("ebus_standard/types.DATA1c.Encode: not implemented")
+}

--- a/protocol/ebus_standard/types/data1c.go
+++ b/protocol/ebus_standard/types/data1c.go
@@ -50,19 +50,22 @@ func (DATA1c) Encode(value any) ([]byte, *DecodeError) {
 	if f > 127.0 {
 		// 127.5 would encode to 0xFF (replacement) — catch that specifically,
 		// everything strictly above is out of range.
-		if math.Abs(f-127.5) < 1e-9 {
+		if f == 127.5 {
 			return nil, newDecodeError(ErrCodeEncodesReplacement, "DATA1c 127.5 would encode to 0xFF replacement")
 		}
 		return nil, newDecodeError(ErrCodeOutOfRange, "DATA1c value must be <= 127 (or exactly 127.5 rejected as replacement)")
 	}
-	// Must round-trip exactly to a half-unit.
+	// Must round-trip EXACTLY to a half-unit under IEEE 754 representation.
+	// No epsilon: inputs like 1e-10 or 0.5000000001 must be rejected, not
+	// silently coerced to the nearest 0.5 increment. math.Modf returns the
+	// fractional part; any non-zero fractional part means f is not an exact
+	// multiple of 0.5.
 	raw := f * 2.0
-	rounded := math.Round(raw)
-	if math.Abs(raw-rounded) > 1e-9 {
+	if _, frac := math.Modf(raw); frac != 0 {
 		return nil, newDecodeError(ErrCodeInvalidRoundTrip, "DATA1c value does not align to a 0.5 half-unit")
 	}
-	if rounded == 0xFF {
+	if raw == 0xFF {
 		return nil, newDecodeError(ErrCodeEncodesReplacement, "DATA1c encoded byte would be 0xFF replacement")
 	}
-	return []byte{byte(rounded)}, nil
+	return []byte{byte(raw)}, nil
 }

--- a/protocol/ebus_standard/types/data1c.go
+++ b/protocol/ebus_standard/types/data1c.go
@@ -40,6 +40,9 @@ func (DATA1c) Encode(value any) ([]byte, *DecodeError) {
 	if !ok {
 		return nil, newDecodeError(ErrCodeInvalidArgument, "DATA1c.Encode requires a numeric value")
 	}
+	if math.IsNaN(f) || math.IsInf(f, 0) {
+		return nil, newDecodeError(ErrCodeOutOfRange, "DATA1c value must be finite (NaN/Inf rejected)")
+	}
 	if f < 0 {
 		return nil, newDecodeError(ErrCodeOutOfRange, "DATA1c value must be non-negative")
 	}

--- a/protocol/ebus_standard/types/data1c_test.go
+++ b/protocol/ebus_standard/types/data1c_test.go
@@ -114,3 +114,27 @@ func TestDATA1c_EncodeOutOfRange(t *testing.T) {
 		t.Fatalf("want out_of_range for 200, got %+v", err)
 	}
 }
+
+func TestDATA1c_EncodeRejectsNonFinite(t *testing.T) {
+	codec := DATA1c{}
+	cases := []struct {
+		name string
+		in   float64
+	}{
+		{"NaN", math.NaN()},
+		{"+Inf", math.Inf(1)},
+		{"-Inf", math.Inf(-1)},
+	}
+	for _, tc := range cases {
+		got, err := codec.Encode(tc.in)
+		if err == nil {
+			t.Fatalf("%s: want error, got bytes %v", tc.name, got)
+		}
+		if err.Code != ErrCodeOutOfRange {
+			t.Fatalf("%s: want out_of_range, got %+v", tc.name, err)
+		}
+		if got != nil {
+			t.Fatalf("%s: must not return bytes on non-finite input, got %v", tc.name, got)
+		}
+	}
+}

--- a/protocol/ebus_standard/types/data1c_test.go
+++ b/protocol/ebus_standard/types/data1c_test.go
@@ -97,6 +97,54 @@ func TestDATA1c_EncodeRejectsNonHalfUnit(t *testing.T) {
 	}
 }
 
+// Regression for Codex r3106398434: the half-unit validation MUST be exact
+// (no epsilon). Values like 1e-10 or 0.5000000001 are NOT valid 0.5
+// increments and must be rejected rather than silently coerced to the
+// nearest half-unit.
+func TestDATA1c_EncodeRejectsNearHalfUnit(t *testing.T) {
+	codec := DATA1c{}
+	rejectCases := []struct {
+		name string
+		in   float64
+	}{
+		{"1e-10", 1e-10},
+		{"0.5000000001", 0.5000000001},
+		{"0.4999999999", 0.4999999999},
+		{"1.0000000001", 1.0000000001},
+	}
+	for _, tc := range rejectCases {
+		got, err := codec.Encode(tc.in)
+		if err == nil {
+			t.Fatalf("%s: want invalid_round_trip, got bytes %v", tc.name, got)
+		}
+		if err.Code != ErrCodeInvalidRoundTrip {
+			t.Fatalf("%s: want invalid_round_trip, got %+v", tc.name, err)
+		}
+		if got != nil {
+			t.Fatalf("%s: must not return bytes on non-half-unit input, got %v", tc.name, got)
+		}
+	}
+
+	acceptCases := []struct {
+		name string
+		in   float64
+		want byte
+	}{
+		{"0.5", 0.5, 0x01},
+		{"1.0", 1.0, 0x02},
+		{"0.0", 0.0, 0x00},
+	}
+	for _, tc := range acceptCases {
+		got, err := codec.Encode(tc.in)
+		if err != nil {
+			t.Fatalf("%s: want accept, got err %+v", tc.name, err)
+		}
+		if len(got) != 1 || got[0] != tc.want {
+			t.Fatalf("%s: got %v want 0x%02X", tc.name, got, tc.want)
+		}
+	}
+}
+
 func TestDATA1c_EncodeRejectsReplacementByte(t *testing.T) {
 	// 127.5 would encode to raw 0xFF which is the replacement sentinel; reject.
 	_, err := DATA1c{}.Encode(127.5)

--- a/protocol/ebus_standard/types/data1c_test.go
+++ b/protocol/ebus_standard/types/data1c_test.go
@@ -1,0 +1,116 @@
+package types
+
+import (
+	"bytes"
+	"math"
+	"testing"
+)
+
+func TestDATA1c_DecodePositive(t *testing.T) {
+	cases := []struct {
+		in   byte
+		want float64
+	}{
+		{0x00, 0.0},
+		{0x01, 0.5},
+		{0x02, 1.0},
+		{0x80, 64.0},
+		{0xC8, 100.0}, // raw 200 / 2 = 100
+		{0xFE, 127.0},
+	}
+	for _, tc := range cases {
+		got := DATA1c{}.Decode([]byte{tc.in})
+		if !got.Valid {
+			t.Fatalf("want Valid=true for 0x%02X, got %+v", tc.in, got)
+		}
+		if got.Replacement {
+			t.Fatalf("0x%02X must not be replacement", tc.in)
+		}
+		v, ok := got.Value.(float64)
+		if !ok {
+			t.Fatalf("want float64, got %T", got.Value)
+		}
+		if math.Abs(v-tc.want) > 1e-9 {
+			t.Fatalf("0x%02X: got %v want %v", tc.in, v, tc.want)
+		}
+	}
+}
+
+func TestDATA1c_DecodeReplacement(t *testing.T) {
+	got := DATA1c{}.Decode([]byte{0xFF})
+	if got.Valid {
+		t.Fatalf("replacement must set Valid=false")
+	}
+	if !got.Replacement {
+		t.Fatalf("Replacement must be true for 0xFF")
+	}
+	if got.Err != nil {
+		t.Fatalf("replacement must not produce err: got %+v", got.Err)
+	}
+	if !bytes.Equal(got.Raw, []byte{0xFF}) {
+		t.Fatalf("raw mismatch: %v", got.Raw)
+	}
+	if got.Value != nil {
+		t.Fatalf("value must be nil on replacement, got %v", got.Value)
+	}
+}
+
+func TestDATA1c_DecodeTruncated(t *testing.T) {
+	got := DATA1c{}.Decode(nil)
+	if got.Err == nil || got.Err.Code != ErrCodeTruncatedPayload {
+		t.Fatalf("want truncated_payload, got %+v", got.Err)
+	}
+}
+
+func TestDATA1c_DecodeOverlong(t *testing.T) {
+	got := DATA1c{}.Decode([]byte{0x10, 0x20})
+	if got.Err == nil || got.Err.Code != ErrCodeOverlongPayload {
+		t.Fatalf("want overlong_payload, got %+v", got.Err)
+	}
+}
+
+func TestDATA1c_EncodeRoundTrip(t *testing.T) {
+	cases := []struct {
+		in   float64
+		want byte
+	}{
+		{0.0, 0x00},
+		{0.5, 0x01},
+		{100.0, 0xC8},
+		{127.0, 0xFE},
+	}
+	for _, tc := range cases {
+		got, err := DATA1c{}.Encode(tc.in)
+		if err != nil {
+			t.Fatalf("%v: %v", tc.in, err)
+		}
+		if len(got) != 1 || got[0] != tc.want {
+			t.Fatalf("%v: got %v want 0x%02X", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestDATA1c_EncodeRejectsNonHalfUnit(t *testing.T) {
+	_, err := DATA1c{}.Encode(0.3) // does not round-trip to a half-unit
+	if err == nil || err.Code != ErrCodeInvalidRoundTrip {
+		t.Fatalf("want invalid_round_trip, got %+v", err)
+	}
+}
+
+func TestDATA1c_EncodeRejectsReplacementByte(t *testing.T) {
+	// 127.5 would encode to raw 0xFF which is the replacement sentinel; reject.
+	_, err := DATA1c{}.Encode(127.5)
+	if err == nil || err.Code != ErrCodeEncodesReplacement {
+		t.Fatalf("want encodes_replacement_value, got %+v", err)
+	}
+}
+
+func TestDATA1c_EncodeOutOfRange(t *testing.T) {
+	codec := DATA1c{}
+	if _, err := codec.Encode(-0.5); err == nil || err.Code != ErrCodeOutOfRange {
+		t.Fatalf("want out_of_range for -0.5, got %+v", err)
+	}
+	if _, err := codec.Encode(200.0); err == nil || err.Code != ErrCodeOutOfRange {
+		t.Fatalf("want out_of_range for 200, got %+v", err)
+	}
+}

--- a/protocol/ebus_standard/types/helpers.go
+++ b/protocol/ebus_standard/types/helpers.go
@@ -1,5 +1,7 @@
 package types
 
+import "math"
+
 // toInt64 normalises common Go integer types to int64. Floats and strings
 // are rejected so that encode rules remain strict.
 func toInt64(v any) (int64, bool) {
@@ -15,6 +17,9 @@ func toInt64(v any) (int64, bool) {
 	case int64:
 		return t, true
 	case uint:
+		if uint64(t) > math.MaxInt64 {
+			return 0, false
+		}
 		return int64(t), true
 	case uint8:
 		return int64(t), true

--- a/protocol/ebus_standard/types/helpers.go
+++ b/protocol/ebus_standard/types/helpers.go
@@ -1,0 +1,48 @@
+package types
+
+// toInt64 normalises common Go integer types to int64. Floats and strings
+// are rejected so that encode rules remain strict.
+func toInt64(v any) (int64, bool) {
+	switch t := v.(type) {
+	case int:
+		return int64(t), true
+	case int8:
+		return int64(t), true
+	case int16:
+		return int64(t), true
+	case int32:
+		return int64(t), true
+	case int64:
+		return t, true
+	case uint:
+		return int64(t), true
+	case uint8:
+		return int64(t), true
+	case uint16:
+		return int64(t), true
+	case uint32:
+		return int64(t), true
+	case uint64:
+		if t > (1<<63 - 1) {
+			return 0, false
+		}
+		return int64(t), true
+	default:
+		return 0, false
+	}
+}
+
+// toFloat64 normalises numeric inputs to float64 for DATA1c-style codecs.
+func toFloat64(v any) (float64, bool) {
+	switch t := v.(type) {
+	case float32:
+		return float64(t), true
+	case float64:
+		return t, true
+	default:
+		if i, ok := toInt64(v); ok {
+			return float64(i), true
+		}
+		return 0, false
+	}
+}

--- a/protocol/ebus_standard/types/raw.go
+++ b/protocol/ebus_standard/types/raw.go
@@ -12,10 +12,43 @@ type RawPayload struct {
 
 // Decode copies payload[:len(payload)] into Raw after enforcing bounds.
 func (r RawPayload) Decode(payload []byte) Value {
-	panic("ebus_standard/types.RawPayload.Decode: not implemented")
+	n := len(payload)
+	if n < r.MinLen {
+		return Value{Raw: cloneBytes(payload), Err: newDecodeError(ErrCodeTruncatedPayload, "raw payload shorter than MinLen")}
+	}
+	if r.MaxLen > 0 && n > r.MaxLen {
+		return Value{Raw: cloneBytes(payload), Err: newDecodeError(ErrCodeOverlongPayload, "raw payload longer than MaxLen")}
+	}
+	raw := cloneBytes(payload)
+	// Value carries a separate defensive copy so that consumers mutating it
+	// cannot disturb Value.Raw.
+	var val []byte
+	if raw != nil {
+		val = append([]byte(nil), raw...)
+	}
+	return Value{
+		Raw:   raw,
+		Value: val,
+		Valid: true,
+	}
 }
 
 // Encode validates length bounds and returns a defensive copy.
 func (r RawPayload) Encode(value any) ([]byte, *DecodeError) {
-	panic("ebus_standard/types.RawPayload.Encode: not implemented")
+	var data []byte
+	switch v := value.(type) {
+	case []byte:
+		data = v
+	case string:
+		data = []byte(v)
+	default:
+		return nil, newDecodeError(ErrCodeInvalidArgument, "RawPayload.Encode requires []byte or string")
+	}
+	if len(data) < r.MinLen {
+		return nil, newDecodeError(ErrCodeTruncatedPayload, "raw payload shorter than MinLen")
+	}
+	if r.MaxLen > 0 && len(data) > r.MaxLen {
+		return nil, newDecodeError(ErrCodeOverlongPayload, "raw payload longer than MaxLen")
+	}
+	return cloneBytes(data), nil
 }

--- a/protocol/ebus_standard/types/raw.go
+++ b/protocol/ebus_standard/types/raw.go
@@ -1,0 +1,21 @@
+package types
+
+// RawPayload decodes a variable-length raw byte slice as defined in
+// 02-l7-types.md §"Variable-Length Raw Payload".
+//
+// The catalog branch supplies MinLen and MaxLen bounds. Zero-length is
+// permitted only when MinLen == 0.
+type RawPayload struct {
+	MinLen int
+	MaxLen int
+}
+
+// Decode copies payload[:len(payload)] into Raw after enforcing bounds.
+func (r RawPayload) Decode(payload []byte) Value {
+	panic("ebus_standard/types.RawPayload.Decode: not implemented")
+}
+
+// Encode validates length bounds and returns a defensive copy.
+func (r RawPayload) Encode(value any) ([]byte, *DecodeError) {
+	panic("ebus_standard/types.RawPayload.Encode: not implemented")
+}

--- a/protocol/ebus_standard/types/raw.go
+++ b/protocol/ebus_standard/types/raw.go
@@ -3,8 +3,10 @@ package types
 // RawPayload decodes a variable-length raw byte slice as defined in
 // 02-l7-types.md §"Variable-Length Raw Payload".
 //
-// The catalog branch supplies MinLen and MaxLen bounds. Zero-length is
-// permitted only when MinLen == 0.
+// The catalog branch supplies MinLen and MaxLen bounds. Both bounds are
+// always enforced; MaxLen == 0 is a legitimate strict zero-length cap
+// (payload must be exactly zero bytes). Zero-length input is permitted
+// only when MinLen == 0.
 type RawPayload struct {
 	MinLen int
 	MaxLen int
@@ -16,7 +18,7 @@ func (r RawPayload) Decode(payload []byte) Value {
 	if n < r.MinLen {
 		return Value{Raw: cloneBytes(payload), Err: newDecodeError(ErrCodeTruncatedPayload, "raw payload shorter than MinLen")}
 	}
-	if r.MaxLen > 0 && n > r.MaxLen {
+	if n > r.MaxLen {
 		return Value{Raw: cloneBytes(payload), Err: newDecodeError(ErrCodeOverlongPayload, "raw payload longer than MaxLen")}
 	}
 	raw := cloneBytes(payload)
@@ -47,7 +49,7 @@ func (r RawPayload) Encode(value any) ([]byte, *DecodeError) {
 	if len(data) < r.MinLen {
 		return nil, newDecodeError(ErrCodeTruncatedPayload, "raw payload shorter than MinLen")
 	}
-	if r.MaxLen > 0 && len(data) > r.MaxLen {
+	if len(data) > r.MaxLen {
 		return nil, newDecodeError(ErrCodeOverlongPayload, "raw payload longer than MaxLen")
 	}
 	return cloneBytes(data), nil

--- a/protocol/ebus_standard/types/raw_test.go
+++ b/protocol/ebus_standard/types/raw_test.go
@@ -89,6 +89,40 @@ func TestRawPayload_EncodeTooLong(t *testing.T) {
 	}
 }
 
+// Regression for Codex r3106271525: MaxLen=0 must enforce a strict
+// zero-length cap (payload must be exactly zero bytes), not be treated as
+// "unbounded".
+func TestRawPayload_DecodeMaxLenZeroRejectsNonEmpty(t *testing.T) {
+	r := RawPayload{MinLen: 0, MaxLen: 0}
+	got := r.Decode([]byte{0x01})
+	if got.Err == nil || got.Err.Code != ErrCodeOverlongPayload {
+		t.Fatalf("want overlong_payload for non-empty input against MaxLen=0, got %+v", got.Err)
+	}
+	if got.Valid {
+		t.Fatalf("value must be invalid when Err is set")
+	}
+	// Zero-length payload against MaxLen=0 must still decode.
+	ok := r.Decode(nil)
+	if !ok.Valid || ok.Err != nil {
+		t.Fatalf("zero-length must decode against MaxLen=0, got %+v", ok)
+	}
+}
+
+func TestRawPayload_EncodeMaxLenZeroRejectsNonEmpty(t *testing.T) {
+	r := RawPayload{MinLen: 0, MaxLen: 0}
+	if _, err := r.Encode([]byte{0x01}); err == nil || err.Code != ErrCodeOverlongPayload {
+		t.Fatalf("want overlong_payload for non-empty encode against MaxLen=0, got %+v", err)
+	}
+	// Zero-length encode against MaxLen=0 must succeed.
+	out, err := r.Encode([]byte{})
+	if err != nil {
+		t.Fatalf("zero-length encode against MaxLen=0 must succeed, got %+v", err)
+	}
+	if len(out) != 0 {
+		t.Fatalf("want empty output, got %v", out)
+	}
+}
+
 func TestRawPayload_EncodeWrongType(t *testing.T) {
 	r := RawPayload{MinLen: 0, MaxLen: 4}
 	if _, err := r.Encode(42); err == nil || err.Code != ErrCodeInvalidArgument {

--- a/protocol/ebus_standard/types/raw_test.go
+++ b/protocol/ebus_standard/types/raw_test.go
@@ -1,0 +1,97 @@
+package types
+
+import (
+	"bytes"
+	"testing"
+)
+
+func TestRawPayload_DecodePositive(t *testing.T) {
+	r := RawPayload{MinLen: 1, MaxLen: 8}
+	in := []byte{0x01, 0x02, 0x03}
+	got := r.Decode(in)
+	if !got.Valid {
+		t.Fatalf("unexpected invalid: %+v", got)
+	}
+	if !bytes.Equal(got.Raw, in) {
+		t.Fatalf("raw mismatch: %v vs %v", got.Raw, in)
+	}
+	v, ok := got.Value.([]byte)
+	if !ok {
+		t.Fatalf("want []byte, got %T", got.Value)
+	}
+	if !bytes.Equal(v, in) {
+		t.Fatalf("value mismatch: %v", v)
+	}
+}
+
+func TestRawPayload_DecodeZeroLengthPermitted(t *testing.T) {
+	r := RawPayload{MinLen: 0, MaxLen: 4}
+	got := r.Decode(nil)
+	if !got.Valid {
+		t.Fatalf("zero-length must decode: %+v", got)
+	}
+	if len(got.Raw) != 0 {
+		t.Fatalf("raw must be empty, got %v", got.Raw)
+	}
+}
+
+func TestRawPayload_DecodeZeroLengthForbidden(t *testing.T) {
+	r := RawPayload{MinLen: 1, MaxLen: 4}
+	got := r.Decode(nil)
+	if got.Err == nil || got.Err.Code != ErrCodeTruncatedPayload {
+		t.Fatalf("want truncated_payload, got %+v", got.Err)
+	}
+}
+
+func TestRawPayload_DecodeOverlong(t *testing.T) {
+	r := RawPayload{MinLen: 1, MaxLen: 3}
+	got := r.Decode([]byte{1, 2, 3, 4})
+	if got.Err == nil || got.Err.Code != ErrCodeOverlongPayload {
+		t.Fatalf("want overlong_payload, got %+v", got.Err)
+	}
+}
+
+func TestRawPayload_DecodeRawIsDefensiveCopy(t *testing.T) {
+	r := RawPayload{MinLen: 1, MaxLen: 4}
+	in := []byte{0x10, 0x20}
+	got := r.Decode(in)
+	if !got.Valid {
+		t.Fatalf("unexpected invalid")
+	}
+	in[0] = 0xFF
+	if got.Raw[0] != 0x10 {
+		t.Fatalf("Raw must be defensive copy, got %#x", got.Raw[0])
+	}
+}
+
+func TestRawPayload_EncodePositive(t *testing.T) {
+	r := RawPayload{MinLen: 1, MaxLen: 4}
+	out, err := r.Encode([]byte{1, 2, 3})
+	if err != nil {
+		t.Fatalf("unexpected err: %v", err)
+	}
+	if !bytes.Equal(out, []byte{1, 2, 3}) {
+		t.Fatalf("got %v", out)
+	}
+}
+
+func TestRawPayload_EncodeTooShort(t *testing.T) {
+	r := RawPayload{MinLen: 2, MaxLen: 4}
+	if _, err := r.Encode([]byte{1}); err == nil || err.Code != ErrCodeTruncatedPayload {
+		t.Fatalf("want truncated, got %+v", err)
+	}
+}
+
+func TestRawPayload_EncodeTooLong(t *testing.T) {
+	r := RawPayload{MinLen: 1, MaxLen: 2}
+	if _, err := r.Encode([]byte{1, 2, 3}); err == nil || err.Code != ErrCodeOverlongPayload {
+		t.Fatalf("want overlong, got %+v", err)
+	}
+}
+
+func TestRawPayload_EncodeWrongType(t *testing.T) {
+	r := RawPayload{MinLen: 0, MaxLen: 4}
+	if _, err := r.Encode(42); err == nil || err.Code != ErrCodeInvalidArgument {
+		t.Fatalf("want invalid_argument, got %+v", err)
+	}
+}

--- a/protocol/ebus_standard/types/selector.go
+++ b/protocol/ebus_standard/types/selector.go
@@ -110,6 +110,13 @@ func (s LengthSelector) Select(input SelectorInput) SelectorResult {
 			if len(input.Payload) < br.MinLen {
 				return SelectorResult{Err: newDecodeError(ErrCodeTruncatedPayload, "payload shorter than branch MinLen")}
 			}
+			// Predicates may read any byte up to the declared LengthPrefix
+			// (NN). If the buffer is shorter than the declared prefix, a
+			// Match function that indexes beyond len(Payload)-1 would panic.
+			// Surface truncated_payload before invoking the predicate.
+			if len(input.Payload) < input.LengthPrefix {
+				return SelectorResult{Err: newDecodeError(ErrCodeTruncatedPayload, "payload shorter than declared LengthPrefix")}
+			}
 			if !br.Match(input) {
 				continue
 			}

--- a/protocol/ebus_standard/types/selector.go
+++ b/protocol/ebus_standard/types/selector.go
@@ -1,0 +1,48 @@
+package types
+
+// SelectorInput carries the selector inputs enumerated in 02-l7-types.md
+// §"Length-Dependent Selector".
+type SelectorInput struct {
+	PB                    byte
+	SB                    byte
+	Direction             string // "request" / "response"
+	Role                  string // "initiator" / "responder"
+	LengthPrefix          int    // NN
+	Payload               []byte
+	SelectorDecoderID     string
+}
+
+// Branch is a catalog branch candidate for a length-dependent selector.
+//
+// MinLen and MaxLen are inclusive bounds on the payload length. AllowsRawTail
+// indicates whether bytes beyond the consumed portion are permitted without
+// triggering OverlongPayload; see rule 5 in 02-l7-types.md §"Length-Dependent
+// Selector".
+//
+// Match is an optional predicate that consumes selected bytes (e.g. a
+// selector byte). A nil Match means the length bounds are the only selector.
+// Match MUST NOT mutate its argument.
+type Branch struct {
+	Name          string
+	MinLen        int
+	MaxLen        int
+	AllowsRawTail bool
+	Match         func(input SelectorInput) bool
+}
+
+// LengthSelector resolves a catalog branch strictly by length / payload.
+type LengthSelector struct {
+	Branches []Branch
+}
+
+// SelectorResult carries the decode outcome. When Err is non-nil, Selected
+// is empty.
+type SelectorResult struct {
+	Selected string
+	Err      *DecodeError
+}
+
+// Select evaluates the branches against input and returns SelectorResult.
+func (s LengthSelector) Select(input SelectorInput) SelectorResult {
+	panic("ebus_standard/types.LengthSelector.Select: not implemented")
+}

--- a/protocol/ebus_standard/types/selector.go
+++ b/protocol/ebus_standard/types/selector.go
@@ -3,13 +3,13 @@ package types
 // SelectorInput carries the selector inputs enumerated in 02-l7-types.md
 // §"Length-Dependent Selector".
 type SelectorInput struct {
-	PB                    byte
-	SB                    byte
-	Direction             string // "request" / "response"
-	Role                  string // "initiator" / "responder"
-	LengthPrefix          int    // NN
-	Payload               []byte
-	SelectorDecoderID     string
+	PB                byte
+	SB                byte
+	Direction         string // "request" / "response"
+	Role              string // "initiator" / "responder"
+	LengthPrefix      int    // NN
+	Payload           []byte
+	SelectorDecoderID string
 }
 
 // Branch is a catalog branch candidate for a length-dependent selector.
@@ -43,6 +43,89 @@ type SelectorResult struct {
 }
 
 // Select evaluates the branches against input and returns SelectorResult.
+//
+// Evaluation order:
+//  1. For each branch, check whether the declared LengthPrefix fits the
+//     branch's window. A branch with AllowsRawTail accepts any LengthPrefix
+//     >= MinLen (extra bytes are treated as a raw tail).
+//  2. For each window-fitting branch, evaluate Match (if any), guarding
+//     against payload-buffer truncation before invoking Match.
+//  3. Zero matches:
+//     - If at least one branch's window contains LengthPrefix but Match
+//       rejected, return unknown_selector_branch.
+//     - If LengthPrefix is shorter than every branch's MinLen, return
+//       truncated_payload.
+//     - If LengthPrefix exceeds every branch's MaxLen (and none allow raw
+//       tail), return overlong_payload.
+//     - Otherwise return unknown_selector_branch.
+//  4. Multiple matches → ambiguous_selector_branch.
+//  5. One match → payload-buffer length sanity check (truncation /
+//     overlong) relative to that branch.
 func (s LengthSelector) Select(input SelectorInput) SelectorResult {
-	panic("ebus_standard/types.LengthSelector.Select: not implemented")
+	var (
+		windowFit []Branch
+	)
+	for _, br := range s.Branches {
+		if input.LengthPrefix < br.MinLen {
+			continue
+		}
+		if !br.AllowsRawTail && input.LengthPrefix > br.MaxLen {
+			continue
+		}
+		windowFit = append(windowFit, br)
+	}
+
+	if len(windowFit) == 0 {
+		// Disambiguate: shorter than every branch → not enough info; longer
+		// than every branch without raw-tail → overlong; else unknown.
+		allTooShort := len(s.Branches) > 0
+		allTooLong := len(s.Branches) > 0
+		for _, br := range s.Branches {
+			if input.LengthPrefix >= br.MinLen {
+				allTooShort = false
+			}
+			if br.AllowsRawTail || input.LengthPrefix <= br.MaxLen {
+				allTooLong = false
+			}
+		}
+		if allTooShort {
+			return SelectorResult{Err: newDecodeError(ErrCodeTruncatedPayload, "declared length shorter than any branch MinLen")}
+		}
+		if allTooLong {
+			return SelectorResult{Err: newDecodeError(ErrCodeOverlongPayload, "declared length longer than any branch MaxLen")}
+		}
+		return SelectorResult{Err: newDecodeError(ErrCodeUnknownSelector, "no branch matches selector inputs")}
+	}
+
+	// Evaluate Match predicates against window-fitting candidates.
+	var matches []Branch
+	for _, br := range windowFit {
+		if br.Match != nil {
+			// Predicate needs at least MinLen bytes available in the buffer.
+			if len(input.Payload) < br.MinLen {
+				return SelectorResult{Err: newDecodeError(ErrCodeTruncatedPayload, "payload shorter than branch MinLen")}
+			}
+			if !br.Match(input) {
+				continue
+			}
+		}
+		matches = append(matches, br)
+	}
+
+	switch len(matches) {
+	case 0:
+		return SelectorResult{Err: newDecodeError(ErrCodeUnknownSelector, "no branch matches selector inputs")}
+	case 1:
+		winner := matches[0]
+		// Buffer checks relative to winner.
+		if len(input.Payload) < input.LengthPrefix {
+			return SelectorResult{Err: newDecodeError(ErrCodeTruncatedPayload, "payload shorter than declared length")}
+		}
+		if !winner.AllowsRawTail && len(input.Payload) > winner.MaxLen {
+			return SelectorResult{Err: newDecodeError(ErrCodeOverlongPayload, "payload buffer longer than branch MaxLen")}
+		}
+		return SelectorResult{Selected: winner.Name}
+	default:
+		return SelectorResult{Err: newDecodeError(ErrCodeAmbiguousSelector, "multiple branches match the same selector inputs")}
+	}
 }

--- a/protocol/ebus_standard/types/selector.go
+++ b/protocol/ebus_standard/types/selector.go
@@ -124,15 +124,23 @@ func (s LengthSelector) Select(input SelectorInput) SelectorResult {
 		matches = append(matches, br)
 	}
 
+	// Payload-buffer truncation check is universal: if the buffer carries
+	// fewer bytes than the declared LengthPrefix, the frame is malformed
+	// regardless of how many (or which) branches matched. Checking this
+	// BEFORE the ambiguity branch prevents a truncated frame from being
+	// misclassified as ambiguous_selector_branch when two nil-Match (or
+	// predicate-accepting) branches happen to fit by length alone. See
+	// Codex r3106398435.
+	if len(matches) > 0 && len(input.Payload) < input.LengthPrefix {
+		return SelectorResult{Err: newDecodeError(ErrCodeTruncatedPayload, "payload shorter than declared length")}
+	}
+
 	switch len(matches) {
 	case 0:
 		return SelectorResult{Err: newDecodeError(ErrCodeUnknownSelector, "no branch matches selector inputs")}
 	case 1:
 		winner := matches[0]
-		// Buffer checks relative to winner.
-		if len(input.Payload) < input.LengthPrefix {
-			return SelectorResult{Err: newDecodeError(ErrCodeTruncatedPayload, "payload shorter than declared length")}
-		}
+		// Buffer upper-bound check relative to winner.
 		if !winner.AllowsRawTail && len(input.Payload) > input.LengthPrefix {
 			return SelectorResult{Err: newDecodeError(ErrCodeOverlongPayload, "payload buffer longer than declared LengthPrefix")}
 		}

--- a/protocol/ebus_standard/types/selector.go
+++ b/protocol/ebus_standard/types/selector.go
@@ -14,10 +14,11 @@ type SelectorInput struct {
 
 // Branch is a catalog branch candidate for a length-dependent selector.
 //
-// MinLen and MaxLen are inclusive bounds on the payload length. AllowsRawTail
-// indicates whether bytes beyond the consumed portion are permitted without
-// triggering OverlongPayload; see rule 5 in 02-l7-types.md §"Length-Dependent
-// Selector".
+// MinLen and MaxLen are inclusive bounds on the declared LengthPrefix (NN).
+// Both bounds are enforced for every branch regardless of AllowsRawTail —
+// AllowsRawTail only relaxes the PAYLOAD BUFFER overlong check (it allows the
+// buffer to carry extra bytes beyond the declared LengthPrefix as a raw tail).
+// See rule 5 in 02-l7-types.md §"Length-Dependent Selector".
 //
 // Match is an optional predicate that consumes selected bytes (e.g. a
 // selector byte). A nil Match means the length bounds are the only selector.
@@ -46,8 +47,8 @@ type SelectorResult struct {
 //
 // Evaluation order:
 //  1. For each branch, check whether the declared LengthPrefix fits the
-//     branch's window. A branch with AllowsRawTail accepts any LengthPrefix
-//     >= MinLen (extra bytes are treated as a raw tail).
+//     branch's [MinLen, MaxLen] window. The MaxLen upper bound applies to
+//     every branch — AllowsRawTail does NOT relax the LengthPrefix bound.
 //  2. For each window-fitting branch, evaluate Match (if any), guarding
 //     against payload-buffer truncation before invoking Match.
 //  3. Zero matches:
@@ -55,12 +56,13 @@ type SelectorResult struct {
 //     rejected, return unknown_selector_branch.
 //     - If LengthPrefix is shorter than every branch's MinLen, return
 //     truncated_payload.
-//     - If LengthPrefix exceeds every branch's MaxLen (and none allow raw
-//     tail), return overlong_payload.
+//     - If LengthPrefix exceeds every branch's MaxLen, return
+//     overlong_payload.
 //     - Otherwise return unknown_selector_branch.
 //  4. Multiple matches → ambiguous_selector_branch.
 //  5. One match → payload-buffer length sanity check (truncation /
-//     overlong) relative to that branch.
+//     overlong) relative to that branch. AllowsRawTail relaxes the buffer
+//     upper-bound check only (buffer may exceed LengthPrefix).
 func (s LengthSelector) Select(input SelectorInput) SelectorResult {
 	var (
 		windowFit []Branch
@@ -69,7 +71,10 @@ func (s LengthSelector) Select(input SelectorInput) SelectorResult {
 		if input.LengthPrefix < br.MinLen {
 			continue
 		}
-		if !br.AllowsRawTail && input.LengthPrefix > br.MaxLen {
+		// MaxLen bounds the declared LengthPrefix (NN) for every branch.
+		// AllowsRawTail only relaxes the payload-buffer overlong check below,
+		// not the declared length itself.
+		if input.LengthPrefix > br.MaxLen {
 			continue
 		}
 		windowFit = append(windowFit, br)
@@ -84,7 +89,7 @@ func (s LengthSelector) Select(input SelectorInput) SelectorResult {
 			if input.LengthPrefix >= br.MinLen {
 				allTooShort = false
 			}
-			if br.AllowsRawTail || input.LengthPrefix <= br.MaxLen {
+			if input.LengthPrefix <= br.MaxLen {
 				allTooLong = false
 			}
 		}

--- a/protocol/ebus_standard/types/selector.go
+++ b/protocol/ebus_standard/types/selector.go
@@ -52,11 +52,11 @@ type SelectorResult struct {
 //     against payload-buffer truncation before invoking Match.
 //  3. Zero matches:
 //     - If at least one branch's window contains LengthPrefix but Match
-//       rejected, return unknown_selector_branch.
+//     rejected, return unknown_selector_branch.
 //     - If LengthPrefix is shorter than every branch's MinLen, return
-//       truncated_payload.
+//     truncated_payload.
 //     - If LengthPrefix exceeds every branch's MaxLen (and none allow raw
-//       tail), return overlong_payload.
+//     tail), return overlong_payload.
 //     - Otherwise return unknown_selector_branch.
 //  4. Multiple matches → ambiguous_selector_branch.
 //  5. One match → payload-buffer length sanity check (truncation /

--- a/protocol/ebus_standard/types/selector.go
+++ b/protocol/ebus_standard/types/selector.go
@@ -121,8 +121,8 @@ func (s LengthSelector) Select(input SelectorInput) SelectorResult {
 		if len(input.Payload) < input.LengthPrefix {
 			return SelectorResult{Err: newDecodeError(ErrCodeTruncatedPayload, "payload shorter than declared length")}
 		}
-		if !winner.AllowsRawTail && len(input.Payload) > winner.MaxLen {
-			return SelectorResult{Err: newDecodeError(ErrCodeOverlongPayload, "payload buffer longer than branch MaxLen")}
+		if !winner.AllowsRawTail && len(input.Payload) > input.LengthPrefix {
+			return SelectorResult{Err: newDecodeError(ErrCodeOverlongPayload, "payload buffer longer than declared LengthPrefix")}
 		}
 		return SelectorResult{Selected: winner.Name}
 	default:

--- a/protocol/ebus_standard/types/selector_test.go
+++ b/protocol/ebus_standard/types/selector_test.go
@@ -94,6 +94,28 @@ func TestLengthSelector_OverlongPayload(t *testing.T) {
 	}
 }
 
+// Regression for Codex r3105815892: the non-raw-tail overlong check MUST
+// compare payload buffer length to the declared LengthPrefix (NN), not to
+// winner.MaxLen. Otherwise, when LengthPrefix < MaxLen, extra trailing bytes
+// leak past the declared prefix without triggering overlong_payload.
+func TestLengthSelector_OverlongAgainstLengthPrefixNotMaxLen(t *testing.T) {
+	sel := LengthSelector{Branches: []Branch{
+		{Name: "wide", MinLen: 1, MaxLen: 8},
+	}}
+	// LengthPrefix=2 (NN) fits the branch, but buffer carries 3 bytes.
+	// Old code checked len(Payload) > MaxLen (3 > 8 = false) and accepted the
+	// trailing byte. New code must reject it as overlong_payload.
+	res := sel.Select(SelectorInput{LengthPrefix: 2, Payload: []byte{0x01, 0x02, 0x03}})
+	if res.Err == nil || res.Err.Code != ErrCodeOverlongPayload {
+		t.Fatalf("want overlong_payload for NN<MaxLen with trailing bytes, got %+v", res)
+	}
+	// Positive: same branch, payload length equals LengthPrefix → accept.
+	res = sel.Select(SelectorInput{LengthPrefix: 2, Payload: []byte{0x01, 0x02}})
+	if res.Err != nil || res.Selected != "wide" {
+		t.Fatalf("positive case want wide, got %+v", res)
+	}
+}
+
 func TestLengthSelector_RawTailBranchAllowsExtra(t *testing.T) {
 	sel := LengthSelector{Branches: []Branch{
 		{Name: "with_tail", MinLen: 1, MaxLen: 1, AllowsRawTail: true},

--- a/protocol/ebus_standard/types/selector_test.go
+++ b/protocol/ebus_standard/types/selector_test.go
@@ -117,12 +117,33 @@ func TestLengthSelector_OverlongAgainstLengthPrefixNotMaxLen(t *testing.T) {
 }
 
 func TestLengthSelector_RawTailBranchAllowsExtra(t *testing.T) {
+	// AllowsRawTail permits the PAYLOAD BUFFER to carry extra bytes beyond
+	// the declared LengthPrefix (NN). It does NOT relax the MaxLen bound on
+	// LengthPrefix itself.
 	sel := LengthSelector{Branches: []Branch{
 		{Name: "with_tail", MinLen: 1, MaxLen: 1, AllowsRawTail: true},
 	}}
-	res := sel.Select(SelectorInput{LengthPrefix: 4, Payload: []byte{1, 2, 3, 4}})
+	// LengthPrefix=1 fits MaxLen=1; buffer carries 3 extra trailing bytes
+	// which AllowsRawTail permits.
+	res := sel.Select(SelectorInput{LengthPrefix: 1, Payload: []byte{1, 2, 3, 4}})
 	if res.Err != nil || res.Selected != "with_tail" {
-		t.Fatalf("raw-tail branch must accept extra bytes, got %+v", res)
+		t.Fatalf("raw-tail branch must accept extra buffer bytes, got %+v", res)
+	}
+}
+
+// Regression for Codex r3106271521: AllowsRawTail must not let LengthPrefix
+// exceed the declared MaxLen. A branch like {MinLen:1, MaxLen:4,
+// AllowsRawTail:true} must reject LengthPrefix=100.
+func TestLengthSelector_RawTailDoesNotBypassMaxLenOnLengthPrefix(t *testing.T) {
+	sel := LengthSelector{Branches: []Branch{
+		{Name: "bounded_tail", MinLen: 1, MaxLen: 4, AllowsRawTail: true},
+	}}
+	res := sel.Select(SelectorInput{LengthPrefix: 100, Payload: make([]byte, 100)})
+	if res.Err == nil || res.Err.Code != ErrCodeOverlongPayload {
+		t.Fatalf("want overlong_payload for LengthPrefix beyond MaxLen even with AllowsRawTail, got %+v", res)
+	}
+	if res.Selected != "" {
+		t.Fatalf("selected must be empty on error, got %q", res.Selected)
 	}
 }
 

--- a/protocol/ebus_standard/types/selector_test.go
+++ b/protocol/ebus_standard/types/selector_test.go
@@ -1,0 +1,130 @@
+package types
+
+import "testing"
+
+// The selector tests follow 02-l7-types.md §"Length-Dependent Selector"
+// requirement to cover: positive selection, no-match, ambiguous-match,
+// truncated-selector, truncated-payload, overlong-payload.
+
+func twoBranchSelector() LengthSelector {
+	// Branch "short" accepts NN in [1,2], branch "long" accepts NN in [4,8].
+	return LengthSelector{Branches: []Branch{
+		{Name: "short", MinLen: 1, MaxLen: 2},
+		{Name: "long", MinLen: 4, MaxLen: 8},
+	}}
+}
+
+func TestLengthSelector_PositiveSelection(t *testing.T) {
+	sel := twoBranchSelector()
+	res := sel.Select(SelectorInput{LengthPrefix: 2, Payload: []byte{0x01, 0x02}})
+	if res.Err != nil {
+		t.Fatalf("unexpected err: %+v", res.Err)
+	}
+	if res.Selected != "short" {
+		t.Fatalf("want short, got %q", res.Selected)
+	}
+	res = sel.Select(SelectorInput{LengthPrefix: 6, Payload: make([]byte, 6)})
+	if res.Err != nil || res.Selected != "long" {
+		t.Fatalf("want long, got %+v", res)
+	}
+}
+
+func TestLengthSelector_NoMatch(t *testing.T) {
+	sel := twoBranchSelector()
+	res := sel.Select(SelectorInput{LengthPrefix: 3, Payload: make([]byte, 3)})
+	if res.Err == nil || res.Err.Code != ErrCodeUnknownSelector {
+		t.Fatalf("want unknown_selector_branch, got %+v", res.Err)
+	}
+	if res.Selected != "" {
+		t.Fatalf("selected must be empty on error")
+	}
+}
+
+func TestLengthSelector_AmbiguousMatch(t *testing.T) {
+	sel := LengthSelector{Branches: []Branch{
+		{Name: "a", MinLen: 2, MaxLen: 4},
+		{Name: "b", MinLen: 3, MaxLen: 5},
+	}}
+	res := sel.Select(SelectorInput{LengthPrefix: 3, Payload: make([]byte, 3)})
+	if res.Err == nil || res.Err.Code != ErrCodeAmbiguousSelector {
+		t.Fatalf("want ambiguous_selector_branch, got %+v", res.Err)
+	}
+}
+
+func TestLengthSelector_TruncatedSelector(t *testing.T) {
+	// A branch whose Match predicate needs payload[0]; providing no payload
+	// while LengthPrefix says 1 must surface truncated_payload.
+	sel := LengthSelector{Branches: []Branch{
+		{
+			Name:   "needs_selector_byte",
+			MinLen: 1,
+			MaxLen: 1,
+			Match: func(in SelectorInput) bool {
+				if len(in.Payload) < 1 {
+					// Should never be called by selector on short payload;
+					// selector must short-circuit.
+					return true
+				}
+				return in.Payload[0] == 0x5A
+			},
+		},
+	}}
+	res := sel.Select(SelectorInput{LengthPrefix: 1, Payload: nil})
+	if res.Err == nil || res.Err.Code != ErrCodeTruncatedPayload {
+		t.Fatalf("want truncated_payload, got %+v", res.Err)
+	}
+}
+
+func TestLengthSelector_TruncatedPayload(t *testing.T) {
+	sel := twoBranchSelector()
+	// Branch "long" wants 4..8, but payload only has 2 bytes.
+	res := sel.Select(SelectorInput{LengthPrefix: 6, Payload: []byte{0, 0}})
+	if res.Err == nil || res.Err.Code != ErrCodeTruncatedPayload {
+		t.Fatalf("want truncated_payload, got %+v", res.Err)
+	}
+}
+
+func TestLengthSelector_OverlongPayload(t *testing.T) {
+	sel := twoBranchSelector()
+	// LengthPrefix=2 (fits "short"), but payload is 5 bytes and no raw tail
+	// is allowed. That is overlong_payload.
+	res := sel.Select(SelectorInput{LengthPrefix: 2, Payload: make([]byte, 5)})
+	if res.Err == nil || res.Err.Code != ErrCodeOverlongPayload {
+		t.Fatalf("want overlong_payload, got %+v", res.Err)
+	}
+}
+
+func TestLengthSelector_RawTailBranchAllowsExtra(t *testing.T) {
+	sel := LengthSelector{Branches: []Branch{
+		{Name: "with_tail", MinLen: 1, MaxLen: 1, AllowsRawTail: true},
+	}}
+	res := sel.Select(SelectorInput{LengthPrefix: 4, Payload: []byte{1, 2, 3, 4}})
+	if res.Err != nil || res.Selected != "with_tail" {
+		t.Fatalf("raw-tail branch must accept extra bytes, got %+v", res)
+	}
+}
+
+func TestLengthSelector_MatchPredicateDiscriminates(t *testing.T) {
+	sel := LengthSelector{Branches: []Branch{
+		{
+			Name: "block1", MinLen: 2, MaxLen: 2,
+			Match: func(in SelectorInput) bool { return in.Payload[0] == 0x01 },
+		},
+		{
+			Name: "block2", MinLen: 2, MaxLen: 2,
+			Match: func(in SelectorInput) bool { return in.Payload[0] == 0x02 },
+		},
+	}}
+	res := sel.Select(SelectorInput{LengthPrefix: 2, Payload: []byte{0x02, 0xAA}})
+	if res.Err != nil || res.Selected != "block2" {
+		t.Fatalf("want block2, got %+v", res)
+	}
+	res = sel.Select(SelectorInput{LengthPrefix: 2, Payload: []byte{0x01, 0xAA}})
+	if res.Err != nil || res.Selected != "block1" {
+		t.Fatalf("want block1, got %+v", res)
+	}
+	res = sel.Select(SelectorInput{LengthPrefix: 2, Payload: []byte{0x99, 0xAA}})
+	if res.Err == nil || res.Err.Code != ErrCodeUnknownSelector {
+		t.Fatalf("want unknown_selector_branch, got %+v", res)
+	}
+}

--- a/protocol/ebus_standard/types/selector_test.go
+++ b/protocol/ebus_standard/types/selector_test.go
@@ -147,6 +147,42 @@ func TestLengthSelector_RawTailDoesNotBypassMaxLenOnLengthPrefix(t *testing.T) {
 	}
 }
 
+// Regression for Codex r3106369840: Select must guard against the declared
+// LengthPrefix exceeding the payload buffer BEFORE invoking a branch's Match
+// predicate. Otherwise a Match function that reads any byte up to
+// LengthPrefix-1 can panic on a short buffer instead of surfacing a proper
+// truncated_payload error.
+func TestLengthSelector_MatchGuardsAgainstLengthPrefixTruncation(t *testing.T) {
+	sel := LengthSelector{Branches: []Branch{
+		{
+			Name:   "reads_index_one",
+			MinLen: 1,
+			MaxLen: 2,
+			Match: func(in SelectorInput) bool {
+				// Declared LengthPrefix tells us byte[1] is valid; selector
+				// must ensure that holds before calling us. If it does not,
+				// this indexes out of range and panics.
+				return in.Payload[1] == 0x5A
+			},
+		},
+	}}
+	// LengthPrefix=2 declares two bytes of payload, but buffer holds 1 byte.
+	// Branch MinLen=1 passes the old guard; the declared-prefix guard must
+	// catch it and return truncated_payload instead of panicking.
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("Select panicked on short buffer: %v", r)
+		}
+	}()
+	res := sel.Select(SelectorInput{LengthPrefix: 2, Payload: []byte{0x5A}})
+	if res.Err == nil || res.Err.Code != ErrCodeTruncatedPayload {
+		t.Fatalf("want truncated_payload, got %+v", res)
+	}
+	if res.Selected != "" {
+		t.Fatalf("selected must be empty on error, got %q", res.Selected)
+	}
+}
+
 func TestLengthSelector_MatchPredicateDiscriminates(t *testing.T) {
 	sel := LengthSelector{Branches: []Branch{
 		{

--- a/protocol/ebus_standard/types/selector_test.go
+++ b/protocol/ebus_standard/types/selector_test.go
@@ -183,6 +183,28 @@ func TestLengthSelector_MatchGuardsAgainstLengthPrefixTruncation(t *testing.T) {
 	}
 }
 
+// Regression for Codex r3106398435: payload-buffer truncation must be
+// reported as truncated_payload even when two branches both match the
+// selector inputs by length/predicate. Otherwise a malformed/truncated
+// frame (declared LengthPrefix exceeds buffer) is misclassified as
+// ambiguous_selector_branch, driving incorrect downstream error handling.
+func TestLengthSelector_TruncatedPayloadBeatsAmbiguity(t *testing.T) {
+	// Two nil-Match branches both match by length alone; LengthPrefix=4 but
+	// the buffer only carries 1 byte. Expect truncated_payload, NOT
+	// ambiguous_selector_branch.
+	sel := LengthSelector{Branches: []Branch{
+		{Name: "a", MinLen: 1, MaxLen: 4},
+		{Name: "b", MinLen: 1, MaxLen: 4},
+	}}
+	res := sel.Select(SelectorInput{LengthPrefix: 4, Payload: []byte{0x01}})
+	if res.Err == nil || res.Err.Code != ErrCodeTruncatedPayload {
+		t.Fatalf("want truncated_payload, got %+v", res)
+	}
+	if res.Selected != "" {
+		t.Fatalf("selected must be empty on error, got %q", res.Selected)
+	}
+}
+
 func TestLengthSelector_MatchPredicateDiscriminates(t *testing.T) {
 	sel := LengthSelector{Branches: []Branch{
 		{

--- a/protocol/ebus_standard/types/types.go
+++ b/protocol/ebus_standard/types/types.go
@@ -20,16 +20,16 @@ package types
 type ErrorCode string
 
 const (
-	ErrCodeTruncatedPayload       ErrorCode = "truncated_payload"
-	ErrCodeOverlongPayload        ErrorCode = "overlong_payload"
-	ErrCodeOutOfRange             ErrorCode = "out_of_range"
-	ErrCodeInvalidNibble          ErrorCode = "invalid_nibble"
-	ErrCodeAmbiguousSelector      ErrorCode = "ambiguous_selector_branch"
-	ErrCodeUnknownSelector        ErrorCode = "unknown_selector_branch"
-	ErrCodeInvalidRoundTrip       ErrorCode = "invalid_round_trip"
-	ErrCodeEncodesReplacement     ErrorCode = "encodes_replacement_value"
-	ErrCodeFixedWidthExceeded     ErrorCode = "fixed_width_exceeded"
-	ErrCodeInvalidArgument        ErrorCode = "invalid_argument"
+	ErrCodeTruncatedPayload   ErrorCode = "truncated_payload"
+	ErrCodeOverlongPayload    ErrorCode = "overlong_payload"
+	ErrCodeOutOfRange         ErrorCode = "out_of_range"
+	ErrCodeInvalidNibble      ErrorCode = "invalid_nibble"
+	ErrCodeAmbiguousSelector  ErrorCode = "ambiguous_selector_branch"
+	ErrCodeUnknownSelector    ErrorCode = "unknown_selector_branch"
+	ErrCodeInvalidRoundTrip   ErrorCode = "invalid_round_trip"
+	ErrCodeEncodesReplacement ErrorCode = "encodes_replacement_value"
+	ErrCodeFixedWidthExceeded ErrorCode = "fixed_width_exceeded"
+	ErrCodeInvalidArgument    ErrorCode = "invalid_argument"
 )
 
 // DecodeError is the structured error type for 02-l7-types.md decode failures.

--- a/protocol/ebus_standard/types/types.go
+++ b/protocol/ebus_standard/types/types.go
@@ -1,0 +1,104 @@
+// Package types implements the L7 primitive types for the cross-vendor
+// ebus_standard namespace.
+//
+// This package is namespace-isolated: it MUST NOT depend on Vaillant 0xB5
+// provider logic, and the Vaillant types package (github.com/Project-Helianthus/
+// helianthus-ebusgo/types) MUST NOT depend on this one.
+//
+// The normative specification for every decode/encode rule implemented here
+// lives in helianthus-docs-ebus:
+//
+//	architecture/ebus_standard/02-l7-types.md
+//
+// Canonical plan SHA-256:
+//
+//	9e0a29bb76d99f551904b05749e322aafd3972621858aa6d1acbe49b9ef37305
+package types
+
+// ErrorCode enumerates structured decoder error codes defined in
+// 02-l7-types.md. These values surface to consumers via Value.Err.
+type ErrorCode string
+
+const (
+	ErrCodeTruncatedPayload       ErrorCode = "truncated_payload"
+	ErrCodeOverlongPayload        ErrorCode = "overlong_payload"
+	ErrCodeOutOfRange             ErrorCode = "out_of_range"
+	ErrCodeInvalidNibble          ErrorCode = "invalid_nibble"
+	ErrCodeAmbiguousSelector      ErrorCode = "ambiguous_selector_branch"
+	ErrCodeUnknownSelector        ErrorCode = "unknown_selector_branch"
+	ErrCodeInvalidRoundTrip       ErrorCode = "invalid_round_trip"
+	ErrCodeEncodesReplacement     ErrorCode = "encodes_replacement_value"
+	ErrCodeFixedWidthExceeded     ErrorCode = "fixed_width_exceeded"
+	ErrCodeInvalidArgument        ErrorCode = "invalid_argument"
+)
+
+// DecodeError is the structured error type for 02-l7-types.md decode failures.
+type DecodeError struct {
+	Code    ErrorCode
+	Message string
+}
+
+func (e *DecodeError) Error() string {
+	if e == nil {
+		return "<nil decode error>"
+	}
+	if e.Message == "" {
+		return string(e.Code)
+	}
+	return string(e.Code) + ": " + e.Message
+}
+
+// newDecodeError returns a pointer to a DecodeError. Using a pointer makes
+// errors.Is / errors.As chains straightforward for consumers that later wrap
+// this error.
+func newDecodeError(code ErrorCode, message string) *DecodeError {
+	return &DecodeError{Code: code, Message: message}
+}
+
+// Value is the decode output for every ebus_standard primitive.
+//
+// Contract (02-l7-types.md §"Decode Output Validity"):
+//
+//   - Raw always holds the exact source bytes in wire order, even when
+//     Valid=false.
+//   - Valid is true only when the decode produced a usable Value.
+//   - Replacement is true when the payload matched a replacement sentinel
+//     (Valid is also false in that case). Replacement and Err are mutually
+//     exclusive: replacement sentinels never set Err.
+//   - Value is zero / unset when Valid=false.
+//   - Err is non-nil when the decode failed for a syntax/range/length/selector
+//     reason rather than because of a replacement sentinel.
+type Value struct {
+	Raw         []byte
+	Value       any
+	Valid       bool
+	Replacement bool
+	Err         *DecodeError
+}
+
+// IsError reports whether Value holds a structured decode error.
+func (v Value) IsError() bool { return v.Err != nil }
+
+// Codec is the encode/decode contract for an L7 primitive.
+type Codec interface {
+	// Decode parses payload. It MUST always populate Raw when it consumes
+	// exactly one primitive's worth of bytes. Payload slices MUST be treated
+	// as read-only; decoders make defensive copies when retaining bytes.
+	Decode(payload []byte) Value
+
+	// Encode serialises value into the primitive's wire format. The returned
+	// byte slice is owned by the caller.
+	Encode(value any) ([]byte, *DecodeError)
+}
+
+// cloneBytes returns a defensive copy of b. Decoders store the copy in
+// Value.Raw so that consumers mutating the slice cannot corrupt cached decode
+// output.
+func cloneBytes(b []byte) []byte {
+	if len(b) == 0 {
+		return nil
+	}
+	out := make([]byte, len(b))
+	copy(out, b)
+	return out
+}


### PR DESCRIPTION
## Summary
M1 milestone of ebus-standard-l7-services-w16-26 locked plan. Implements L7 primitive types for the cross-vendor `ebus_standard` namespace in Go.

## Companion docs
Normative spec: [helianthus-docs-ebus `architecture/ebus_standard/02-l7-types.md`](https://github.com/Project-Helianthus/helianthus-docs-ebus/blob/main/architecture/ebus_standard/02-l7-types.md) (M0, merged via #267 / squash `b85e7084`).

## Canonical
- Meta-issue: [Project-Helianthus/helianthus-execution-plans#14](https://github.com/Project-Helianthus/helianthus-execution-plans/issues/14)
- Issue: [Project-Helianthus/helianthus-ebusgo#136](https://github.com/Project-Helianthus/helianthus-ebusgo/issues/136)
- Locked plan: `ebus-standard-l7-services-w16-26.locked`
- Canonical-SHA256: `9e0a29bb76d99f551904b05749e322aafd3972621858aa6d1acbe49b9ef37305`

## Acceptance criteria satisfied
- [x] AC1 BYTE — single-byte unsigned + replacement sentinel
- [x] AC2 CHAR — exact byte handling + padding rules (CHAR, CHARSigned, CHARText with `Pad *byte` override; non-printable bytes escaped on display)
- [x] AC3 DATA1c — explicit signedness + replacement-value sentinels (0xFF; 0.5 resolution; round-trip + replacement-encode guards)
- [x] AC4 variable-length raw payload — `Min`/`Max` bounds; defensive copies; truncated/overlong errors propagate
- [x] AC5 composite BCD — nibble order + invalid-nibble policy (component-level diagnostics)
- [x] AC6 length-dependent selector — strict length validation; truncated/overlong/unknown/ambiguous disambiguation; `AllowsRawTail` support
- [x] AC7 validity propagation — every decode result carries `Raw`, `Value`, `Valid`, `Replacement`, `Err`
- [x] AC8 golden vectors POSITIVE and NEGATIVE per primitive (50+ tests)

## TDD strict — RED commit evidence
- RED commit: `4c5f284` `test(ebus_standard/types): RED for BYTE/CHAR/DATA1c/raw/BCD/length-selector`
- RED CI: `not_triggered_by_branch_push` (this repo's `.github/workflows/ci.yml` triggers only on push-to-main and pull_request; feature-branch push alone does not fire CI)
- RED local evidence: orchestrator independently reproduced — `git checkout 4c5f284 && go test ./protocol/ebus_standard/types/...` → `FAIL` with `panic: not implemented` stacks on every test (substitute for CI evidence per cruise-tdd-gate VERIFY_CI_SAW_EXPECTED_OUTCOME under `ci_workflow_does_not_trigger_on_feature_branch_push` caveat)
- Backlog: separate issue for `ci.yml` trigger expansion to `push.branches: ['issue/**']`

## Files (14 new under `protocol/ebus_standard/types/`)
`types.go` (Value, DecodeError) · `byte.go` + `byte_test.go` · `char.go` + `char_test.go` · `data1c.go` + `data1c_test.go` · `raw.go` + `raw_test.go` · `bcd.go` + `bcd_test.go` · `selector.go` + `selector_test.go` · `helpers.go`.

No external deps added (`go.mod` untouched).

## Gates
- TDD: strict (RED commit + local-RED evidence; CI evidence caveated above)
- Doc-gate: N/A (M1 not in plan trigger list; consumes M0 docs)
- Transport-gate: **owner override** — see `c3bfc33` `chore(m1): lock transport-gate owner override` with `Transport-Gate-Override` + `Transport-Gate-Override-Reason` trailers. Rationale: `ebus_standard` is L7 strictly above `protocol.Frame` per canonical §1+§5; M1 not in plan transport-gate trigger list `{M4, M4b1, M4b2, M4c1, M4c2, M6a}`; no framing/CRC/escaping/transport touch.
- Local CI: pass — see commit status `ci/local` on `c3bfc33` (with override envs)
- Smoke: none (offline Go tests)

## Namespace isolation
New package imports nothing from `helianthus-ebusgo/types` (Vaillant codecs) or `helianthus-ebusgo/errors`. `Value` and `Codec` are intentionally richer than Vaillant `types.Value` to carry `Raw`, `Replacement`, structured `Err` per `02-l7-types.md` §"Decode Output Validity".

Tracks cruise-run [#14](https://github.com/Project-Helianthus/helianthus-execution-plans/issues/14). Closes #136.