### PR TITLE
feat(protocol): A.7a — canonical address table API + Companion rebased on docs-owned table

### DIFF
--- a/protocol/canonical_address_table.go
+++ b/protocol/canonical_address_table.go
@@ -1,0 +1,79 @@
+package protocol
+
+// Canonical address table API. All lookups in this file are O(1) via maps
+// derived once from sourceAddressTableV1 at package init. The
+// sourceAddressTableV1 itself is the docs-owned authoritative table from
+// architecture/ebus_standard/12-source-address-table.md (canonical hash
+// e78954445087f63064818ab60a2739b9a6b9bf0ae0147fbe92aac5ac76592103).
+//
+// These lookups replace ad-hoc math+nibble derivations. Math (+5/-5 with
+// IsInitiatorCapableAddress) happens to produce identical results for the 25
+// canonical pairs, but it does not expose tier (priority class) or free-use
+// metadata, and it cannot reject by-construction non-canonical addresses
+// (e.g. real devices like 0x26 / 0xEC that are not in the eBUS standard
+// pair table).
+//
+// Vocabulary: the eBUS standard table uses "Source" (initiator-capable,
+// arbitration-eligible address) and "Companion" (the responder-side
+// peer at Source+0x05 mod 0x100). These match the doc terms.
+
+var (
+	canonicalSourceToCompanion = map[byte]byte{}
+	canonicalCompanionToSource = map[byte]byte{}
+	canonicalSourceTier        = map[byte]SourceAddressPriorityIndex{}
+	canonicalSourceFreeUse     = map[byte]bool{}
+)
+
+func init() {
+	for _, row := range sourceAddressTableV1 {
+		canonicalSourceToCompanion[row.Source] = row.Companion
+		canonicalCompanionToSource[row.Companion] = row.Source
+		canonicalSourceTier[row.Source] = row.PriorityIndex
+		canonicalSourceFreeUse[row.Source] = row.FreeUse
+	}
+}
+
+// CompanionOfSource returns the canonical companion of source per the eBUS
+// standard table. Returns (0, false) for any non-canonical source.
+func CompanionOfSource(source byte) (byte, bool) {
+	companion, ok := canonicalSourceToCompanion[source]
+	return companion, ok
+}
+
+// SourceOfCompanion returns the canonical source of companion per the eBUS
+// standard table. Returns (0, false) for any non-canonical companion.
+func SourceOfCompanion(companion byte) (byte, bool) {
+	source, ok := canonicalCompanionToSource[companion]
+	return source, ok
+}
+
+// IsCanonicalSource reports whether addr is one of the 25 canonical source
+// addresses. This is stricter than IsInitiatorCapableAddress because it
+// asserts presence in the docs-owned table, not just nibble pattern
+// validity.
+func IsCanonicalSource(addr byte) bool {
+	_, ok := canonicalSourceToCompanion[addr]
+	return ok
+}
+
+// IsCanonicalCompanion reports whether addr is one of the 25 canonical
+// companion addresses per the eBUS standard table.
+func IsCanonicalCompanion(addr byte) bool {
+	_, ok := canonicalCompanionToSource[addr]
+	return ok
+}
+
+// SourceTier returns the priority class (p0..p4) of a canonical source.
+// Returns ("", false) for non-canonical sources.
+func SourceTier(source byte) (SourceAddressPriorityIndex, bool) {
+	tier, ok := canonicalSourceTier[source]
+	return tier, ok
+}
+
+// IsFreeUseSource reports whether a canonical source is marked free-use in
+// the eBUS standard table (used by Helianthus startup-source-selection
+// candidate ranking). Returns (false, false) for non-canonical sources.
+func IsFreeUseSource(source byte) (bool, bool) {
+	free, ok := canonicalSourceFreeUse[source]
+	return free, ok
+}

