### PR TITLE
feat(protocol): M4_SOURCE_SELECTION_HINT — hint candidate bias for selector

### DIFF
--- a/protocol/source_address_selection.go
+++ b/protocol/source_address_selection.go
@@ -233,6 +233,25 @@ type SourceAddressSelectionConfig struct {
 	ExplicitSource    byte
 	ExplicitSourceSet bool
 
+	// HintCandidate is a cached preferred source address from a prior
+	// admission cycle (e.g. runtime_state.ebus.self.last_admitted_source).
+	// When HintCandidateSet is true and the hint resolves to a row in the
+	// standard source-address table that matches the active filters
+	// (SourceDescription / PriorityIndex), the hint row is tried FIRST in
+	// the candidate sequence — biasing the selector toward the source it
+	// previously admitted to keep address allocation stable across
+	// restarts. Standard validation still applies; the hint never bypasses
+	// warmup or evidence checks. If the hint fails validation, candidate
+	// iteration falls through to the regular candidate order (same rows
+	// the selector would have tried without the hint).
+	//
+	// HintCandidate is mutually exclusive with ExplicitSourceSet: an
+	// operator-supplied explicit source already pins the candidate set to
+	// one row, so a hint adds no information. When both are set the hint
+	// is silently ignored.
+	HintCandidate    byte
+	HintCandidateSet bool
+
 	Evidence KnownAddressEvidence
 }
 
@@ -247,6 +266,26 @@ type SourceAddressSelectionMetrics struct {
 	ObservedSourceAddresses []byte
 	ObservedProbableTargets []byte
 	TopTalkersBySource      []byte
+
+	// HintCandidate echoes the hint that was passed in via
+	// SourceAddressSelectionConfig.HintCandidate. Zero when no hint was
+	// active (or when the hint was filtered out by description / priority).
+	HintCandidate byte
+	// HintCandidateSet mirrors the corresponding config flag and lets
+	// metrics consumers distinguish "hint=0x00 was actively passed and
+	// validated" from "no hint was passed".
+	HintCandidateSet bool
+	// HintAccepted is true when the hint was passed AND the selector
+	// returned the hint row as the admitted source (i.e. validation
+	// succeeded on the hint). False when the hint was rejected and
+	// fall-through to the regular candidate order picked a different row,
+	// or when no hint was passed.
+	HintAccepted bool
+	// HintRejectionReason is the validator reason returned for the hint
+	// row when it was tried but rejected. Empty when the hint was
+	// accepted, when no hint was passed, or when the hint was not present
+	// in the active candidate set (e.g. filtered out by description).
+	HintRejectionReason string
 }
 
 // SourceAddressSelection contains the selected source and companion address.
@@ -374,6 +413,12 @@ func (s *SourceAddressSelector) Select(ctx context.Context) (SourceAddressSelect
 		TopTalkersBySource:      observation.topTalkers(defaultSourceAddressTopTalkerCount),
 	}
 
