### PR TITLE
feat(protocol): M0B + M2 + ACKCorrelation — Companion(addr) + ACKCorrelation type for AD04 disambiguation (RED→GREEN)

### DIFF
--- a/protocol/ack_correlation.go
+++ b/protocol/ack_correlation.go
@@ -1,0 +1,20 @@
+package protocol
+
+type ACKPosition string
+
+const (
+	ACKPositionRequestACK ACKPosition = "request_ack"
+)
+
+type ACKCorrelator string
+
+const (
+	ACKCorrelatorM2A ACKCorrelator = "M2A"
+)
+
+type ACKCorrelation struct {
+	Byte            byte
+	Position        ACKPosition
+	CompleteRequest bool
+	Correlator      ACKCorrelator
+}

--- a/protocol/companion.go
+++ b/protocol/companion.go
@@ -1,7 +1,7 @@
 package protocol
 
-// Companion returns the eBUS companion address (master/slave pair) for addr,
-// per the eBUS standard (master+5 / slave-5) with bit-pattern validity check.
+// Companion returns the eBUS companion address (initiator/target pair) for addr,
+// per the eBUS standard (initiator+5 / target-5) with bit-pattern validity check.
 // Returns (companion, true) when a valid pair exists, else (0, false).
 //
 // Decision references: AD03, AD04 (frame-position disambiguation for 0xFF

--- a/protocol/companion.go
+++ b/protocol/companion.go
@@ -1,0 +1,19 @@
+package protocol
+
+// Companion returns the eBUS companion address (master/slave pair) for addr,
+// per the eBUS standard (master+5 / slave-5) with bit-pattern validity check.
+// Returns (companion, true) when a valid pair exists, else (0, false).
+//
+// Decision references: AD03, AD04 (frame-position disambiguation for 0xFF
+// is the caller's responsibility; this function operates on already-
+// disambiguated address bytes).
+func Companion(addr byte) (byte, bool) {
+	if IsInitiatorCapableAddress(addr) {
+		return addr + 0x05, true
+	}
+	candidate := byte((int(addr) - 0x05) & 0xFF)
+	if IsInitiatorCapableAddress(candidate) {
+		return candidate, true
+	}
+	return 0, false
+}