--- a/protocol/canonical_address_table_test.go
+++ b/protocol/canonical_address_table_test.go
@@ -1,0 +1,202 @@
+package protocol
+
+import "testing"
+
+// Tests for the canonical-address-table-derived companion API. These RED tests
+// verify that companion derivation, master/slave lookup, tier classification,
+// and free-use status are sourced from the docs-owned sourceAddressTableV1
+// (helianthus-docs-ebus/architecture/ebus_standard/12-source-address-table.md)
+// rather than from byte-arithmetic guesses with nibble-pattern checks.
+
+// canonicalPairs is the operator-pinned ground truth for the 25 canonical
+// master/slave pairs from the eBUS standard table. Tests assert each direction.
+var canonicalPairs = []struct {
+	master byte
+	slave  byte
+	tier   SourceAddressPriorityIndex
+	free   bool
+}{
+	{0x00, 0x05, SourceAddressPriorityP0, false},
+	{0x10, 0x15, SourceAddressPriorityP0, false},
+	{0x30, 0x35, SourceAddressPriorityP0, false},
+	{0x70, 0x75, SourceAddressPriorityP0, false},
+	{0xF0, 0xF5, SourceAddressPriorityP0, false},
+	{0x01, 0x06, SourceAddressPriorityP1, false},
+	{0x11, 0x16, SourceAddressPriorityP1, false},
+	{0x31, 0x36, SourceAddressPriorityP1, false},
+	{0x71, 0x76, SourceAddressPriorityP1, false},
+	{0xF1, 0xF6, SourceAddressPriorityP1, false},
+	{0x03, 0x08, SourceAddressPriorityP2, false},
+	{0x13, 0x18, SourceAddressPriorityP2, false},
+	{0x33, 0x38, SourceAddressPriorityP2, false},
+	{0x73, 0x78, SourceAddressPriorityP2, false},
+	{0xF3, 0xF8, SourceAddressPriorityP2, false},
+	{0x07, 0x0C, SourceAddressPriorityP3, true},
+	{0x17, 0x1C, SourceAddressPriorityP3, true},
+	{0x37, 0x3C, SourceAddressPriorityP3, true},
+	{0x77, 0x7C, SourceAddressPriorityP3, true},
+	{0xF7, 0xFC, SourceAddressPriorityP3, true},
+	{0x0F, 0x14, SourceAddressPriorityP4, false},
+	{0x1F, 0x24, SourceAddressPriorityP4, true},
+	{0x3F, 0x44, SourceAddressPriorityP4, true},
+	{0x7F, 0x84, SourceAddressPriorityP4, true},
+	{0xFF, 0x04, SourceAddressPriorityP4, false},
+}
+
+func TestCanonical_SlaveOfMaster_AllPairs(t *testing.T) {
+	t.Parallel()
+	for _, pair := range canonicalPairs {
+		pair := pair
+		t.Run("master_0x"+hex2(pair.master), func(t *testing.T) {
+			t.Parallel()
+			got, ok := SlaveOfMaster(pair.master)
+			if !ok || got != pair.slave {
+				t.Fatalf("SlaveOfMaster(0x%02X) = (0x%02X, %v); want (0x%02X, true)", pair.master, got, ok, pair.slave)
+			}
+		})
+	}
+}
+
+func TestCanonical_MasterOfSlave_AllPairs(t *testing.T) {
+	t.Parallel()
+	for _, pair := range canonicalPairs {
+		pair := pair
+		t.Run("slave_0x"+hex2(pair.slave), func(t *testing.T) {
+			t.Parallel()
+			got, ok := MasterOfSlave(pair.slave)
+			if !ok || got != pair.master {
+				t.Fatalf("MasterOfSlave(0x%02X) = (0x%02X, %v); want (0x%02X, true)", pair.slave, got, ok, pair.master)
+			}
+		})
+	}
+}
+
+func TestCanonical_IsCanonicalMaster_AllPairs(t *testing.T) {
+	t.Parallel()
+	for _, pair := range canonicalPairs {
+		pair := pair
+		t.Run("master_0x"+hex2(pair.master), func(t *testing.T) {
+			t.Parallel()
+			if !IsCanonicalMaster(pair.master) {
+				t.Fatalf("IsCanonicalMaster(0x%02X) = false; want true", pair.master)
+			}
+		})
+	}
+}
+
+func TestCanonical_IsCanonicalSlave_AllPairs(t *testing.T) {
+	t.Parallel()
+	for _, pair := range canonicalPairs {
+		pair := pair
+		t.Run("slave_0x"+hex2(pair.slave), func(t *testing.T) {
+			t.Parallel()
+			if !IsCanonicalSlave(pair.slave) {
+				t.Fatalf("IsCanonicalSlave(0x%02X) = false; want true", pair.slave)
+			}
+		})
+	}
+}
+
+func TestCanonical_MasterTier_AllPairs(t *testing.T) {
+	t.Parallel()
+	for _, pair := range canonicalPairs {
+		pair := pair
+		t.Run("master_0x"+hex2(pair.master), func(t *testing.T) {
+			t.Parallel()
+			got, ok := MasterTier(pair.master)
+			if !ok || got != pair.tier {
+				t.Fatalf("MasterTier(0x%02X) = (%q, %v); want (%q, true)", pair.master, got, ok, pair.tier)
+			}
+		})
+	}
+}
+
+func TestCanonical_NonCanonical_RejectsMaster(t *testing.T) {
+	t.Parallel()
+	// Addresses that pass IsInitiatorCapableAddress nibble check but are
+	// not in the canonical table — none exist for the +5 math because
+	// IsInitiatorCapableAddress matches exactly the 25 canonical masters.
+	// However, any other byte (e.g. 0x02, 0x26, 0x38 acting as src) MUST
+	// NOT be classified as a canonical master.
+	nonMasters := []byte{0x02, 0x04, 0x05, 0x09, 0x14, 0x21, 0x26, 0x38, 0x44, 0x84, 0xEC}
+	for _, addr := range nonMasters {
+		addr := addr
+		t.Run("non_master_0x"+hex2(addr), func(t *testing.T) {
+			t.Parallel()
+			if IsCanonicalMaster(addr) {
+				t.Fatalf("IsCanonicalMaster(0x%02X) = true; want false (not in canonical table)", addr)
+			}
+			if _, ok := MasterTier(addr); ok {
+				t.Fatalf("MasterTier(0x%02X) ok = true; want false", addr)
+			}
+			if _, ok := SlaveOfMaster(addr); ok {
+				t.Fatalf("SlaveOfMaster(0x%02X) ok = true; want false (not a master)", addr)
+			}
+		})
+	}
+}
+
+func TestCanonical_NonCanonical_RejectsSlave(t *testing.T) {
+	t.Parallel()
+	// 0x26 (VR_71 slave) and 0xEC (SOL00 slave) are real devices but NOT
+	// in the canonical pair table — they have no math companion.
+	nonSlaves := []byte{0x02, 0x07, 0x10, 0x21, 0x26, 0x33, 0xEC, 0xFE, 0xFF}
+	for _, addr := range nonSlaves {
+		addr := addr
+		t.Run("non_slave_0x"+hex2(addr), func(t *testing.T) {
+			t.Parallel()
+			if IsCanonicalSlave(addr) {
+				t.Fatalf("IsCanonicalSlave(0x%02X) = true; want false (not in canonical table)", addr)
+			}
+			if _, ok := MasterOfSlave(addr); ok {
+				t.Fatalf("MasterOfSlave(0x%02X) ok = true; want false (not a slave)", addr)
+			}
+		})
+	}
+}
+
+func TestCanonical_FreeUseFlag(t *testing.T) {
+	t.Parallel()
+	for _, pair := range canonicalPairs {
+		pair := pair
+		t.Run("master_0x"+hex2(pair.master), func(t *testing.T) {
+			t.Parallel()
+			got, ok := IsFreeUseMaster(pair.master)
+			if !ok {
+				t.Fatalf("IsFreeUseMaster(0x%02X) ok = false; want true (canonical master)", pair.master)
+			}
+			if got != pair.free {
+				t.Fatalf("IsFreeUseMaster(0x%02X) = %v; want %v", pair.master, got, pair.free)
+			}
+		})
+	}
+}
+
+func TestCanonical_Companion_BackedByTable(t *testing.T) {
+	t.Parallel()
+	// After A.7a, Companion MUST resolve via the canonical table — not via
+	// math + nibble check. The 25 canonical pairs are returned in both
+	// directions; everything else is (0, false).
+	for _, pair := range canonicalPairs {
+		pair := pair
+		t.Run("master_0x"+hex2(pair.master), func(t *testing.T) {
+			t.Parallel()
+			got, ok := Companion(pair.master)
+			if !ok || got != pair.slave {
+				t.Fatalf("Companion(0x%02X master) = (0x%02X, %v); want (0x%02X, true)", pair.master, got, ok, pair.slave)
+			}
+		})
+		t.Run("slave_0x"+hex2(pair.slave), func(t *testing.T) {
+			t.Parallel()
+			got, ok := Companion(pair.slave)
+			if !ok || got != pair.master {
+				t.Fatalf("Companion(0x%02X slave) = (0x%02X, %v); want (0x%02X, true)", pair.slave, got, ok, pair.master)
+			}
+		})
+	}
+}
+
+func hex2(b byte) string {
+	const hexDigits = "0123456789ABCDEF"
+	return string([]byte{hexDigits[b>>4], hexDigits[b&0x0F]})
+}

