### PR TITLE
chore: gitignore .claude/ orchestrator-session artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 AGENT-local.md
 tinygo-check
+
+# Claude Code orchestrator-session artifacts (per-session tool/skills config, not repo-tracked)
+.claude/


### PR DESCRIPTION
Gitignore Claude Code .claude/ directories (per-session tool/skills config, similar to .vscode/.idea/). Not repo-level infrastructure; workspace-root skills read from filesystem so cross-repo review infra unaffected.

LANE C internal chore. No logic change.