### PR TITLE
feat(M4c1 PR-B): protocol/responder package — decoder + dispatcher + FSM + timing harness

### DIFF
--- a/protocol/responder/dispatcher.go
+++ b/protocol/responder/dispatcher.go
@@ -48,25 +48,39 @@ func (d *LocalResponderDispatcher) Dropped() uint64 {
 	return d.dropped
 }
 
-// Handle routes a decoded frame. If frame.Target != localAddr the frame
-// is dropped silently (dropped counter increments). Otherwise the bound
-// FSM advances via OnInboundFrame(true). Returns `true` if the frame was
-// accepted for local handling, `false` if filtered out.
-func (d *LocalResponderDispatcher) Handle(frame DecodedFrame) bool {
+// Handle routes a decoded frame. Return semantics:
+//
+//   - (true, nil): frame.Target matched localAddr and the bound FSM
+//     accepted the transition (Idle → AckReceived).
+//   - (false, ErrInvalidTransition): frame.Target matched localAddr but
+//     the FSM rejected the transition (e.g. an out-of-order inbound
+//     arrived while the FSM was not in StateIdle). Surfaces the sentinel
+//     so callers can log/metric the protocol violation instead of
+//     silently treating the frame as accepted.
+//   - (false, nil): frame.Target did NOT match localAddr — the frame is
+//     dropped silently (dropped counter increments). This preserves the
+//     bus-hygiene invariant: a responder lane MUST NOT ACK non-local
+//     frames, and MUST NOT emit noise for them.
+//
+// A nil bound FSM behaves as (true, nil) after the ZZ match — useful for
+// exercising the filter in isolation.
+func (d *LocalResponderDispatcher) Handle(frame DecodedFrame) (bool, error) {
 	d.mu.Lock()
 	if frame.Target != d.localAddr {
 		d.dropped++
 		d.mu.Unlock()
-		return false
+		return false, nil
 	}
 	fsm := d.fsm
 	d.mu.Unlock()
 	if fsm != nil {
 		// CRC validity is the FrameDecoder's contract — a DecodedFrame
 		// in hand implies CRC passed.
-		_, _ = fsm.OnInboundFrame(true)
+		if _, err := fsm.OnInboundFrame(true); err != nil {
+			return false, err
+		}
 	}
-	return true
+	return true, nil
 }
 
 func init() {

--- a/protocol/responder/dispatcher.go
+++ b/protocol/responder/dispatcher.go
@@ -1,0 +1,74 @@
+// M4c1 PR-B: LocalResponderDispatcher — inbound-frame router.
+//
+// Routes decoded frames whose ZZ matches the configured local responder
+// address; drops frames addressed elsewhere silently (bus-hygiene
+// invariant: a responder lane MUST NOT ACK non-local frames).
+
+package responder
+
+import (
+	"reflect"
+	"sync"
+)
+
+// LocalResponderDispatcher owns the ZZ filter + FSM handoff for a single
+// local responder address. Thread-safe under its own mutex; the bound FSM
+// has its own mutex, so concurrent Handle calls serialise cleanly.
+type LocalResponderDispatcher struct {
+	mu        sync.Mutex
+	localAddr byte
+	fsm       *FSM
+	// dropped counts frames filtered out by the ZZ filter. Exposed via
+	// Dropped() for observability / testing.
+	dropped uint64
+}
+
+// NewLocalResponderDispatcher binds a dispatcher to the configured local
+// responder address and an FSM instance. `fsm` MAY be nil if the caller
+// only wants to exercise the ZZ filter (the state transitions become
+// no-ops).
+func NewLocalResponderDispatcher(localAddr byte, fsm *FSM) *LocalResponderDispatcher {
+	return &LocalResponderDispatcher{
+		localAddr: localAddr,
+		fsm:       fsm,
+	}
+}
+
+// LocalAddress returns the configured local responder address.
+func (d *LocalResponderDispatcher) LocalAddress() byte {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.localAddr
+}
+
+// Dropped returns the count of frames filtered out by the ZZ filter.
+func (d *LocalResponderDispatcher) Dropped() uint64 {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	return d.dropped
+}
+
+// Handle routes a decoded frame. If frame.Target != localAddr the frame
+// is dropped silently (dropped counter increments). Otherwise the bound
+// FSM advances via OnInboundFrame(true). Returns `true` if the frame was
+// accepted for local handling, `false` if filtered out.
+func (d *LocalResponderDispatcher) Handle(frame DecodedFrame) bool {
+	d.mu.Lock()
+	if frame.Target != d.localAddr {
+		d.dropped++
+		d.mu.Unlock()
+		return false
+	}
+	fsm := d.fsm
+	d.mu.Unlock()
+	if fsm != nil {
+		// CRC validity is the FrameDecoder's contract — a DecodedFrame
+		// in hand implies CRC passed.
+		_, _ = fsm.OnInboundFrame(true)
+	}
+	return true
+}
+
+func init() {
+	registerExport("LocalResponderDispatcher", reflect.TypeOf((*LocalResponderDispatcher)(nil)))
+}

--- a/protocol/responder/doc.go
+++ b/protocol/responder/doc.go
@@ -3,12 +3,33 @@
 // final-ACK FSM, and a timing harness measuring received-frame-CRC →
 // responder-ACK-emit latency.
 //
-// M4c1: implementation stub, tests fail until impl. PR-B ships the runtime.
+// M4c1 PR-B: GREEN-phase implementation per decision doc
+// `helianthus-execution-plans/ebus-standard-l7-services-w16-26.implementing/
+// decisions/m4b2-responder-go-no-go.md` §6.1.
+//
+// Scope (PR-B):
+//   - FrameDecoder       — inbound frame parser (header + CRC validation)
+//   - LocalResponderDispatcher — routes frames with matching ZZ; drops
+//     non-local frames silently.
+//   - FSM                — Idle → AckReceived → ResponseSent → {Idle |
+//     retry | aborted} state machine.
+//   - TimingHarness      — clock-injected CRC-to-ACK latency meter.
+//
+// The package consumes the PR-A-landed `transport.ResponderTransport`
+// capability for outbound byte emission but does NOT reach into transport
+// internals — all transport-specific logic stays at the transport boundary.
 package responder
 
-// responderExportRegistry is the RED-phase sentinel. PR-B impl must populate
-// it (via an init() in frame_decoder.go / fsm.go / dispatcher.go) with the
-// expected type names so the RED tests can detect the end-state.
-//
-// Left nil today so all M4c1 PR-B tests fail.
+// responderExportRegistry publishes the PR-B exported surface so the RED
+// contract tests (which consult the registry by name) can observe the
+// end-state. The registry is populated from init() functions in the files
+// below; the map itself is allocated lazily on first registration to keep
+// declaration order independent of file compilation order.
 var responderExportRegistry map[string]any
+
+func registerExport(name string, value any) {
+	if responderExportRegistry == nil {
+		responderExportRegistry = make(map[string]any)
+	}
+	responderExportRegistry[name] = value
+}

--- a/protocol/responder/frame_decoder.go
+++ b/protocol/responder/frame_decoder.go
@@ -1,0 +1,91 @@
+// M4c1 PR-B: inbound frame decoder for the responder lane.
+//
+// Parses an eBUS initiator-to-responder frame:
+//
+//	QQ ZZ PB SB NN DB1..DBn CRC
+//
+// All bytes are expected to be already unescaped (the caller is responsible
+// for the wire-level 0xA9 / 0xAA de-escape, per the established transport
+// discipline in `protocol/bus.go`). The decoder validates the CRC across
+// the header+payload span and returns a `DecodedFrame` on success, or an
+// error classifying the failure (short frame, length mismatch, CRC bad).
+
+package responder
+
+import (
+	"errors"
+	"reflect"
+
+	"github.com/Project-Helianthus/helianthus-ebusgo/protocol"
+)
+
+// DecodedFrame is the parsed, CRC-validated form of an inbound initiator
+// -to-responder eBUS frame.
+type DecodedFrame struct {
+	// Source (QQ) is the initiator address.
+	Source byte
+	// Target (ZZ) is the destination address; matched against the
+	// configured local responder address by LocalResponderDispatcher.
+	Target byte
+	// Primary (PB) and Secondary (SB) are the eBUS service-bank opcodes.
+	Primary   byte
+	Secondary byte
+	// Payload is the DB1..DBn bytes (length == NN).
+	Payload []byte
+	// CRC is the validated frame CRC byte.
+	CRC byte
+}
+
+// FrameDecoder parses inbound responder-direction frames. It is stateless
+// and safe for concurrent use.
+type FrameDecoder struct{}
+
+// NewFrameDecoder constructs a FrameDecoder.
+func NewFrameDecoder() *FrameDecoder {
+	return &FrameDecoder{}
+}
+
+// Errors returned by FrameDecoder.Decode.
+var (
+	// ErrFrameTooShort is returned when the input is shorter than the
+	// minimum possible frame (QQ ZZ PB SB NN CRC == 6 bytes).
+	ErrFrameTooShort = errors.New("responder: frame too short")
+	// ErrLengthMismatch is returned when NN declares a payload size that
+	// does not fit in the supplied byte slice.
+	ErrLengthMismatch = errors.New("responder: NN length mismatch")
+	// ErrBadCRC is returned when the CRC byte does not match the
+	// computed CRC over QQ..DBn.
+	ErrBadCRC = errors.New("responder: bad CRC")
+)
+
+// Decode parses a single unescaped frame. `frame` must be exactly
+// `5 + NN + 1` bytes (header + payload + CRC).
+func (d *FrameDecoder) Decode(frame []byte) (DecodedFrame, error) {
+	if len(frame) < 6 {
+		return DecodedFrame{}, ErrFrameTooShort
+	}
+	nn := int(frame[4])
+	want := 5 + nn + 1
+	if len(frame) != want {
+		return DecodedFrame{}, ErrLengthMismatch
+	}
+	crcByte := frame[want-1]
+	body := frame[:want-1]
+	if protocol.CRC(body) != crcByte {
+		return DecodedFrame{}, ErrBadCRC
+	}
+	payload := make([]byte, nn)
+	copy(payload, frame[5:5+nn])
+	return DecodedFrame{
+		Source:    frame[0],
+		Target:    frame[1],
+		Primary:   frame[2],
+		Secondary: frame[3],
+		Payload:   payload,
+		CRC:       crcByte,
+	}, nil
+}
+
+func init() {
+	registerExport("FrameDecoder", reflect.TypeOf((*FrameDecoder)(nil)))
+}

--- a/protocol/responder/frame_decoder_test.go
+++ b/protocol/responder/frame_decoder_test.go
@@ -12,7 +12,6 @@ import (
 // TestM4c1_PRB_FrameDecoder_Exported asserts a FrameDecoder type is
 // published by the responder package. Fails today — type absent.
 func TestM4c1_PRB_FrameDecoder_Exported(t *testing.T) {
-	t.Skip("M4c1 PR-B impl pending — see issue/138 PR-B dispatch")
 	if responderExportRegistry == nil {
 		t.Fatalf("M4c1 PR-B: protocol/responder package has no exported FrameDecoder yet")
 	}
@@ -24,7 +23,6 @@ func TestM4c1_PRB_FrameDecoder_Exported(t *testing.T) {
 // TestM4c1_PRB_LocalResponderDispatcher_Exported asserts a
 // LocalResponderDispatcher is published. Fails today.
 func TestM4c1_PRB_LocalResponderDispatcher_Exported(t *testing.T) {
-	t.Skip("M4c1 PR-B impl pending — see issue/138 PR-B dispatch")
 	if responderExportRegistry == nil {
 		t.Fatalf("M4c1 PR-B: protocol/responder package has no exported LocalResponderDispatcher yet")
 	}
@@ -36,7 +34,6 @@ func TestM4c1_PRB_LocalResponderDispatcher_Exported(t *testing.T) {
 // TestM4c1_PRB_FSM_Exported asserts the ACK/response/final-ACK FSM is
 // published. Fails today.
 func TestM4c1_PRB_FSM_Exported(t *testing.T) {
-	t.Skip("M4c1 PR-B impl pending — see issue/138 PR-B dispatch")
 	if responderExportRegistry == nil {
 		t.Fatalf("M4c1 PR-B: protocol/responder package has no exported FSM yet")
 	}
@@ -51,9 +48,19 @@ func TestM4c1_PRB_FSM_Exported(t *testing.T) {
 // dropped without emitting an ACK or advancing the FSM. Stubbed — fails
 // today because the harness is absent.
 func TestM4c1_PRB_LocalResponderAddressFilter_DropsNonLocalZZ(t *testing.T) {
-	t.Skip("M4c1 PR-B impl pending — see issue/138 PR-B dispatch")
 	// End-state: call dispatcher.Handle(frame{ZZ: 0x10}) with local=0x71 and
 	// assert the FSM stayed in Idle and no outbound byte was queued.
-	// Until PR-B lands there is no dispatcher to call.
-	t.Fatalf("M4c1 PR-B: LocalResponderDispatcher ZZ filter harness absent — end-state requires drop+no-ACK when ZZ != local responder addr")
+	fsm := NewFSM()
+	disp := NewLocalResponderDispatcher(0x71, fsm)
+	frame := DecodedFrame{Source: 0x03, Target: 0x10, Primary: 0x07, Secondary: 0x04}
+	accepted := disp.Handle(frame)
+	if accepted {
+		t.Fatalf("M4c1 PR-B: LocalResponderDispatcher accepted non-local ZZ (want drop)")
+	}
+	if fsm.State() != StateIdle {
+		t.Fatalf("M4c1 PR-B: FSM advanced on non-local ZZ (state=%s, want StateIdle)", fsm.State())
+	}
+	if got := disp.Dropped(); got != 1 {
+		t.Fatalf("M4c1 PR-B: dropped counter = %d, want 1", got)
+	}
 }

--- a/protocol/responder/frame_decoder_test.go
+++ b/protocol/responder/frame_decoder_test.go
@@ -6,6 +6,7 @@
 package responder
 
 import (
+	"errors"
 	"testing"
 )
 
@@ -53,7 +54,10 @@ func TestM4c1_PRB_LocalResponderAddressFilter_DropsNonLocalZZ(t *testing.T) {
 	fsm := NewFSM()
 	disp := NewLocalResponderDispatcher(0x71, fsm)
 	frame := DecodedFrame{Source: 0x03, Target: 0x10, Primary: 0x07, Secondary: 0x04}
-	accepted := disp.Handle(frame)
+	accepted, err := disp.Handle(frame)
+	if err != nil {
+		t.Fatalf("M4c1 PR-B: non-local ZZ surfaced error = %v, want nil (silent drop)", err)
+	}
 	if accepted {
 		t.Fatalf("M4c1 PR-B: LocalResponderDispatcher accepted non-local ZZ (want drop)")
 	}
@@ -62,5 +66,43 @@ func TestM4c1_PRB_LocalResponderAddressFilter_DropsNonLocalZZ(t *testing.T) {
 	}
 	if got := disp.Dropped(); got != 1 {
 		t.Fatalf("M4c1 PR-B: dropped counter = %d, want 1", got)
+	}
+}
+
+// TestM4c1_PRB_Dispatcher_Handle_PropagatesInvalidTransition asserts that
+// when a local-addressed frame arrives while the FSM is not in StateIdle
+// (e.g. duplicate/new inbound request before the previous exchange has
+// completed), Handle surfaces ErrInvalidTransition instead of silently
+// reporting `accepted=true`. Regression guard for Codex P1 finding on PR
+// #140 (handle discarded the FSM error).
+func TestM4c1_PRB_Dispatcher_Handle_PropagatesInvalidTransition(t *testing.T) {
+	fsm := NewFSM()
+	// Drive FSM out of StateIdle: Idle → AckReceived → ResponseSent.
+	if _, err := fsm.OnInboundFrame(true); err != nil {
+		t.Fatalf("setup: OnInboundFrame: %v", err)
+	}
+	if _, err := fsm.OnEmitResponse(); err != nil {
+		t.Fatalf("setup: OnEmitResponse: %v", err)
+	}
+	if got := fsm.State(); got != StateResponseSent {
+		t.Fatalf("setup: FSM state = %s, want StateResponseSent", got)
+	}
+
+	disp := NewLocalResponderDispatcher(0x71, fsm)
+	frame := DecodedFrame{Source: 0x03, Target: 0x71, Primary: 0x07, Secondary: 0x04}
+	accepted, err := disp.Handle(frame)
+	if accepted {
+		t.Fatalf("Handle accepted=true while FSM was StateResponseSent (want accepted=false)")
+	}
+	if err == nil {
+		t.Fatalf("Handle err = nil, want ErrInvalidTransition surfaced to caller")
+	}
+	if !errors.Is(err, ErrInvalidTransition) {
+		t.Fatalf("Handle err = %v, want ErrInvalidTransition", err)
+	}
+	// Dropped counter MUST NOT increment on FSM rejection — the frame was
+	// local (ZZ matched), not filtered by the bus-hygiene drop path.
+	if got := disp.Dropped(); got != 0 {
+		t.Fatalf("dropped counter = %d, want 0 (FSM reject is not a ZZ-filter drop)", got)
 	}
 }

--- a/protocol/responder/fsm.go
+++ b/protocol/responder/fsm.go
@@ -1,0 +1,172 @@
+// M4c1 PR-B: responder ACK / response / final-ACK FSM.
+//
+// States (see `fsm_test.go` for the locked contract):
+//
+//	Idle
+//	  └─(inbound-frame-for-local, CRC ok)────▶ AckReceived
+//	  └─(inbound-frame-for-local, CRC bad)───▶ NackReceived ──▶ Idle
+//	AckReceived
+//	  └─(emit ACK)──▶ ResponseSent (after emitting response payload)
+//	ResponseSent
+//	  └─(initiator final ACK)──▶ Idle
+//	  └─(initiator NACK, retries < N)──▶ AckReceived (re-send)
+//	  └─(initiator NACK, retries = N)──▶ Idle (aborted)
+
+package responder
+
+import (
+	"errors"
+	"reflect"
+	"sync"
+)
+
+// State is the FSM state type.
+type State int
+
+// FSM state constants. The exact names are locked by
+// `TestM4c1_PRB_FSM_States_Declared`.
+const (
+	StateIdle State = iota
+	StateAckReceived
+	StateNackReceived
+	StateResponseSent
+)
+
+// String returns the state's declared identifier.
+func (s State) String() string {
+	switch s {
+	case StateIdle:
+		return "StateIdle"
+	case StateAckReceived:
+		return "StateAckReceived"
+	case StateNackReceived:
+		return "StateNackReceived"
+	case StateResponseSent:
+		return "StateResponseSent"
+	default:
+		return "StateUnknown"
+	}
+}
+
+// FSM-level errors.
+var (
+	// ErrInvalidTransition is returned when a transition method is
+	// called from a state that does not permit it.
+	ErrInvalidTransition = errors.New("responder: invalid FSM transition")
+	// ErrRetriesExhausted is returned from OnInitiatorNack when the
+	// configured retry budget has been consumed.
+	ErrRetriesExhausted = errors.New("responder: retries exhausted")
+)
+
+// DefaultMaxNackRetries is the default retry budget for ResponseSent →
+// AckReceived re-send. Conservative value per eBUS spec (typical
+// responder-side retry budget is 1–3). Callers may override via
+// `FSM.MaxNackRetries`.
+const DefaultMaxNackRetries = 3
+
+// FSM implements the responder state machine. All public methods are safe
+// for concurrent use (mutex-guarded).
+type FSM struct {
+	mu             sync.Mutex
+	state          State
+	retries        int
+	MaxNackRetries int
+}
+
+// NewFSM returns an FSM in StateIdle.
+func NewFSM() *FSM {
+	return &FSM{
+		state:          StateIdle,
+		MaxNackRetries: DefaultMaxNackRetries,
+	}
+}
+
+// State returns the current FSM state.
+func (f *FSM) State() State {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.state
+}
+
+// OnInboundFrame records the receipt of an inbound-for-local frame.
+// `crcOk` selects the Idle → AckReceived (true) or
+// Idle → NackReceived (false) edge. NackReceived auto-recovers to Idle.
+func (f *FSM) OnInboundFrame(crcOk bool) (State, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.state != StateIdle {
+		return f.state, ErrInvalidTransition
+	}
+	if crcOk {
+		f.state = StateAckReceived
+		f.retries = 0
+	} else {
+		// Transient NackReceived → auto-recover to Idle in a single
+		// atomic transition. Observers using State() see Idle; the
+		// explicit NackReceived state is declared so the FSM surface
+		// is complete per the locked spec.
+		f.state = StateNackReceived
+		f.state = StateIdle
+	}
+	return f.state, nil
+}
+
+// OnEmitResponse advances AckReceived → ResponseSent after the responder
+// has emitted its ACK+payload onto the wire.
+func (f *FSM) OnEmitResponse() (State, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.state != StateAckReceived {
+		return f.state, ErrInvalidTransition
+	}
+	f.state = StateResponseSent
+	return f.state, nil
+}
+
+// OnInitiatorFinalAck advances ResponseSent → Idle when the initiator's
+// final ACK has been observed.
+func (f *FSM) OnInitiatorFinalAck() (State, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.state != StateResponseSent {
+		return f.state, ErrInvalidTransition
+	}
+	f.state = StateIdle
+	f.retries = 0
+	return f.state, nil
+}
+
+// OnInitiatorNack reacts to an initiator NACK in ResponseSent. If retries
+// remain it returns AckReceived (caller re-emits the response). If the
+// retry budget is exhausted it returns Idle + ErrRetriesExhausted.
+func (f *FSM) OnInitiatorNack() (State, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.state != StateResponseSent {
+		return f.state, ErrInvalidTransition
+	}
+	f.retries++
+	if f.retries >= f.MaxNackRetries {
+		f.state = StateIdle
+		return f.state, ErrRetriesExhausted
+	}
+	f.state = StateAckReceived
+	return f.state, nil
+}
+
+// Reset forces the FSM back to Idle. Intended for test harnesses and
+// recovery after unrecoverable transport error.
+func (f *FSM) Reset() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.state = StateIdle
+	f.retries = 0
+}
+
+func init() {
+	registerExport("FSM", reflect.TypeOf((*FSM)(nil)))
+	registerExport("StateIdle", StateIdle)
+	registerExport("StateAckReceived", StateAckReceived)
+	registerExport("StateNackReceived", StateNackReceived)
+	registerExport("StateResponseSent", StateResponseSent)
+}

--- a/protocol/responder/fsm.go
+++ b/protocol/responder/fsm.go
@@ -145,11 +145,15 @@ func (f *FSM) OnInitiatorNack() (State, error) {
 	if f.state != StateResponseSent {
 		return f.state, ErrInvalidTransition
 	}
-	f.retries++
+	// Invariant: MaxNackRetries=N permits exactly N retries. The N-th
+	// retry succeeds (returns StateAckReceived); the (N+1)-th NACK
+	// exhausts the budget. Compare BEFORE incrementing so that f.retries
+	// records the number of retries already consumed.
 	if f.retries >= f.MaxNackRetries {
 		f.state = StateIdle
 		return f.state, ErrRetriesExhausted
 	}
+	f.retries++
 	f.state = StateAckReceived
 	return f.state, nil
 }

--- a/protocol/responder/fsm_test.go
+++ b/protocol/responder/fsm_test.go
@@ -16,7 +16,11 @@
 
 package responder
 
-import "testing"
+import (
+	"errors"
+	"fmt"
+	"testing"
+)
 
 // Expected state constant names, in declaration order. PR-B GREEN must
 // export these as a named-int type `State` with String() values matching
@@ -105,6 +109,9 @@ func TestM4c1_PRB_FSM_Transition_ResponseSentToAckReceived_OnInitiatorNack_Retry
 }
 
 func TestM4c1_PRB_FSM_Transition_ResponseSentToIdle_OnInitiatorNack_Exhausted(t *testing.T) {
+	// With MaxNackRetries=1 the FSM permits exactly one retry. The first
+	// NACK returns StateAckReceived (the single allowed retry); the second
+	// NACK exhausts the budget and returns StateIdle + ErrRetriesExhausted.
 	fsm := NewFSM()
 	fsm.MaxNackRetries = 1
 	if _, err := fsm.OnInboundFrame(true); err != nil {
@@ -113,11 +120,66 @@ func TestM4c1_PRB_FSM_Transition_ResponseSentToIdle_OnInitiatorNack_Exhausted(t 
 	if _, err := fsm.OnEmitResponse(); err != nil {
 		t.Fatalf("prime OnEmitResponse: %v", err)
 	}
+	// 1st NACK: within budget → retry (StateAckReceived).
 	s, err := fsm.OnInitiatorNack()
+	if err != nil {
+		t.Fatalf("M4c1 PR-B: OnInitiatorNack #1 within budget returned err: %v", err)
+	}
+	if s != StateAckReceived {
+		t.Fatalf("M4c1 PR-B: OnInitiatorNack #1 = %s, want StateAckReceived", s)
+	}
+	// Re-emit to return to ResponseSent.
+	if _, err := fsm.OnEmitResponse(); err != nil {
+		t.Fatalf("prime OnEmitResponse (2): %v", err)
+	}
+	// 2nd NACK: budget consumed → exhausted.
+	s, err = fsm.OnInitiatorNack()
 	if err == nil {
-		t.Fatalf("M4c1 PR-B: OnInitiatorNack with retries=1 should exhaust, got no err")
+		t.Fatalf("M4c1 PR-B: OnInitiatorNack #2 with budget=1 should exhaust, got no err")
 	}
 	if s != StateIdle {
 		t.Fatalf("M4c1 PR-B: ResponseSent→? on NACK (exhausted) = %s, want StateIdle", s)
+	}
+}
+
+// TestM4c1_PRB_FSM_OnInitiatorNack_RespectsExactBudget locks the retry-budget
+// invariant: with MaxNackRetries=N the FSM permits exactly N retries (each
+// returning StateAckReceived) and aborts on the (N+1)-th NACK with
+// ErrRetriesExhausted + StateIdle. Regression guard for the off-by-one that
+// pre-incremented f.retries before the budget check.
+func TestM4c1_PRB_FSM_OnInitiatorNack_RespectsExactBudget(t *testing.T) {
+	for _, N := range []int{1, 2, 3, 5} {
+		t.Run(fmt.Sprintf("N=%d", N), func(t *testing.T) {
+			fsm := NewFSM()
+			fsm.MaxNackRetries = N
+			if _, err := fsm.OnInboundFrame(true); err != nil {
+				t.Fatalf("prime OnInboundFrame: %v", err)
+			}
+			if _, err := fsm.OnEmitResponse(); err != nil {
+				t.Fatalf("prime OnEmitResponse: %v", err)
+			}
+			// N NACKs must all succeed with StateAckReceived; re-emit
+			// after each to return to StateResponseSent.
+			for i := 1; i <= N; i++ {
+				s, err := fsm.OnInitiatorNack()
+				if err != nil {
+					t.Fatalf("N=%d NACK #%d within budget returned err: %v", N, i, err)
+				}
+				if s != StateAckReceived {
+					t.Fatalf("N=%d NACK #%d = %s, want StateAckReceived", N, i, s)
+				}
+				if _, err := fsm.OnEmitResponse(); err != nil {
+					t.Fatalf("N=%d re-emit after NACK #%d: %v", N, i, err)
+				}
+			}
+			// (N+1)-th NACK: exhausted.
+			s, err := fsm.OnInitiatorNack()
+			if !errors.Is(err, ErrRetriesExhausted) {
+				t.Fatalf("N=%d NACK #%d want ErrRetriesExhausted, got err=%v", N, N+1, err)
+			}
+			if s != StateIdle {
+				t.Fatalf("N=%d NACK #%d = %s, want StateIdle", N, N+1, s)
+			}
+		})
 	}
 }

--- a/protocol/responder/fsm_test.go
+++ b/protocol/responder/fsm_test.go
@@ -29,7 +29,6 @@ var expectedFSMStates = []string{
 }
 
 func TestM4c1_PRB_FSM_States_Declared(t *testing.T) {
-	t.Skip("M4c1 PR-B impl pending — see issue/138 PR-B dispatch")
 	if responderExportRegistry == nil {
 		t.Fatalf("M4c1 PR-B: protocol/responder FSM state constants not declared yet")
 	}
@@ -41,28 +40,84 @@ func TestM4c1_PRB_FSM_States_Declared(t *testing.T) {
 }
 
 func TestM4c1_PRB_FSM_Transition_IdleToAckReceived_OnValidInbound(t *testing.T) {
-	t.Skip("M4c1 PR-B impl pending — see issue/138 PR-B dispatch")
 	// End-state: construct FSM in StateIdle, feed a valid for-local-responder
 	// frame, assert transition to StateAckReceived.
-	t.Fatalf("M4c1 PR-B: FSM transition harness absent — Idle→AckReceived on valid inbound")
+	fsm := NewFSM()
+	if fsm.State() != StateIdle {
+		t.Fatalf("M4c1 PR-B: initial FSM state = %s, want StateIdle", fsm.State())
+	}
+	s, err := fsm.OnInboundFrame(true)
+	if err != nil {
+		t.Fatalf("M4c1 PR-B: OnInboundFrame(true) from Idle returned err: %v", err)
+	}
+	if s != StateAckReceived {
+		t.Fatalf("M4c1 PR-B: Idle→? on valid inbound = %s, want StateAckReceived", s)
+	}
 }
 
 func TestM4c1_PRB_FSM_Transition_AckReceivedToResponseSent_OnEmit(t *testing.T) {
-	t.Skip("M4c1 PR-B impl pending — see issue/138 PR-B dispatch")
-	t.Fatalf("M4c1 PR-B: FSM transition harness absent — AckReceived→ResponseSent on payload emit")
+	fsm := NewFSM()
+	if _, err := fsm.OnInboundFrame(true); err != nil {
+		t.Fatalf("M4c1 PR-B: priming to AckReceived failed: %v", err)
+	}
+	s, err := fsm.OnEmitResponse()
+	if err != nil {
+		t.Fatalf("M4c1 PR-B: OnEmitResponse from AckReceived returned err: %v", err)
+	}
+	if s != StateResponseSent {
+		t.Fatalf("M4c1 PR-B: AckReceived→? on emit = %s, want StateResponseSent", s)
+	}
 }
 
 func TestM4c1_PRB_FSM_Transition_ResponseSentToIdle_OnFinalAck(t *testing.T) {
-	t.Skip("M4c1 PR-B impl pending — see issue/138 PR-B dispatch")
-	t.Fatalf("M4c1 PR-B: FSM transition harness absent — ResponseSent→Idle on initiator final ACK")
+	fsm := NewFSM()
+	if _, err := fsm.OnInboundFrame(true); err != nil {
+		t.Fatalf("prime OnInboundFrame: %v", err)
+	}
+	if _, err := fsm.OnEmitResponse(); err != nil {
+		t.Fatalf("prime OnEmitResponse: %v", err)
+	}
+	s, err := fsm.OnInitiatorFinalAck()
+	if err != nil {
+		t.Fatalf("M4c1 PR-B: OnInitiatorFinalAck from ResponseSent returned err: %v", err)
+	}
+	if s != StateIdle {
+		t.Fatalf("M4c1 PR-B: ResponseSent→? on final ACK = %s, want StateIdle", s)
+	}
 }
 
 func TestM4c1_PRB_FSM_Transition_ResponseSentToAckReceived_OnInitiatorNack_Retry(t *testing.T) {
-	t.Skip("M4c1 PR-B impl pending — see issue/138 PR-B dispatch")
-	t.Fatalf("M4c1 PR-B: FSM retry transition harness absent — ResponseSent→AckReceived on NACK within retry budget")
+	fsm := NewFSM()
+	fsm.MaxNackRetries = 3
+	if _, err := fsm.OnInboundFrame(true); err != nil {
+		t.Fatalf("prime OnInboundFrame: %v", err)
+	}
+	if _, err := fsm.OnEmitResponse(); err != nil {
+		t.Fatalf("prime OnEmitResponse: %v", err)
+	}
+	s, err := fsm.OnInitiatorNack()
+	if err != nil {
+		t.Fatalf("M4c1 PR-B: OnInitiatorNack within budget returned err: %v", err)
+	}
+	if s != StateAckReceived {
+		t.Fatalf("M4c1 PR-B: ResponseSent→? on NACK (within budget) = %s, want StateAckReceived", s)
+	}
 }
 
 func TestM4c1_PRB_FSM_Transition_ResponseSentToIdle_OnInitiatorNack_Exhausted(t *testing.T) {
-	t.Skip("M4c1 PR-B impl pending — see issue/138 PR-B dispatch")
-	t.Fatalf("M4c1 PR-B: FSM abort transition harness absent — ResponseSent→Idle on NACK with retries exhausted")
+	fsm := NewFSM()
+	fsm.MaxNackRetries = 1
+	if _, err := fsm.OnInboundFrame(true); err != nil {
+		t.Fatalf("prime OnInboundFrame: %v", err)
+	}
+	if _, err := fsm.OnEmitResponse(); err != nil {
+		t.Fatalf("prime OnEmitResponse: %v", err)
+	}
+	s, err := fsm.OnInitiatorNack()
+	if err == nil {
+		t.Fatalf("M4c1 PR-B: OnInitiatorNack with retries=1 should exhaust, got no err")
+	}
+	if s != StateIdle {
+		t.Fatalf("M4c1 PR-B: ResponseSent→? on NACK (exhausted) = %s, want StateIdle", s)
+	}
 }

--- a/protocol/responder/timing_harness.go
+++ b/protocol/responder/timing_harness.go
@@ -1,0 +1,139 @@
+// M4c1 PR-B: responder ACK timing harness.
+//
+// Measures the elapsed wall-clock time between the moment the inbound
+// frame's final CRC byte was parsed OK (t0) and the moment the first ACK
+// byte is handed to the transport write path (t1). Compares elapsed
+// against responderAckBudget.
+//
+// Clock abstraction: tests inject a deterministic Clock; production uses
+// realClock (time.Now). This keeps the harness unit-testable without
+// relying on real wall-clock latency.
+//
+// BENCH-REPLACE obligation: the 15 ms budget below is a literature-backed
+// placeholder from the Vaillant eBUS target-response window cited in the
+// M4b1 spike artifact (§4 timing-budget row) and the eBUS Adapter 3.1
+// documentation. Per decision doc §7.1 no-go criterion (1), the operator
+// MUST run this harness on live BASV2 hardware before M4c2 IMPL GREEN and
+// replace the placeholder with the measured value. This PR ships the
+// measurement infrastructure; the measured constant is a separate
+// follow-up commit.
+
+package responder
+
+import (
+	"reflect"
+	"sync"
+	"time"
+)
+
+// responderAckBudget is the upper bound on the CRC-to-ACK elapsed window.
+//
+// BENCH-REPLACE: measured value from BASV2 bench pending per decision
+// §7.1 no-go criterion (1). Literature-backed placeholder derived from
+// the Vaillant eBUS target-response window (~15 ms after the initiator's
+// final CRC byte) cited in `_spike/m4b1-responder-feasibility.md` §4 and
+// the eBUS Adapter 3.1 documentation. Community cross-reference:
+// ebusd-esp32#14 on arbitration/turnaround timing.
+const responderAckBudget time.Duration = 15 * time.Millisecond
+
+// Clock is the time source used by the timing harness. `time.Now` is the
+// production implementation; tests inject a fake for determinism.
+type Clock interface {
+	Now() time.Time
+}
+
+// realClock is the production Clock (time.Now).
+type realClock struct{}
+
+func (realClock) Now() time.Time { return time.Now() }
+
+// TimingHarness measures the CRC-to-ACK elapsed window for a single
+// responder transaction. Each transaction should use a fresh harness (or
+// call Reset between uses). Safe for concurrent use; in practice one
+// transaction runs at a time.
+type TimingHarness struct {
+	mu            sync.Mutex
+	clock         Clock
+	inboundCRCAt  time.Time
+	ackEmitAt     time.Time
+	haveInboundAt bool
+	haveAckAt     bool
+}
+
+// NewTimingHarness constructs a harness backed by the real clock.
+func NewTimingHarness() *TimingHarness {
+	return &TimingHarness{clock: realClock{}}
+}
+
+// NewTimingHarnessWithClock constructs a harness with an injected clock.
+func NewTimingHarnessWithClock(c Clock) *TimingHarness {
+	if c == nil {
+		c = realClock{}
+	}
+	return &TimingHarness{clock: c}
+}
+
+// MarkInboundCRCOk records t0 — the moment the inbound frame's final CRC
+// byte was parsed OK. If `at` is the zero time, the harness's clock is
+// consulted.
+func (h *TimingHarness) MarkInboundCRCOk(at time.Time) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if at.IsZero() {
+		at = h.clock.Now()
+	}
+	h.inboundCRCAt = at
+	h.haveInboundAt = true
+}
+
+// MarkAckEmit records t1 — the moment the first ACK byte was handed to
+// the transport write path. If `at` is the zero time, the harness's clock
+// is consulted.
+func (h *TimingHarness) MarkAckEmit(at time.Time) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if at.IsZero() {
+		at = h.clock.Now()
+	}
+	h.ackEmitAt = at
+	h.haveAckAt = true
+}
+
+// Elapsed returns t1 - t0. Returns 0 and false if either mark is missing.
+func (h *TimingHarness) Elapsed() (time.Duration, bool) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	if !h.haveInboundAt || !h.haveAckAt {
+		return 0, false
+	}
+	return h.ackEmitAt.Sub(h.inboundCRCAt), true
+}
+
+// WithinBudget returns true iff Elapsed() is present and <=
+// responderAckBudget.
+func (h *TimingHarness) WithinBudget() bool {
+	elapsed, ok := h.Elapsed()
+	if !ok {
+		return false
+	}
+	return elapsed <= responderAckBudget
+}
+
+// Budget returns the currently configured ACK budget.
+func (h *TimingHarness) Budget() time.Duration {
+	return responderAckBudget
+}
+
+// Reset clears the recorded marks so the harness can be reused.
+func (h *TimingHarness) Reset() {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+	h.inboundCRCAt = time.Time{}
+	h.ackEmitAt = time.Time{}
+	h.haveInboundAt = false
+	h.haveAckAt = false
+}
+
+func init() {
+	registerExport("TimingHarness", reflect.TypeOf((*TimingHarness)(nil)))
+}

--- a/protocol/responder/timing_harness.go
+++ b/protocol/responder/timing_harness.go
@@ -109,11 +109,21 @@ func (h *TimingHarness) Elapsed() (time.Duration, bool) {
 	return h.ackEmitAt.Sub(h.inboundCRCAt), true
 }
 
-// WithinBudget returns true iff Elapsed() is present and <=
-// responderAckBudget.
+// WithinBudget returns true iff Elapsed() is present, non-negative, and
+// <= responderAckBudget.
+//
+// Fail-closed on negative durations: a negative elapsed (ackEmitAt <
+// inboundCRCAt) indicates out-of-order timestamps — concurrent
+// instrumentation, a clock that went backwards, or a test injecting
+// inverted marks. Treating such a value as "in budget" would mask a real
+// measurement-integrity bug, so WithinBudget returns false rather than
+// silently passing.
 func (h *TimingHarness) WithinBudget() bool {
 	elapsed, ok := h.Elapsed()
 	if !ok {
+		return false
+	}
+	if elapsed < 0 {
 		return false
 	}
 	return elapsed <= responderAckBudget

--- a/protocol/responder/timing_harness_test.go
+++ b/protocol/responder/timing_harness_test.go
@@ -19,14 +19,15 @@ import (
 	"time"
 )
 
-// responderAckBudgetPlaceholder is the RED sentinel. PR-B GREEN replaces
-// this with an empirically measured budget (BASV2 live bench, per §6.1 of
-// the M4b2 decision doc). The zero value guarantees the RED test fails
-// regardless of any accidental fast path.
-const responderAckBudgetPlaceholder time.Duration = 0
+// responderAckBudgetPlaceholder mirrors the production `responderAckBudget`
+// constant for the RED→GREEN contract test. PR-B GREEN pinned the value
+// to a literature-backed 15 ms placeholder (Vaillant eBUS target-response
+// window per `_spike/m4b1-responder-feasibility.md` §4). Per decision
+// doc §7.1(1) the operator MUST replace this with a measured BASV2 bench
+// value before M4c2 IMPL GREEN (BENCH-REPLACE in `timing_harness.go`).
+const responderAckBudgetPlaceholder time.Duration = 15 * time.Millisecond
 
 func TestM4c1_PRB_TimingHarness_Exists(t *testing.T) {
-	t.Skip("M4c1 PR-B impl pending — see issue/138 PR-B dispatch")
 	if responderExportRegistry == nil {
 		t.Fatalf("M4c1 PR-B: timing harness not yet present — expected exported TimingHarness type")
 	}
@@ -36,18 +37,30 @@ func TestM4c1_PRB_TimingHarness_Exists(t *testing.T) {
 }
 
 func TestM4c1_PRB_TimingHarness_MeasuresCRCToAckElapsed(t *testing.T) {
-	t.Skip("M4c1 PR-B impl pending — see issue/138 PR-B dispatch")
-	// End-state harness shape (pseudo):
+	// End-state harness shape:
 	//   h := responder.NewTimingHarness()
 	//   h.MarkInboundCRCOk(t0)
 	//   h.MarkAckEmit(t1)
 	//   elapsed := h.Elapsed()
 	//   if elapsed > responderAckBudget { t.Fatalf(...) }
-	t.Fatalf("M4c1 PR-B: TimingHarness.Elapsed() not implemented — CRC→ACK measurement unavailable")
+	t0 := time.Unix(0, 0)
+	t1 := t0.Add(2 * time.Millisecond)
+	h := NewTimingHarness()
+	h.MarkInboundCRCOk(t0)
+	h.MarkAckEmit(t1)
+	elapsed, ok := h.Elapsed()
+	if !ok {
+		t.Fatalf("M4c1 PR-B: Elapsed() reported not-ok after both marks recorded")
+	}
+	if elapsed != 2*time.Millisecond {
+		t.Fatalf("M4c1 PR-B: Elapsed() = %v, want 2ms", elapsed)
+	}
+	if !h.WithinBudget() {
+		t.Fatalf("M4c1 PR-B: WithinBudget() = false with elapsed=2ms, budget=%v", h.Budget())
+	}
 }
 
 func TestM4c1_PRB_TimingHarness_BudgetAssertion_Placeholder(t *testing.T) {
-	t.Skip("M4c1 PR-B impl pending — see issue/138 PR-B dispatch")
 	// Budget pinned to zero in RED; PR-B GREEN must replace
 	// responderAckBudgetPlaceholder with a real, bench-measured constant
 	// and update this assertion accordingly.

--- a/protocol/responder/timing_harness_test.go
+++ b/protocol/responder/timing_harness_test.go
@@ -60,6 +60,30 @@ func TestM4c1_PRB_TimingHarness_MeasuresCRCToAckElapsed(t *testing.T) {
 	}
 }
 
+// TestM4c1_PRB_TimingHarness_NegativeElapsed_IsInvalid locks the fail-closed
+// contract: inverted timestamps (ackEmitAt < inboundCRCAt) must NOT be
+// reported as within budget. Regression guard for the silent pass-through
+// where a signed raw Sub() result landed under the upper-bound check and
+// hid measurement-integrity bugs.
+func TestM4c1_PRB_TimingHarness_NegativeElapsed_IsInvalid(t *testing.T) {
+	// Inject inverted marks: ackEmitAt is BEFORE inboundCRCAt.
+	t0 := time.Unix(0, int64(5*time.Millisecond))
+	t1 := time.Unix(0, int64(1*time.Millisecond))
+	h := NewTimingHarness()
+	h.MarkInboundCRCOk(t0)
+	h.MarkAckEmit(t1)
+	elapsed, ok := h.Elapsed()
+	if !ok {
+		t.Fatalf("M4c1 PR-B: Elapsed() reported not-ok after both marks recorded")
+	}
+	if elapsed >= 0 {
+		t.Fatalf("M4c1 PR-B: inverted marks should produce negative elapsed, got %v", elapsed)
+	}
+	if h.WithinBudget() {
+		t.Fatalf("M4c1 PR-B: WithinBudget() = true with negative elapsed=%v — fail-closed invariant violated", elapsed)
+	}
+}
+
 func TestM4c1_PRB_TimingHarness_BudgetAssertion_Placeholder(t *testing.T) {
 	// Budget pinned to zero in RED; PR-B GREEN must replace
 	// responderAckBudgetPlaceholder with a real, bench-measured constant


### PR DESCRIPTION
## Summary

M4c1 PR-B green-phase implementation. Lands the `protocol/responder` package per decision doc `helianthus-execution-plans/ebus-standard-l7-services-w16-26.implementing/decisions/m4b2-responder-go-no-go.md` §6.1.

Completes M4c1 scope; unblocks M4c2 (gateway runtime wiring) + M4D (responder-role NM interrogator / `07 04` responder).

### Changes

- `protocol/responder/frame_decoder.go` — inbound frame parser (header + CRC validation + PB/SB/payload extraction)
- `protocol/responder/dispatcher.go` — `LocalResponderDispatcher` routes frames where ZZ matches the configured local responder address; drops non-local frames silently (bus-hygiene invariant)
- `protocol/responder/fsm.go` — `StateIdle → StateAckReceived → StateResponseSent → {StateIdle | retry | aborted}` state machine, mutex-guarded
- `protocol/responder/timing_harness.go` — clock-injected CRC-to-ACK latency meter
- `protocol/responder/doc.go` — lazy-init sentinel registry populated from each file's `init()`
- Test files: `t.Skip` lines removed (skip-unskip pattern); placeholder `t.Fatalf("harness absent")` bodies replaced with real assertions.

### PR-A interface surface — untouched

`transport/` files are not modified. The PR-A `transport.ResponderTransport` interface remains the thin capability surface; PR-B consumes that capability at a higher layer (actual write integration happens in M4c2 gateway runtime).

### Timing budget — BENCH-REPLACE obligation

`responderAckBudget = 15 * time.Millisecond` is a **literature-backed placeholder** derived from the Vaillant eBUS target-response window cited in `_spike/m4b1-responder-feasibility.md` §4 and eBUS Adapter 3.1 documentation (community cross-ref: ebusd-esp32#14 on turnaround timing).

**Operator obligation** per decision doc §7.1 no-go criterion (1): run the harness on live BASV2 hardware before M4c2 IMPL GREEN and commit the measured budget as a follow-up. Clear `BENCH-REPLACE:` comment flags the line in `timing_harness.go`.

## Verification

- 13/13 previously-skipped PR-B tests now green
- Full repo test suite: green (all packages)
- `./scripts/ci_local.sh`: green (terminology, gofmt, vet, build, test -race, golangci-lint, transport-gate, tinygo build) — EXIT=0
- Terminology gate: green (initiator/responder vocabulary throughout)

## Test plan

- [x] `go test ./protocol/responder/... -v` → 13/13 PASS
- [x] `go test ./...` → green
- [x] `./scripts/ci_local.sh` → green
- [ ] Operator: run timing harness on live BASV2; replace 15ms placeholder with measured value before M4c2 GREEN
- [ ] Codex review

## References

- Issue: #138 (PR-B scope)
- Meta: Project-Helianthus/helianthus-execution-plans#14
- Decision doc: helianthus-execution-plans#17 (squash 567a6798) §6.1, §7.1
- Spike: `spike/m4b1-responder-feasibility` §4 (timing-budget row)
- PR-A: #139 (squash e5c8841) — `transport.ResponderTransport` interface

🤖 Generated with [Claude Code](https://claude.com/claude-code)