--- a/protocol/canonical_address_table_test.go
+++ b/protocol/canonical_address_table_test.go
@@ -2,19 +2,25 @@ package protocol
 
 import "testing"
 
-// Tests for the canonical-address-table-derived companion API. These RED tests
-// verify that companion derivation, master/slave lookup, tier classification,
-// and free-use status are sourced from the docs-owned sourceAddressTableV1
+// Tests for the canonical-address-table-derived companion API. These RED
+// tests verify that companion derivation, source/companion lookup, tier
+// classification, and free-use status are sourced from the docs-owned
+// sourceAddressTableV1
 // (helianthus-docs-ebus/architecture/ebus_standard/12-source-address-table.md)
 // rather than from byte-arithmetic guesses with nibble-pattern checks.
+//
+// Vocabulary follows the docs-owned table: "Source" (initiator-capable,
+// arbitration-eligible address) and "Companion" (the responder-side peer
+// at Source+0x05 mod 0x100).
 
 // canonicalPairs is the operator-pinned ground truth for the 25 canonical
-// master/slave pairs from the eBUS standard table. Tests assert each direction.
+// source/companion pairs from the eBUS standard table. Tests assert each
+// direction.
 var canonicalPairs = []struct {
-	master byte
-	slave  byte
-	tier   SourceAddressPriorityIndex
-	free   bool
+	source    byte
+	companion byte
+	tier      SourceAddressPriorityIndex
+	free      bool
 }{
 	{0x00, 0x05, SourceAddressPriorityP0, false},
 	{0x10, 0x15, SourceAddressPriorityP0, false},
@@ -43,113 +49,114 @@ var canonicalPairs = []struct {
 	{0xFF, 0x04, SourceAddressPriorityP4, false},
 }
 
-func TestCanonical_SlaveOfMaster_AllPairs(t *testing.T) {
+func TestCanonical_CompanionOfSource_AllPairs(t *testing.T) {
 	t.Parallel()
 	for _, pair := range canonicalPairs {
 		pair := pair
-		t.Run("master_0x"+hex2(pair.master), func(t *testing.T) {
+		t.Run("source_0x"+hex2(pair.source), func(t *testing.T) {
 			t.Parallel()
-			got, ok := SlaveOfMaster(pair.master)
-			if !ok || got != pair.slave {
-				t.Fatalf("SlaveOfMaster(0x%02X) = (0x%02X, %v); want (0x%02X, true)", pair.master, got, ok, pair.slave)
+			got, ok := CompanionOfSource(pair.source)
+			if !ok || got != pair.companion {
+				t.Fatalf("CompanionOfSource(0x%02X) = (0x%02X, %v); want (0x%02X, true)", pair.source, got, ok, pair.companion)
 			}
 		})
 	}
 }
 
-func TestCanonical_MasterOfSlave_AllPairs(t *testing.T) {
+func TestCanonical_SourceOfCompanion_AllPairs(t *testing.T) {
 	t.Parallel()
 	for _, pair := range canonicalPairs {
 		pair := pair
-		t.Run("slave_0x"+hex2(pair.slave), func(t *testing.T) {
+		t.Run("companion_0x"+hex2(pair.companion), func(t *testing.T) {
 			t.Parallel()
-			got, ok := MasterOfSlave(pair.slave)
-			if !ok || got != pair.master {
-				t.Fatalf("MasterOfSlave(0x%02X) = (0x%02X, %v); want (0x%02X, true)", pair.slave, got, ok, pair.master)
+			got, ok := SourceOfCompanion(pair.companion)
+			if !ok || got != pair.source {
+				t.Fatalf("SourceOfCompanion(0x%02X) = (0x%02X, %v); want (0x%02X, true)", pair.companion, got, ok, pair.source)
 			}
 		})
 	}
 }
 
-func TestCanonical_IsCanonicalMaster_AllPairs(t *testing.T) {
+func TestCanonical_IsCanonicalSource_AllPairs(t *testing.T) {
 	t.Parallel()
 	for _, pair := range canonicalPairs {
 		pair := pair
-		t.Run("master_0x"+hex2(pair.master), func(t *testing.T) {
+		t.Run("source_0x"+hex2(pair.source), func(t *testing.T) {
 			t.Parallel()
-			if !IsCanonicalMaster(pair.master) {
-				t.Fatalf("IsCanonicalMaster(0x%02X) = false; want true", pair.master)
+			if !IsCanonicalSource(pair.source) {
+				t.Fatalf("IsCanonicalSource(0x%02X) = false; want true", pair.source)
 			}
 		})
 	}
 }
 
-func TestCanonical_IsCanonicalSlave_AllPairs(t *testing.T) {
+func TestCanonical_IsCanonicalCompanion_AllPairs(t *testing.T) {
 	t.Parallel()
 	for _, pair := range canonicalPairs {
 		pair := pair
-		t.Run("slave_0x"+hex2(pair.slave), func(t *testing.T) {
+		t.Run("companion_0x"+hex2(pair.companion), func(t *testing.T) {
 			t.Parallel()
-			if !IsCanonicalSlave(pair.slave) {
-				t.Fatalf("IsCanonicalSlave(0x%02X) = false; want true", pair.slave)
+			if !IsCanonicalCompanion(pair.companion) {
+				t.Fatalf("IsCanonicalCompanion(0x%02X) = false; want true", pair.companion)
 			}
 		})
 	}
 }
 
-func TestCanonical_MasterTier_AllPairs(t *testing.T) {
+func TestCanonical_SourceTier_AllPairs(t *testing.T) {
 	t.Parallel()
 	for _, pair := range canonicalPairs {
 		pair := pair
-		t.Run("master_0x"+hex2(pair.master), func(t *testing.T) {
+		t.Run("source_0x"+hex2(pair.source), func(t *testing.T) {
 			t.Parallel()
-			got, ok := MasterTier(pair.master)
+			got, ok := SourceTier(pair.source)
 			if !ok || got != pair.tier {
-				t.Fatalf("MasterTier(0x%02X) = (%q, %v); want (%q, true)", pair.master, got, ok, pair.tier)
+				t.Fatalf("SourceTier(0x%02X) = (%q, %v); want (%q, true)", pair.source, got, ok, pair.tier)
 			}
 		})
 	}
 }
 
-func TestCanonical_NonCanonical_RejectsMaster(t *testing.T) {
+func TestCanonical_NonCanonical_RejectsSource(t *testing.T) {
 	t.Parallel()
 	// Addresses that pass IsInitiatorCapableAddress nibble check but are
 	// not in the canonical table — none exist for the +5 math because
-	// IsInitiatorCapableAddress matches exactly the 25 canonical masters.
+	// IsInitiatorCapableAddress matches exactly the 25 canonical sources.
 	// However, any other byte (e.g. 0x02, 0x26, 0x38 acting as src) MUST
-	// NOT be classified as a canonical master.
-	nonMasters := []byte{0x02, 0x04, 0x05, 0x09, 0x14, 0x21, 0x26, 0x38, 0x44, 0x84, 0xEC}
-	for _, addr := range nonMasters {
+	// NOT be classified as a canonical source.
+	nonSources := []byte{0x02, 0x04, 0x05, 0x09, 0x14, 0x21, 0x26, 0x38, 0x44, 0x84, 0xEC}
+	for _, addr := range nonSources {
 		addr := addr
-		t.Run("non_master_0x"+hex2(addr), func(t *testing.T) {
+		t.Run("non_source_0x"+hex2(addr), func(t *testing.T) {
 			t.Parallel()
-			if IsCanonicalMaster(addr) {
-				t.Fatalf("IsCanonicalMaster(0x%02X) = true; want false (not in canonical table)", addr)
+			if IsCanonicalSource(addr) {
+				t.Fatalf("IsCanonicalSource(0x%02X) = true; want false (not in canonical table)", addr)
 			}
-			if _, ok := MasterTier(addr); ok {
-				t.Fatalf("MasterTier(0x%02X) ok = true; want false", addr)
+			if _, ok := SourceTier(addr); ok {
+				t.Fatalf("SourceTier(0x%02X) ok = true; want false", addr)
 			}
-			if _, ok := SlaveOfMaster(addr); ok {
-				t.Fatalf("SlaveOfMaster(0x%02X) ok = true; want false (not a master)", addr)
+			if _, ok := CompanionOfSource(addr); ok {
+				t.Fatalf("CompanionOfSource(0x%02X) ok = true; want false (not a source)", addr)
 			}
 		})
 	}
 }
 
-func TestCanonical_NonCanonical_RejectsSlave(t *testing.T) {
+func TestCanonical_NonCanonical_RejectsCompanion(t *testing.T) {
 	t.Parallel()
-	// 0x26 (VR_71 slave) and 0xEC (SOL00 slave) are real devices but NOT
-	// in the canonical pair table — they have no math companion.
-	nonSlaves := []byte{0x02, 0x07, 0x10, 0x21, 0x26, 0x33, 0xEC, 0xFE, 0xFF}
-	for _, addr := range nonSlaves {
+	// 0x26 (VR_71 companion-like physical address) and 0xEC (SOL00
+	// companion-like physical address) are real devices but NOT in the
+	// canonical pair table — they have no math companion.
+	nonCompanions := []byte{0x02, 0x07, 0x10, 0x21, 0x26, 0x33, 0xEC, 0xFE, 0xFF}
+	for _, addr := range nonCompanions {
 		addr := addr
-		t.Run("non_slave_0x"+hex2(addr), func(t *testing.T) {
+		t.Run("non_companion_0x"+hex2(addr), func(t *testing.T) {
 			t.Parallel()
-			if IsCanonicalSlave(addr) {
-				t.Fatalf("IsCanonicalSlave(0x%02X) = true; want false (not in canonical table)", addr)
+			if IsCanonicalCompanion(addr) {
+				t.Fatalf("IsCanonicalCompanion(0x%02X) = true; want false (not in canonical table)", addr)
 			}
-			if _, ok := MasterOfSlave(addr); ok {
-				t.Fatalf("MasterOfSlave(0x%02X) ok = true; want false (not a slave)", addr)
+			if _, ok := SourceOfCompanion(addr); ok {
+				t.Fatalf("SourceOfCompanion(0x%02X) ok = true; want false (not a companion)", addr)
 			}
 		})
 	}
@@ -159,14 +166,14 @@ func TestCanonical_FreeUseFlag(t *testing.T) {
 	t.Parallel()
 	for _, pair := range canonicalPairs {
 		pair := pair
-		t.Run("master_0x"+hex2(pair.master), func(t *testing.T) {
+		t.Run("source_0x"+hex2(pair.source), func(t *testing.T) {
 			t.Parallel()
-			got, ok := IsFreeUseMaster(pair.master)
+			got, ok := IsFreeUseSource(pair.source)
 			if !ok {
-				t.Fatalf("IsFreeUseMaster(0x%02X) ok = false; want true (canonical master)", pair.master)
+				t.Fatalf("IsFreeUseSource(0x%02X) ok = false; want true (canonical source)", pair.source)
 			}
 			if got != pair.free {
-				t.Fatalf("IsFreeUseMaster(0x%02X) = %v; want %v", pair.master, got, pair.free)
+				t.Fatalf("IsFreeUseSource(0x%02X) = %v; want %v", pair.source, got, pair.free)
 			}
 		})
 	}
@@ -179,20 +186,61 @@ func TestCanonical_Companion_BackedByTable(t *testing.T) {
 	// directions; everything else is (0, false).
 	for _, pair := range canonicalPairs {
 		pair := pair
-		t.Run("master_0x"+hex2(pair.master), func(t *testing.T) {
+		t.Run("source_0x"+hex2(pair.source), func(t *testing.T) {
 			t.Parallel()
-			got, ok := Companion(pair.master)
-			if !ok || got != pair.slave {
-				t.Fatalf("Companion(0x%02X master) = (0x%02X, %v); want (0x%02X, true)", pair.master, got, ok, pair.slave)
+			got, ok := Companion(pair.source)
+			if !ok || got != pair.companion {
+				t.Fatalf("Companion(0x%02X source) = (0x%02X, %v); want (0x%02X, true)", pair.source, got, ok, pair.companion)
 			}
 		})
-		t.Run("slave_0x"+hex2(pair.slave), func(t *testing.T) {
+		t.Run("companion_0x"+hex2(pair.companion), func(t *testing.T) {
 			t.Parallel()
-			got, ok := Companion(pair.slave)
-			if !ok || got != pair.master {
-				t.Fatalf("Companion(0x%02X slave) = (0x%02X, %v); want (0x%02X, true)", pair.slave, got, ok, pair.master)
+			got, ok := Companion(pair.companion)
+			if !ok || got != pair.source {
+				t.Fatalf("Companion(0x%02X companion) = (0x%02X, %v); want (0x%02X, true)", pair.companion, got, ok, pair.source)
 			}
 		})
+	}
+}
+
+// TestCanonical_TableInvariants asserts the docs-owned source-address table
+// has exactly 25 unique source/companion pairs. Catches accidental future
+// table expansion or silent overwrite from duplicate keys (Codex review nit
+// from PR #149).
+func TestCanonical_TableInvariants(t *testing.T) {
+	t.Parallel()
+
+	const wantRows = 25
+	if got := len(sourceAddressTableV1); got != wantRows {
+		t.Fatalf("sourceAddressTableV1 has %d rows; want %d", got, wantRows)
+	}
+
+	uniqueSources := make(map[byte]bool, wantRows)
+	uniqueCompanions := make(map[byte]bool, wantRows)
+	for _, row := range sourceAddressTableV1 {
+		if uniqueSources[row.Source] {
+			t.Fatalf("duplicate Source 0x%02X in sourceAddressTableV1", row.Source)
+		}
+		uniqueSources[row.Source] = true
+		if uniqueCompanions[row.Companion] {
+			t.Fatalf("duplicate Companion 0x%02X in sourceAddressTableV1", row.Companion)
+		}
+		uniqueCompanions[row.Companion] = true
+	}
+
+	// Map coverage parity: the 4 derived maps must each have exactly
+	// wantRows entries, matching the table 1:1.
+	if got := len(canonicalSourceToCompanion); got != wantRows {
+		t.Fatalf("canonicalSourceToCompanion has %d entries; want %d", got, wantRows)
+	}
+	if got := len(canonicalCompanionToSource); got != wantRows {
+		t.Fatalf("canonicalCompanionToSource has %d entries; want %d", got, wantRows)
+	}
+	if got := len(canonicalSourceTier); got != wantRows {
+		t.Fatalf("canonicalSourceTier has %d entries; want %d", got, wantRows)
+	}
+	if got := len(canonicalSourceFreeUse); got != wantRows {
+		t.Fatalf("canonicalSourceFreeUse has %d entries; want %d", got, wantRows)
 	}
 }
 

--- a/protocol/companion.go
+++ b/protocol/companion.go
@@ -1,19 +1,27 @@
 package protocol
 
 // Companion returns the eBUS companion address (initiator/target pair) for addr,
-// per the eBUS standard (initiator+5 / target-5) with bit-pattern validity check.
-// Returns (companion, true) when a valid pair exists, else (0, false).
+// resolved through the docs-owned canonical address table
+// (architecture/ebus_standard/12-source-address-table.md, canonical hash
+// e78954445087f63064818ab60a2739b9a6b9bf0ae0147fbe92aac5ac76592103).
+// Returns (companion, true) when addr is a canonical source OR canonical
+// companion, else (0, false).
 //
 // Decision references: AD03, AD04 (frame-position disambiguation for 0xFF
 // is the caller's responsibility; this function operates on already-
 // disambiguated address bytes).
+//
+// Pre-A.7 implementation used math (+5/-5 with IsInitiatorCapableAddress
+// nibble check). For the 25 canonical pairs the result is identical, but
+// the table-backed lookup is the single authoritative source — it also
+// exposes priority tier and free-use metadata via SlaveOfMaster /
+// MasterOfSlave / MasterTier / IsFreeUseMaster.
 func Companion(addr byte) (byte, bool) {
-	if IsInitiatorCapableAddress(addr) {
-		return addr + 0x05, true
+	if companion, ok := CompanionOfSource(addr); ok {
+		return companion, true
 	}
-	candidate := byte((int(addr) - 0x05) & 0xFF)
-	if IsInitiatorCapableAddress(candidate) {
-		return candidate, true
+	if source, ok := SourceOfCompanion(addr); ok {
+		return source, true
 	}
 	return 0, false
 }


### PR DESCRIPTION
## Summary

A.7a in cruise plan `address-table-registry-w19-26` follow-up.

Operator flagged that the math-based `Companion()` (+5/-5 with `IsInitiatorCapableAddress`) is "weak grav" — produces correct results for the 25 canonical pairs but doesn't reflect the docs-owned eBUS standard table (`architecture/ebus_standard/12-source-address-table.md`, canonical hash `e78954445087f63064818ab60a2739b9a6b9bf0ae0147fbe92aac5ac76592103`).

This PR adds table-derived public lookups + rebases `Companion()` on them. `sourceAddressTableV1` remains the single source of truth.

### New public API
- `SlaveOfMaster(master) (slave, ok)`
- `MasterOfSlave(slave) (master, ok)`
- `IsCanonicalMaster(addr) bool`
- `IsCanonicalSlave(addr) bool`
- `MasterTier(master) (PriorityIndex, ok)` — p0..p4
- `IsFreeUseMaster(master) (bool, ok)`

All O(1) via maps built once at `init()` from `sourceAddressTableV1`.

### Companion() rebased
`Companion(addr) (byte, bool)` now resolves through `SlaveOfMaster` then `MasterOfSlave`. For the 25 canonical pairs the result is bit-identical to the prior math implementation; for non-canonical addresses (like real-but-non-canonical slaves 0x26 / 0xEC) the table-backed version correctly rejects them as having no canonical pair.

## Test plan

- [x] RED: 7 new test functions in `canonical_address_table_test.go` covering 25 pairs × both directions × all 6 lookups + operator-pinned negatives (`0x26`, `0xEC`, `0x21`, `0x38` confirmed canonical slave).
- [x] GREEN: all RED tests pass; existing `TestCompanion_OperatorPinnedCases`, `TestCompanion_NoMasterPair`, `TestCompanion_MasterToSlave_OffsetFive` still pass.
- [x] `go test -race ./...` — full suite green.
- [ ] Downstream cruise: gateway A.7b (inserter) + A.7c/d (observability + tier labels) + A.7e (registry pre-seed) consume this API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)