--- a/protocol/companion_test.go
+++ b/protocol/companion_test.go
@@ -13,14 +13,14 @@ func TestCompanion_OperatorPinnedCases(t *testing.T) {
 		want      byte
 		wantFound bool
 	}{
-		{"master 0x04 to slave 0xFF", 0x04, 0xFF, true},
-		{"slave 0xFF to master 0x04", 0xFF, 0x04, true},
-		{"master 0xF1 to slave 0xF6", 0xF1, 0xF6, true},
-		{"slave 0xF6 to master 0xF1", 0xF6, 0xF1, true},
-		{"master 0x08 to slave 0x03", 0x08, 0x03, true},
-		{"slave 0x03 to master 0x08", 0x03, 0x08, true},
-		{"master 0x10 to slave 0x15", 0x10, 0x15, true},
-		{"slave 0x15 to master 0x10", 0x15, 0x10, true},
+		{"initiator 0x04 to target 0xFF", 0x04, 0xFF, true},
+		{"target 0xFF to initiator 0x04", 0xFF, 0x04, true},
+		{"initiator 0xF1 to target 0xF6", 0xF1, 0xF6, true},
+		{"target 0xF6 to initiator 0xF1", 0xF6, 0xF1, true},
+		{"initiator 0x08 to target 0x03", 0x08, 0x03, true},
+		{"target 0x03 to initiator 0x08", 0x03, 0x08, true},
+		{"initiator 0x10 to target 0x15", 0x10, 0x15, true},
+		{"target 0x15 to initiator 0x10", 0x15, 0x10, true},
 	}
 
 	for _, tc := range tests {
@@ -43,8 +43,8 @@ func TestCompanion_NoMasterPair(t *testing.T) {
 		name string
 		addr byte
 	}{
-		{"0x26 has no initiator-capable 0x21 master", 0x26},
-		{"0xEC has no initiator-capable 0xE7 master", 0xEC},
+		{"0x26 has no initiator-capable 0x21 initiator-capable byte", 0x26},
+		{"0xEC has no initiator-capable 0xE7 initiator-capable byte", 0xEC},
 	}
 
 	for _, tc := range tests {
@@ -69,16 +69,16 @@ func TestCompanion_MasterToSlave_OffsetFive(t *testing.T) {
 			continue
 		}
 
-		slave, found := Companion(addr)
+		target, found := Companion(addr)
 		if !found {
 			t.Fatalf("Companion(0x%02X) found = false; want true", addr)
 		}
-		wantSlave := addr + 5
-		if slave != wantSlave {
-			t.Fatalf("Companion(0x%02X) = (0x%02X, true); want (0x%02X, true)", addr, slave, wantSlave)
+		wantTarget := addr + 5
+		if target != wantTarget {
+			t.Fatalf("Companion(0x%02X) = (0x%02X, true); want (0x%02X, true)", addr, target, wantTarget)
 		}
-		if gotMaster := slave - 5; gotMaster != addr {
-			t.Fatalf("Companion(0x%02X) round-trip master = 0x%02X; want 0x%02X", addr, gotMaster, addr)
+		if gotInitiator := target - 5; gotInitiator != addr {
+			t.Fatalf("Companion(0x%02X) round-trip initiator = 0x%02X; want 0x%02X", addr, gotInitiator, addr)
 		}
 	}
 }

--- a/protocol/companion_test.go
+++ b/protocol/companion_test.go
@@ -1,0 +1,84 @@
+package protocol
+
+import "testing"
+
+// RED tests for cruise plan address-table-registry-w19-26 M0B/ebusgo — references M2 Companion func that intentionally doesn't exist yet.
+
+func TestCompanion_OperatorPinnedCases(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		addr      byte
+		want      byte
+		wantFound bool
+	}{
+		{"master 0x04 to slave 0xFF", 0x04, 0xFF, true},
+		{"slave 0xFF to master 0x04", 0xFF, 0x04, true},
+		{"master 0xF1 to slave 0xF6", 0xF1, 0xF6, true},
+		{"slave 0xF6 to master 0xF1", 0xF6, 0xF1, true},
+		{"master 0x08 to slave 0x03", 0x08, 0x03, true},
+		{"slave 0x03 to master 0x08", 0x03, 0x08, true},
+		{"master 0x10 to slave 0x15", 0x10, 0x15, true},
+		{"slave 0x15 to master 0x10", 0x15, 0x10, true},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, found := Companion(tc.addr)
+			if got != tc.want || found != tc.wantFound {
+				t.Fatalf("Companion(0x%02X) = (0x%02X, %v); want (0x%02X, %v)", tc.addr, got, found, tc.want, tc.wantFound)
+			}
+		})
+	}
+}
+
+func TestCompanion_NoMasterPair(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		addr byte
+	}{
+		{"0x26 has no initiator-capable 0x21 master", 0x26},
+		{"0xEC has no initiator-capable 0xE7 master", 0xEC},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, found := Companion(tc.addr)
+			if got != 0 || found {
+				t.Fatalf("Companion(0x%02X) = (0x%02X, %v); want (0x00, false)", tc.addr, got, found)
+			}
+		})
+	}
+}
+
+func TestCompanion_MasterToSlave_OffsetFive(t *testing.T) {
+	t.Parallel()
+
+	for i := 0; i <= 0xFF; i++ {
+		addr := byte(i)
+		if !IsInitiatorCapableAddress(addr) {
+			continue
+		}
+
+		slave, found := Companion(addr)
+		if !found {
+			t.Fatalf("Companion(0x%02X) found = false; want true", addr)
+		}
+		wantSlave := addr + 5
+		if slave != wantSlave {
+			t.Fatalf("Companion(0x%02X) = (0x%02X, true); want (0x%02X, true)", addr, slave, wantSlave)
+		}
+		if gotMaster := slave - 5; gotMaster != addr {
+			t.Fatalf("Companion(0x%02X) round-trip master = 0x%02X; want 0x%02X", addr, gotMaster, addr)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

M2_COMPANION_PURE_FUNC of cruise plan [`address-table-registry-w19-26.locked`](https://github.com/Project-Helianthus/helianthus-execution-plans/tree/main/address-table-registry-w19-26.locked) (meta-issue [helianthus-execution-plans#23](https://github.com/Project-Helianthus/helianthus-execution-plans/issues/23)).

Per AD09 strict TDD: this PR contains both the M0B/ebusgo RED commit (test-only, intentionally failing) AND the M2 GREEN commit (impl turning the tests green). cruise-pr-review-loop verifies RED→GREEN ordering.

## RED→GREEN

**Commit 1** `test(protocol): RED for M0B Companion derivation` — RED tests for `protocol.Companion(addr) (byte, bool)` referencing the not-yet-existing function.

**Commit 2** `feat(protocol): M2 — Companion(addr) pure func per AD03` — implements companion arithmetic per eBUS standard:
- master+5 / slave-5 with bit-pattern validity (each nibble in {0x0, 0x1, 0x3, 0x7, 0xF})
- pinned cases pass: 0x04↔0xFF, 0xF1↔0xF6, 0x08↔0x03, 0x10↔0x15
- exception list: 0x26, 0xEC return (0, false) (no master pair)
- round-trip property: for all initiator-capable M, Companion(M)=(M+5, true) ∧ Companion(M+5)=(M, true)

## CI

- `go test ./protocol/...` GREEN
- `go vet ./protocol/...` GREEN
- `go build ./...` GREEN

🤖 Generated with [Claude Code](https://claude.com/claude-code)