+	hintActive := cfg.HintCandidateSet && !cfg.ExplicitSourceSet
+	if hintActive {
+		metrics.HintCandidate = cfg.HintCandidate
+		metrics.HintCandidateSet = true
+	}
+
 	rows, err := candidateRowsForSourceAddressSelection(cfg)
 	if err != nil {
 		return SourceAddressSelection{}, err
@@ -383,10 +428,16 @@ func (s *SourceAddressSelector) Select(ctx context.Context) (SourceAddressSelect
 		appendUniqueByte(&metrics.CandidatesConsidered, row.Source)
 		if validationErr := validateSourceAddressCandidate(row, cfg.Evidence, observation, &metrics); validationErr != nil {
 			metrics.RejectionReasons[row.Source] = append(metrics.RejectionReasons[row.Source], validationErr.Reason)
+			if hintActive && row.Source == cfg.HintCandidate && metrics.HintRejectionReason == "" {
+				metrics.HintRejectionReason = validationErr.Reason
+			}
 			if cfg.ExplicitSourceSet {
 				return SourceAddressSelection{}, validationErr
 			}
 			continue
+		}
+		if hintActive && row.Source == cfg.HintCandidate {
+			metrics.HintAccepted = true
 		}
 		return SourceAddressSelection{
 			Source:       row.Source,
@@ -537,7 +588,7 @@ func candidateRowsForSourceAddressSelection(cfg SourceAddressSelectionConfig) ([
 			}
 			rows = append(rows, row)
 		}
-		return rows, nil
+		return applyHintBias(rows, cfg), nil
 	}
 
 	rows := make([]SourceAddressTableRow, 0, len(helianthusGatewayDefaultPolicyV1))
@@ -551,7 +602,41 @@ func candidateRowsForSourceAddressSelection(cfg SourceAddressSelectionConfig) ([
 		}
 		rows = append(rows, row)
 	}
-	return rows, nil
+	return applyHintBias(rows, cfg), nil
+}
+
+// applyHintBias reorders rows so that the hint candidate (if set, valid,
+// and present in rows) appears first. Other rows preserve their relative
+// order so default-policy fallback semantics are unchanged. When the hint
+// is unset, not in the standard table, or filtered out by the active
+// description/priority, rows are returned unchanged.
+//
+// HintCandidate is silently ignored when ExplicitSourceSet — caller has
+// already pinned candidates to one row; biasing adds no information.
+func applyHintBias(rows []SourceAddressTableRow, cfg SourceAddressSelectionConfig) []SourceAddressTableRow {
+	if !cfg.HintCandidateSet || cfg.ExplicitSourceSet {
+		return rows
+	}
+	if len(rows) <= 1 {
+		// Single-candidate or empty list — nothing to reorder.
+		return rows
+	}
+	hintIdx := -1
+	for i, row := range rows {
+		if row.Source == cfg.HintCandidate {
+			hintIdx = i
+			break
+		}
+	}
+	if hintIdx <= 0 {
+		// Hint absent (filtered out / not in table) or already first — no work.
+		return rows
+	}
+	reordered := make([]SourceAddressTableRow, 0, len(rows))
+	reordered = append(reordered, rows[hintIdx])
+	reordered = append(reordered, rows[:hintIdx]...)
+	reordered = append(reordered, rows[hintIdx+1:]...)
+	return reordered
 }
 
 func validateSourceAddressSelectionConfig(cfg SourceAddressSelectionConfig) error {

--- a/protocol/source_address_selection_test.go
+++ b/protocol/source_address_selection_test.go
@@ -609,6 +609,174 @@ func sourceAddressTableMarkdownForHash() string {
 	return builder.String()
 }
 
+// -----------------------------------------------------------------------------
+// M4_SOURCE_SELECTION_HINT (runtime-state-w19-26.locked):
+// HintCandidate biases candidate ordering toward a cached preferred source
+// from a prior admission cycle. Validation is unchanged: a hint that fails
+// validation falls through to the regular candidate order.
+// -----------------------------------------------------------------------------
+
+func TestSourceAddressSelector_HintCandidateAcceptedFirst(t *testing.T) {
+	t.Parallel()
+
+	// Default policy normally returns 0x7F first (0xFF companion unknown).
+	// Pass a hint of 0x77 — a row LATER in the default policy — and verify
+	// the selector tries it first and admits it.
+	selector := NewSourceAddressSelector(&scriptedSourceAddressSelectionBus{}, SourceAddressSelectionConfig{
+		ListenWarmup:     2 * time.Millisecond,
+		HintCandidate:    0x77,
+		HintCandidateSet: true,
+	})
+	result, err := selector.Select(context.Background())
+	if err != nil {
+		t.Fatalf("Select error = %v", err)
+	}
+	if result.Source != 0x77 {
+		t.Fatalf("Source = 0x%02x; want 0x77 (hint biased to head of candidate order)", result.Source)
+	}
+	if !result.Metrics.HintCandidateSet || result.Metrics.HintCandidate != 0x77 {
+		t.Fatalf("HintCandidate=%v set=%v; want 0x77 set=true", result.Metrics.HintCandidate, result.Metrics.HintCandidateSet)
+	}
+	if !result.Metrics.HintAccepted {
+		t.Fatalf("HintAccepted = false; want true when hint succeeded")
+	}
+	if result.Metrics.HintRejectionReason != "" {
+		t.Fatalf("HintRejectionReason = %q; want empty when hint accepted", result.Metrics.HintRejectionReason)
+	}
+	if len(result.Metrics.CandidatesConsidered) == 0 || result.Metrics.CandidatesConsidered[0] != 0x77 {
+		t.Fatalf("CandidatesConsidered[0] = 0x%02x; want 0x77 first", firstByteOrZero(result.Metrics.CandidatesConsidered))
+	}
+}
+
+func TestSourceAddressSelector_HintCandidateRejectionFallsBackToDefaultPolicy(t *testing.T) {
+	t.Parallel()
+
+	// Hint = 0xFF — default policy's first candidate, but its companion
+	// 0x04 has unknown occupancy → validator rejects with "companion-unknown".
+	// Selector must fall through to 0x7F (next default-policy row) without
+	// erroring or mutating the hint state — and expose the rejection reason.
+	selector := NewSourceAddressSelector(&scriptedSourceAddressSelectionBus{}, SourceAddressSelectionConfig{
+		ListenWarmup:     2 * time.Millisecond,
+		HintCandidate:    0xFF,
+		HintCandidateSet: true,
+	})
+	result, err := selector.Select(context.Background())
+	if err != nil {
+		t.Fatalf("Select error = %v", err)
+	}
+	if result.Source != 0x7F {
+		t.Fatalf("Source = 0x%02x; want 0x7f after hint=0xff rejection", result.Source)
+	}
+	if !result.Metrics.HintCandidateSet || result.Metrics.HintCandidate != 0xFF {
+		t.Fatalf("HintCandidate=%v set=%v; want 0xff set=true", result.Metrics.HintCandidate, result.Metrics.HintCandidateSet)
+	}
+	if result.Metrics.HintAccepted {
+		t.Fatalf("HintAccepted = true; want false when hint rejected")
+	}
+	if result.Metrics.HintRejectionReason != "companion-unknown" {
+		t.Fatalf("HintRejectionReason = %q; want companion-unknown", result.Metrics.HintRejectionReason)
+	}
+	// Default-policy fall-through must keep its order intact.
+	if len(result.Metrics.CandidatesConsidered) < 2 ||
+		result.Metrics.CandidatesConsidered[0] != 0xFF ||
+		result.Metrics.CandidatesConsidered[1] != 0x7F {
+		t.Fatalf("CandidatesConsidered = %s; want 0xff,0x7f,...", hexBytes(result.Metrics.CandidatesConsidered))
+	}
+}
+
+func TestSourceAddressSelector_HintCandidateNotInTableIgnored(t *testing.T) {
+	t.Parallel()
+
+	// 0x42 is not a row in sourceAddressTableV1. Selector must silently
+	// ignore the hint and proceed with default policy. Metrics should
+	// still reflect HintCandidateSet=true so observability can attribute
+	// the absence to a missing row, not "no hint passed".
+	selector := NewSourceAddressSelector(&scriptedSourceAddressSelectionBus{}, SourceAddressSelectionConfig{
+		ListenWarmup:     2 * time.Millisecond,
+		HintCandidate:    0x42,
+		HintCandidateSet: true,
+	})
+	result, err := selector.Select(context.Background())
+	if err != nil {
+		t.Fatalf("Select error = %v", err)
+	}
+	if result.Source != 0x7F {
+		t.Fatalf("Source = 0x%02x; want 0x7f (default policy unaffected)", result.Source)
+	}
+	if result.Metrics.HintAccepted {
+		t.Fatalf("HintAccepted = true; want false when hint not in table")
+	}
+	if result.Metrics.HintRejectionReason != "" {
+		t.Fatalf("HintRejectionReason = %q; want empty (hint never tried)", result.Metrics.HintRejectionReason)
+	}
+}
+
+func TestSourceAddressSelector_HintCandidateIgnoredWhenExplicitSourceSet(t *testing.T) {
+	t.Parallel()
+
+	// Operator pinned ExplicitSource — hint must be silently ignored to
+	// avoid biasing the operator-supplied candidate set.
+	selector := NewSourceAddressSelector(&scriptedSourceAddressSelectionBus{}, SourceAddressSelectionConfig{
+		ListenWarmup:      2 * time.Millisecond,
+		ExplicitSource:    0x71,
+		ExplicitSourceSet: true,
+		HintCandidate:     0x77,
+		HintCandidateSet:  true,
+	})
+	result, err := selector.Select(context.Background())
+	if err != nil {
+		t.Fatalf("Select error = %v", err)
+	}
+	if result.Source != 0x71 {
+		t.Fatalf("Source = 0x%02x; want 0x71 (explicit source pinned, hint ignored)", result.Source)
+	}
+	// HintCandidateSet metric must report false because explicit source
+	// suppressed the hint — observability shouldn't claim the hint was used.
+	if result.Metrics.HintCandidateSet || result.Metrics.HintAccepted {
+		t.Fatalf("Hint metrics should be cleared when explicit source set; got set=%v accepted=%v",
+			result.Metrics.HintCandidateSet, result.Metrics.HintAccepted)
+	}
+}
+
+func TestSourceAddressSelector_HintCandidateSetWithZeroIsHonored(t *testing.T) {
+	t.Parallel()
+
+	// HintCandidate=0x00 + HintCandidateSet=true means "hint = 0x00", not
+	// "no hint" — the byte-zero ambiguity is resolved by the explicit
+	// HintCandidateSet flag. 0x00 is in the default policy table (last
+	// entry), and without occupancy evidence its companion (0x05) is
+	// unknown but still allowed by the validator. Selector must promote
+	// 0x00 to head of the candidate sequence and admit it.
+	selector := NewSourceAddressSelector(&scriptedSourceAddressSelectionBus{}, SourceAddressSelectionConfig{
+		ListenWarmup:     2 * time.Millisecond,
+		HintCandidate:    0x00,
+		HintCandidateSet: true,
+	})
+	result, err := selector.Select(context.Background())
+	if err != nil {
+		t.Fatalf("Select error = %v", err)
+	}
+	if result.Source != 0x00 {
+		t.Fatalf("Source = 0x%02x; want 0x00 (hint biased to head of candidate order)", result.Source)
+	}
+	if !result.Metrics.HintCandidateSet || result.Metrics.HintCandidate != 0x00 {
+		t.Fatalf("HintCandidate=%v set=%v; want 0x00 set=true", result.Metrics.HintCandidate, result.Metrics.HintCandidateSet)
+	}
+	if !result.Metrics.HintAccepted {
+		t.Fatalf("HintAccepted = false; want true (hint=0x00 honored, not treated as unset)")
+	}
+	if len(result.Metrics.CandidatesConsidered) == 0 || result.Metrics.CandidatesConsidered[0] != 0x00 {
+		t.Fatalf("CandidatesConsidered[0] = 0x%02x; want 0x00 first", firstByteOrZero(result.Metrics.CandidatesConsidered))
+	}
+}
+
+func firstByteOrZero(b []byte) byte {
+	if len(b) == 0 {
+		return 0
+	}
+	return b[0]
+}
+
 func equalBytes(a, b []byte) bool {
 	if len(a) != len(b) {
 		return false


### PR DESCRIPTION
## Summary

M4_SOURCE_SELECTION_HINT for `runtime-state-w19-26.locked` — Part 1/2 (ebusgo).

Adds optional `HintCandidate` / `HintCandidateSet` to `SourceAddressSelectionConfig` so the gateway can pass `runtime_state.ebus.self.last_admitted_source` as a candidate-ordering bias. The hint reorders candidates so the cached source is tried first; full validation (warmup observation, companion occupancy, evidence) still runs — the hint never bypasses the locked invariants.

If the hint fails validation, candidate iteration falls through to the regular candidate order. The hint is mutually exclusive with `ExplicitSourceSet`.

## Behavior

| Scenario | Outcome |
|----------|---------|
| Hint set, hint validates | Hint admitted, `HintAccepted=true` |
| Hint set, hint rejected | Falls through to default policy; `HintRejectionReason` populated |
| Hint set, not in standard table | Silently ignored, default policy unaffected |
| Hint set + `ExplicitSourceSet` | Hint silently ignored |
| `HintCandidate=0x00` + `HintCandidateSet=true` | Honored as `0x00` (byte-zero ambiguity resolved by the flag) |

New telemetry on `SourceAddressSelectionMetrics`:
- `HintCandidate` / `HintCandidateSet` — input echo
- `HintAccepted` — boolean outcome
- `HintRejectionReason` — validator reason when hint was tried + rejected

## Test plan

- [x] `go test ./...` — full suite green (12 packages)
- [x] 5 new tests on the hint mechanism (accepted, rejected fallthrough, missing-table-row, explicit-overrides-hint, byte-zero)
- [x] Existing 30+ selector tests unaffected
- [x] `go vet ./protocol/...` clean

## Plan reference

- Plan: `runtime-state-w19-26.locked`
- Milestone: M4_SOURCE_SELECTION_HINT
- Issue map: RTS-GW-04
- Canonical-SHA256: `5f723d7122dd24c81357dc7adb640cbdb805679a5d91c8b8dedcbe6ef60edede`

Part 2/2 (gateway integration + AD24 invariant test) lands in a follow-up PR on `helianthus-ebusgateway` once this merges and the `go.mod` pin is bumped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)