### PR TITLE
feat(protocol): Phase C M-C2 + M-C4 — Frame.FrameType field + Frame.Validate + ValidateFrameAddressing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ jobs:
               ':!protocol/initiator_address_test.go' \
               ':!protocol/address_class.go' \
               ':!protocol/address_class_test.go' \
+              ':!protocol/validate_frame_addressing.go' \
+              ':!protocol/validate_frame_addressing_test.go' \
               ':!emulation/' \
               ':!transport/ebusd_tcp.go' \
               ':!README.md'; then

--- a/protocol/protocol.go
+++ b/protocol/protocol.go
@@ -20,17 +20,52 @@ const (
 )
 
 // Frame represents a parsed eBUS frame.
+//
+// FrameType is an optional explicit declaration of the frame's
+// application-layer semantic kind (M2S / M2M / M2BC). When zero-valued
+// (FrameTypeUnknown), the frame's effective type is derived from
+// Target via FrameTypeForTarget. The Phase C transport-side validator
+// (Bus.Send + Frame.Validate) requires every emitted frame to have an
+// explicit non-zero FrameType for new semantic API call sites — see
+// Frame.Validate doc + Phase C M-C7 enrichment.
 type Frame struct {
 	Source    byte
 	Target    byte
 	Primary   byte
 	Secondary byte
 	Data      []byte
+	FrameType FrameType
 }
 
 // Type returns the frame type based on the target address.
+//
+// Used by parser-side code that always derives from Target. New
+// emit-side code should prefer Frame.EffectiveFrameType which respects
+// the explicit Frame.FrameType field.
 func (f Frame) Type() FrameType {
 	return FrameTypeForTarget(f.Target)
+}
+
+// EffectiveFrameType returns the explicit Frame.FrameType when set
+// (non-Unknown), otherwise FrameTypeForTarget(Target). Used by
+// Frame.Validate to assert caller intent matches the destination class.
+func (f Frame) EffectiveFrameType() FrameType {
+	if f.FrameType != FrameTypeUnknown {
+		return f.FrameType
+	}
+	return FrameTypeForTarget(f.Target)
+}
+
+// Validate enforces the Phase C frame-type addressing contract by
+// delegating to ValidateFrameAddressing(EffectiveFrameType, Source,
+// Target). Returns nil on conformance; ErrInvalidFrameAddress (or a
+// wrapped variant) on rejection.
+//
+// Decision references: AD24 (additive Frame.FrameType field +
+// Frame.Validate invoked from Bus.Send), AD26 (validator contract),
+// AD28 (per-API-site explicit frame-type declaration).
+func (f Frame) Validate() error {
+	return ValidateFrameAddressing(f.EffectiveFrameType(), f.Source, f.Target)
 }
 
 // FrameTypeForTarget determines the frame type based on the destination address.

