### PR TITLE
feat(protocol): Phase C M-C5 — Bus.Send invokes Frame.Validate + InvalidFrameAddressTotal counter

### DIFF
--- a/protocol/bus.go
+++ b/protocol/bus.go
@@ -160,6 +160,16 @@ func (b *Bus) Send(ctx context.Context, frame Frame) (*Frame, error) {
 		return nil, err
 	}
 
+	// Phase C M-C5: enforce frame-type addressing contract before any
+	// wire write. Rejection increments invalidFrameAddressTotal and
+	// returns ErrInvalidFrameAddress wrapped with the failing clause.
+	// Decision references: AD24 (additive Frame.FrameType + Validate),
+	// AD26 (validator contract).
+	if err := frame.Validate(); err != nil {
+		atomic.AddUint64(&invalidFrameAddressTotal, 1)
+		return nil, err
+	}
+
 	b.queueMu.Lock()
 	if b.closed {
 		b.queueMu.Unlock()
@@ -176,6 +186,7 @@ func (b *Bus) Send(ctx context.Context, frame Frame) (*Frame, error) {
 			Primary:   frame.Primary,
 			Secondary: frame.Secondary,
 			Data:      append([]byte(nil), frame.Data...),
+			FrameType: frame.FrameType,
 		},
 		ctx: ctx,
 		// Capacity 1 to avoid blocking the run loop when delivering results.

--- a/protocol/validate_frame_addressing.go
+++ b/protocol/validate_frame_addressing.go
@@ -3,7 +3,24 @@ package protocol
 import (
 	"errors"
 	"fmt"
+	"sync/atomic"
 )
+
+// invalidFrameAddressTotal counts frames rejected by Bus.Send via
+// Frame.Validate. Exposed via InvalidFrameAddressTotal so the gateway
+// can publish the value as Prometheus counter
+// `ebus_transport_invalid_frame_address_total`. Atomic for race safety.
+//
+// Decision: counter increments Bus.Send-side, NOT validator-side, so
+// unit tests that call ValidateFrameAddressing in isolation don't bump
+// production metrics.
+var invalidFrameAddressTotal uint64
+
+// InvalidFrameAddressTotal returns the cumulative count of frames
+// rejected by Bus.Send via Frame.Validate (Phase C M-C5).
+func InvalidFrameAddressTotal() uint64 {
+	return atomic.LoadUint64(&invalidFrameAddressTotal)
+}
 
 // ErrInvalidFrameAddress is the sentinel error returned by
 // ValidateFrameAddressing when a frame's (FrameType, src, dst) tuple


### PR DESCRIPTION
Phase C M-C5_BUS_SEND_ENFORCE. Bus.Send invokes Frame.Validate at top; on non-nil error increments atomic InvalidFrameAddressTotal counter and returns immediately without wire write. InvalidFrameAddressTotal() reader for gateway Prometheus exposition.

Verified: gateway full test suite (cmd/gateway + adaptermux + all internal/) passes against this branch — existing emit paths construct well-typed frames; M-C7 enrichment will make Frame.FrameType explicit at every callsite.

Decision references: AD24, AD26.