--- a/protocol/validate_frame_addressing.go
+++ b/protocol/validate_frame_addressing.go
@@ -1,0 +1,87 @@
+package protocol
+
+import (
+	"errors"
+	"fmt"
+)
+
+// ErrInvalidFrameAddress is the sentinel error returned by
+// ValidateFrameAddressing when a frame's (FrameType, src, dst) tuple
+// does not satisfy the Phase C frame-type addressing contract documented
+// in helianthus-docs-ebus/architecture/ebus_standard/12-address-table.md.
+//
+// Callers can match via errors.Is(err, protocol.ErrInvalidFrameAddress).
+// The wrapper error always carries a descriptive message naming the
+// specific clause that rejected the frame.
+//
+// Decision references: AD26 (validator contract).
+var ErrInvalidFrameAddress = errors.New("eBUS: invalid frame address")
+
+// ValidateFrameAddressing enforces the 6-clause Phase C contract:
+//
+//  1. ft != FrameTypeUnknown.
+//  2. src != dst (no self-addressing — gateway-side discipline).
+//  3. AddressClassOf(src) and AddressClassOf(dst) must not be Reserved.
+//  4. ft == M2S → AddressClassOf(src) == Master AND
+//     AddressClassOf(dst) == Slave.
+//  5. ft == M2M → AddressClassOf(src) == Master AND
+//     AddressClassOf(dst) == Master.
+//  6. ft == M2BC → AddressClassOf(src) == Master AND dst == 0xFE
+//     (AddressClassOf(dst) == Broadcast).
+//
+// The function returns nil on conformance; otherwise an error wrapping
+// ErrInvalidFrameAddress.
+//
+// Doc reference: 12-address-table.md "Validator Contract" section
+// (taxonomy + frame-type contract block, hash
+// 316baf20ab0d0a64b36613bb8c7604d7570fecc01071daca94931029ae82ebec).
+func ValidateFrameAddressing(ft FrameType, src, dst byte) error {
+	// Clause 1: reject zero/unknown frame type.
+	if ft == FrameTypeUnknown {
+		return fmt.Errorf("%w: frame_type=unknown (caller must declare M2S/M2M/M2BC explicitly)", ErrInvalidFrameAddress)
+	}
+	// Clause 2: no self-addressing.
+	if src == dst {
+		return fmt.Errorf("%w: src == dst == 0x%02X (self-addressing forbidden)", ErrInvalidFrameAddress, src)
+	}
+
+	srcClass := AddressClassOf(src)
+	dstClass := AddressClassOf(dst)
+
+	// Clause 3: reserved bytes (SYN, ESCAPE) cannot appear as src or dst.
+	if srcClass == AddressClassReserved {
+		return fmt.Errorf("%w: src=0x%02X is reserved (SYN/ESCAPE)", ErrInvalidFrameAddress, src)
+	}
+	if dstClass == AddressClassReserved {
+		return fmt.Errorf("%w: dst=0x%02X is reserved (SYN/ESCAPE)", ErrInvalidFrameAddress, dst)
+	}
+
+	// Clauses 4-6: per-frame-type src/dst class match.
+	switch ft {
+	case FrameTypeInitiatorTarget:
+		if srcClass != AddressClassMaster {
+			return fmt.Errorf("%w: M2S requires src=Master, got src=0x%02X (%s)", ErrInvalidFrameAddress, src, srcClass)
+		}
+		if dstClass != AddressClassSlave {
+			return fmt.Errorf("%w: M2S requires dst=Slave, got dst=0x%02X (%s)", ErrInvalidFrameAddress, dst, dstClass)
+		}
+	case FrameTypeInitiatorInitiator:
+		if srcClass != AddressClassMaster {
+			return fmt.Errorf("%w: M2M requires src=Master, got src=0x%02X (%s)", ErrInvalidFrameAddress, src, srcClass)
+		}
+		if dstClass != AddressClassMaster {
+			return fmt.Errorf("%w: M2M requires dst=Master, got dst=0x%02X (%s)", ErrInvalidFrameAddress, dst, dstClass)
+		}
+	case FrameTypeBroadcast:
+		if srcClass != AddressClassMaster {
+			return fmt.Errorf("%w: M2BC requires src=Master, got src=0x%02X (%s)", ErrInvalidFrameAddress, src, srcClass)
+		}
+		if dstClass != AddressClassBroadcast {
+			return fmt.Errorf("%w: M2BC requires dst=0xFE, got dst=0x%02X (%s)", ErrInvalidFrameAddress, dst, dstClass)
+		}
+	default:
+		return fmt.Errorf("%w: unsupported FrameType %d", ErrInvalidFrameAddress, ft)
+	}
+
+	return nil
+}

--- a/protocol/validate_frame_addressing_test.go
+++ b/protocol/validate_frame_addressing_test.go
@@ -1,0 +1,131 @@
+package protocol
+
+import (
+	"errors"
+	"testing"
+)
+
+// Phase C M-C2 + M-C3 + M-C4: ValidateFrameAddressing + Frame.Validate
+// + Frame.FrameType field + Frame.EffectiveFrameType().
+
+func TestValidateFrameAddressing_M2S_OK(t *testing.T) {
+	t.Parallel()
+	// 0x10 master → 0x15 slave canonical pair.
+	if err := ValidateFrameAddressing(FrameTypeInitiatorTarget, 0x10, 0x15); err != nil {
+		t.Fatalf("ValidateFrameAddressing(M2S, 0x10, 0x15) = %v; want nil", err)
+	}
+}
+
+func TestValidateFrameAddressing_M2M_OK(t *testing.T) {
+	t.Parallel()
+	// 0x71 master → 0x10 master.
+	if err := ValidateFrameAddressing(FrameTypeInitiatorInitiator, 0x71, 0x10); err != nil {
+		t.Fatalf("ValidateFrameAddressing(M2M, 0x71, 0x10) = %v; want nil", err)
+	}
+}
+
+func TestValidateFrameAddressing_M2BC_OK(t *testing.T) {
+	t.Parallel()
+	if err := ValidateFrameAddressing(FrameTypeBroadcast, 0x71, 0xFE); err != nil {
+		t.Fatalf("ValidateFrameAddressing(M2BC, 0x71, 0xFE) = %v; want nil", err)
+	}
+}
+
+func TestValidateFrameAddressing_RejectsM2SWithSlaveSrc(t *testing.T) {
+	t.Parallel()
+	err := ValidateFrameAddressing(FrameTypeInitiatorTarget, 0x15, 0x08)
+	if !errors.Is(err, ErrInvalidFrameAddress) {
+		t.Fatalf("ValidateFrameAddressing(M2S, 0x15-slave, 0x08) = %v; want ErrInvalidFrameAddress", err)
+	}
+}
+
+func TestValidateFrameAddressing_RejectsM2SWithMasterDst(t *testing.T) {
+	t.Parallel()
+	err := ValidateFrameAddressing(FrameTypeInitiatorTarget, 0x71, 0x10)
+	if !errors.Is(err, ErrInvalidFrameAddress) {
+		t.Fatalf("ValidateFrameAddressing(M2S, 0x71, 0x10-master) = %v; want ErrInvalidFrameAddress", err)
+	}
+}
+
+func TestValidateFrameAddressing_RejectsM2BCWithNonFEDst(t *testing.T) {
+	t.Parallel()
+	err := ValidateFrameAddressing(FrameTypeBroadcast, 0x71, 0x15)
+	if !errors.Is(err, ErrInvalidFrameAddress) {
+		t.Fatalf("ValidateFrameAddressing(M2BC, 0x71, 0x15) = %v; want ErrInvalidFrameAddress", err)
+	}
+}
+
+func TestValidateFrameAddressing_RejectsUnknownFrameType(t *testing.T) {
+	t.Parallel()
+	err := ValidateFrameAddressing(FrameTypeUnknown, 0x71, 0x15)
+	if !errors.Is(err, ErrInvalidFrameAddress) {
+		t.Fatalf("ValidateFrameAddressing(Unknown, ...) = %v; want ErrInvalidFrameAddress", err)
+	}
+}
+
+func TestValidateFrameAddressing_RejectsSelfAddressing(t *testing.T) {
+	t.Parallel()
+	err := ValidateFrameAddressing(FrameTypeInitiatorTarget, 0x71, 0x71)
+	if !errors.Is(err, ErrInvalidFrameAddress) {
+		t.Fatalf("ValidateFrameAddressing(M2S, 0x71, 0x71) = %v; want ErrInvalidFrameAddress (self)", err)
+	}
+}
+
+func TestValidateFrameAddressing_RejectsReservedDst(t *testing.T) {
+	t.Parallel()
+	for _, dst := range []byte{0xAA, 0xA9} {
+		dst := dst
+		t.Run("dst_reserved", func(t *testing.T) {
+			err := ValidateFrameAddressing(FrameTypeInitiatorTarget, 0x71, dst)
+			if !errors.Is(err, ErrInvalidFrameAddress) {
+				t.Fatalf("ValidateFrameAddressing(M2S, 0x71, 0x%02X-reserved) = %v; want ErrInvalidFrameAddress", dst, err)
+			}
+		})
+	}
+}
+
+func TestFrame_FrameTypeField_ZeroDerivesFromTarget(t *testing.T) {
+	t.Parallel()
+	// Zero-value FrameType means "derive from Target via FrameTypeForTarget".
+	f := Frame{Source: 0x71, Target: 0x15}
+	if got := f.EffectiveFrameType(); got != FrameTypeInitiatorTarget {
+		t.Fatalf("Frame{...}.EffectiveFrameType() = %v; want FrameTypeInitiatorTarget (derived from Target=0x15)", got)
+	}
+}
+
+func TestFrame_FrameTypeField_ExplicitOverride(t *testing.T) {
+	t.Parallel()
+	// Explicit FrameType wins over Target-derived.
+	f := Frame{
+		Source:    0x71,
+		Target:    0x15, // would derive M2S
+		FrameType: FrameTypeInitiatorInitiator,
+	}
+	if got := f.EffectiveFrameType(); got != FrameTypeInitiatorInitiator {
+		t.Fatalf("Frame{FrameType:M2M}.EffectiveFrameType() = %v; want M2M", got)
+	}
+}
+
+func TestFrame_Validate_HappyPath(t *testing.T) {
+	t.Parallel()
+	f := Frame{Source: 0x71, Target: 0x15} // implicit M2S via Target
+	if err := f.Validate(); err != nil {
+		t.Fatalf("Frame.Validate() = %v; want nil", err)
+	}
+}
+
+func TestFrame_Validate_RejectsExplicitMismatch(t *testing.T) {
+	t.Parallel()
+	// Caller declares M2S but Target is broadcast 0xFE: clause-6
+	// FrameTypeForTarget(0xFE) == FrameTypeBroadcast; declared M2S
+	// disagrees → reject.
+	f := Frame{
+		Source:    0x71,
+		Target:    0xFE,
+		FrameType: FrameTypeInitiatorTarget,
+	}
+	err := f.Validate()
+	if !errors.Is(err, ErrInvalidFrameAddress) {
+		t.Fatalf("Frame{M2S, dst=0xFE}.Validate() = %v; want ErrInvalidFrameAddress (clause-6)", err)
+	}
+}


### PR DESCRIPTION
Phase C M-C2 (additive Frame.FrameType field, EffectiveFrameType, Validate method) + M-C4 (ValidateFrameAddressing standalone fn + ErrInvalidFrameAddress sentinel) combined. Implements the 6-clause contract from 12-address-table.md (hash 316baf20...). M-C3 (Bus.Send wiring) is staged separately for soft cutover. 13 RED→GREEN tests.