### PR TITLE
fix(protocol): split first-byte arbitration-loss-shaped mismatch into ErrBusCollision (round 7)

### DIFF
--- a/protocol/bus.go
+++ b/protocol/bus.go
@@ -900,7 +900,19 @@ func (b *Bus) sendInitiatorTelegram(runCtx, reqCtx context.Context, telegram []b
 		start = 1
 	}
 	for i := start; i < len(telegram); i++ {
-		if err := b.sendSymbolWithEcho(runCtx, reqCtx, telegram[i], true); err != nil {
+		// batch-26 round-7 — first-byte arbitration-loss split. The
+		// first iteration of this loop writes the first wire byte
+		// AFTER arbitration: with includeSource=false (ENH path) it's
+		// telegram[1] (DST); with includeSource=true (plain-path
+		// NACK-retry) it's telegram[0] (SRC re-sent without
+		// re-arbitrating). In both cases i==start identifies the
+		// position. sendSymbolWithEcho receives the flag and the
+		// downstream sendRawWithEcho classifies a mismatch from a
+		// foreign master-class byte as ErrBusCollision rather than
+		// ErrBusCollision-via-"echo mismatch" string (which routes
+		// through BusOutcomeEchoMismatch).
+		isFirstByte := i == start
+		if err := b.sendSymbolWithEcho(runCtx, reqCtx, telegram[i], true, isFirstByte); err != nil {
 			return err
 		}
 	}
@@ -908,10 +920,13 @@ func (b *Bus) sendInitiatorTelegram(runCtx, reqCtx context.Context, telegram []b
 }
 
 func (b *Bus) sendEndOfMessage(runCtx, reqCtx context.Context) error {
-	return b.sendSymbolWithEcho(runCtx, reqCtx, SymbolSyn, false)
+	// End-of-message SYN is never the first byte after arbitration —
+	// it terminates a frame whose first byte fired far earlier in
+	// sendInitiatorTelegram. Pass isFirstByteAfterArbitration=false.
+	return b.sendSymbolWithEcho(runCtx, reqCtx, SymbolSyn, false, false)
 }
 
-func (b *Bus) sendSymbolWithEcho(runCtx, reqCtx context.Context, symbol byte, escape bool) error {
+func (b *Bus) sendSymbolWithEcho(runCtx, reqCtx context.Context, symbol byte, escape bool, isFirstByteAfterArbitration bool) error {
 	if b.unescapedTransport || !escape || (symbol != SymbolEscape && symbol != SymbolSyn) {
 		// F-23 (Codex bot r3 on #154): for ENH-class transports, a
 		// `raw == SymbolSyn` write can be either a structural
@@ -923,7 +938,7 @@ func (b *Bus) sendSymbolWithEcho(runCtx, reqCtx context.Context, symbol byte, es
 		// fire on the FIRST case — otherwise legitimate payload
 		// 0xAA echoes are misclassified as bus collisions.
 		expectRawSyn := !escape && symbol == SymbolSyn
-		return b.sendRawWithEcho(runCtx, reqCtx, symbol, expectRawSyn)
+		return b.sendRawWithEcho(runCtx, reqCtx, symbol, expectRawSyn, isFirstByteAfterArbitration)
 	}
 
 	// Plain transport: wire-level escape for 0xA9/0xAA symbols. The
@@ -932,14 +947,19 @@ func (b *Bus) sendSymbolWithEcho(runCtx, reqCtx context.Context, symbol byte, es
 	// expectRawSyn=false for both. The new ENH guards only fire on
 	// unescapedTransport=true anyway, so this is defensive parameter
 	// hygiene rather than load-bearing.
-	if err := b.sendRawWithEcho(runCtx, reqCtx, SymbolEscape, false); err != nil {
+	//
+	// First-byte-after-arbitration semantics for the escape pair: the
+	// FIRST wire byte is the escape lead (0xA9) — that is what the
+	// adapter is going to transmit on the wire. So the lead carries
+	// the isFirstByte flag; the trailing escape data byte does NOT.
+	if err := b.sendRawWithEcho(runCtx, reqCtx, SymbolEscape, false, isFirstByteAfterArbitration); err != nil {
 		return err
 	}
 	esc := byte(0x00)
 	if symbol == SymbolSyn {
 		esc = 0x01
 	}
-	return b.sendRawWithEcho(runCtx, reqCtx, esc, false)
+	return b.sendRawWithEcho(runCtx, reqCtx, esc, false, false)
 }
 
 // sendRawWithEcho writes a single byte and validates the wire echo.
@@ -949,7 +969,18 @@ func (b *Bus) sendSymbolWithEcho(runCtx, reqCtx context.Context, symbol byte, es
 // false, raw is a payload byte: the adapter may legitimately
 // wire-escape values 0xA9/0xAA, and the echo's WasEscaped flag
 // reflects that without indicating collision.
-func (b *Bus) sendRawWithEcho(runCtx, reqCtx context.Context, raw byte, expectRawSyn bool) error {
+//
+// isFirstByteAfterArbitration (batch-26 round-7) — when true, this
+// write is the first wire byte sent AFTER arbitration completed. A
+// mismatch where the echo arrives as a foreign-initiator-class byte
+// (AddressClassMaster, value ≠ raw) is unambiguous evidence of
+// arbitration loss to a concurrent master, NOT a generic echo
+// mismatch. Classify as Collision rather than EchoMismatch so the
+// retry path (Is(ErrBusCollision) AND NOT contains("echo mismatch"))
+// routes through BusOutcomeCollision, and the gateway P10 counter
+// surface records the event under the collision class rather than
+// inflating the echo_mismatch population.
+func (b *Bus) sendRawWithEcho(runCtx, reqCtx context.Context, raw byte, expectRawSyn bool, isFirstByteAfterArbitration bool) error {
 	written, err := b.transport.Write([]byte{raw})
 	if err != nil {
 		b.emitOutcomeEvent(Frame{}, FrameTypeUnknown, 0, err)
@@ -1090,6 +1121,49 @@ func (b *Bus) sendRawWithEcho(runCtx, reqCtx context.Context, raw byte, expectRa
 		return err
 	}
 	if echo != raw {
+		// batch-26 round-7 — first-byte-after-arbitration foreign-
+		// initiator split. When the echo of the FIRST byte after
+		// arbitration comes back as a master-class byte that is NOT
+		// our raw write AND was NOT escape-decoded, that is the
+		// classic arbitration-loss shape: a concurrent master won
+		// the bus and its SOF is on the wire instead of our echoed
+		// byte. Classify as Collision rather than EchoMismatch so:
+		//   - busOutcomeFromError routes to BusOutcomeCollision
+		//     (the routing keys off Is(ErrBusCollision) AND the
+		//     "echo mismatch" substring; the new error message below
+		//     omits that substring deliberately so the existing
+		//     classifier discriminates without changing).
+		//   - The observer event emits BusEventCollision (not
+		//     BusEventEchoMismatch) so downstream gateway P10 counters
+		//     route to ebus_errors_total{class="collision"} rather
+		//     than {class="echo_mismatch"}.
+		//
+		// Guard layering:
+		//   - isFirstByteAfterArbitration: only the first wire byte
+		//     after arbitration can be an arbitration-loss observation.
+		//     Mid-frame mismatches are echo-stream corruption, not
+		//     arbitration races.
+		//   - !echoWasEscaped: an escape-decoded payload byte arriving
+		//     as the "echo" is not a wire-level foreign-initiator
+		//     signal — it's escape-stream contamination, which the
+		//     existing F-23 / batch-23 round-5 guards already
+		//     classify as EchoMismatch with the right subclass.
+		//   - AddressClassOf(echo) == AddressClassMaster: only foreign
+		//     master-class bytes are arbitration-loss evidence. A
+		//     slave/broadcast/reserved byte in echo position would be
+		//     wire corruption or bit-flip — keep generic EchoMismatch
+		//     for those.
+		if isFirstByteAfterArbitration && !echoWasEscaped && AddressClassOf(echo) == AddressClassMaster {
+			b.emitObserverEvent(BusEvent{
+				Kind:           BusEventCollision,
+				Outcome:        BusOutcomeCollision,
+				Byte:           echo,
+				EchoWasEscaped: echoWasEscaped,
+			})
+			err := fmt.Errorf("first-byte arbitration loss: wrote 0x%02X, wire echo 0x%02X (foreign initiator): %w", raw, echo, ebuserrors.ErrBusCollision)
+			b.emitOutcomeEvent(Frame{}, FrameTypeUnknown, 0, err)
+			return err
+		}
 		b.emitObserverEvent(BusEvent{
 			Kind:           BusEventEchoMismatch,
 			Outcome:        BusOutcomeEchoMismatch,

--- a/protocol/bus.go
+++ b/protocol/bus.go
@@ -828,7 +828,9 @@ func (b *Bus) sendTransaction(runCtx, reqCtx context.Context, frame Frame, attem
 		segment = append(segment, lengthSym)
 		segment = append(segment, data...)
 		if CRC(segment) != crcValue {
-			if err := b.sendSymbolWithEcho(runCtx, reqCtx, SymbolNack, true); err != nil {
+			// ACK/NACK are response-phase sends — never the first wire byte
+			// after arbitration, so isFirstByteAfterArbitration=false.
+			if err := b.sendSymbolWithEcho(runCtx, reqCtx, SymbolNack, true, false); err != nil {
 				return nil, err
 			}
 			b.emitObserverEvent(BusEvent{
@@ -861,7 +863,9 @@ func (b *Bus) sendTransaction(runCtx, reqCtx context.Context, frame Frame, attem
 			return nil, err
 		}
 
-		if err := b.sendSymbolWithEcho(runCtx, reqCtx, SymbolAck, true); err != nil {
+		// ACK/NACK are response-phase sends — never the first wire byte
+		// after arbitration, so isFirstByteAfterArbitration=false.
+		if err := b.sendSymbolWithEcho(runCtx, reqCtx, SymbolAck, true, false); err != nil {
 			return nil, err
 		}
 		response := &Frame{

--- a/protocol/bus.go
+++ b/protocol/bus.go
@@ -1137,10 +1137,10 @@ func (b *Bus) sendRawWithEcho(runCtx, reqCtx context.Context, raw byte, expectRa
 		//     "echo mismatch" substring; the new error message below
 		//     omits that substring deliberately so the existing
 		//     classifier discriminates without changing).
-		//   - The observer event emits BusEventCollision (not
-		//     BusEventEchoMismatch) so downstream gateway P10 counters
-		//     route to ebus_errors_total{class="collision"} rather
-		//     than {class="echo_mismatch"}.
+		//   - downstream observability records via the existing
+		//     BusEventRetry / BusOutcomeCollision arm in
+		//     bus_observability_store.go — no new BusEventKind is
+		//     needed (Codex r2 defect 2 — MEDIUM).
 		//
 		// Guard layering:
 		//   - isFirstByteAfterArbitration: only the first wire byte
@@ -1158,12 +1158,19 @@ func (b *Bus) sendRawWithEcho(runCtx, reqCtx context.Context, raw byte, expectRa
 		//     wire corruption or bit-flip — keep generic EchoMismatch
 		//     for those.
 		if isFirstByteAfterArbitration && !echoWasEscaped && AddressClassOf(echo) == AddressClassMaster {
-			b.emitObserverEvent(BusEvent{
-				Kind:           BusEventCollision,
-				Outcome:        BusOutcomeCollision,
-				Byte:           echo,
-				EchoWasEscaped: echoWasEscaped,
-			})
+			// batch-26 round-7 (Codex r2 defect 2 — MEDIUM): no direct
+			// BusEvent emission for this branch. Routing already works
+			// via the standard outcome path:
+			//   - error wraps ErrBusCollision WITHOUT "echo mismatch"
+			//     substring → busOutcomeFromError → BusOutcomeCollision.
+			//   - the bus retry path emits BusEventRetry with
+			//     Outcome=BusOutcomeCollision via busOutcomeFromError;
+			//     the gateway-side BusObservabilityStore.OnBusEvent
+			//     increments ebus_errors_total{class="collision",
+			//     scope="active",phase="request"} on that retry event.
+			// Emitting a separate BusEventCollision here would be a
+			// dead-letter event with no downstream consumer, so we drop
+			// it. The error wrapping is the load-bearing signal.
 			err := fmt.Errorf("first-byte arbitration loss: wrote 0x%02X, wire echo 0x%02X (foreign initiator): %w", raw, echo, ebuserrors.ErrBusCollision)
 			b.emitOutcomeEvent(Frame{}, FrameTypeUnknown, 0, err)
 			return err

--- a/protocol/bus_first_byte_collision_test.go
+++ b/protocol/bus_first_byte_collision_test.go
@@ -1,0 +1,230 @@
+package protocol_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+
+	ebuserrors "github.com/Project-Helianthus/helianthus-ebusgo/errors"
+	"github.com/Project-Helianthus/helianthus-ebusgo/protocol"
+)
+
+// TestFirstByteEchoMismatch_ForeignInitiator_RoutesToCollision (batch-26
+// round-7) verifies the first-byte-after-arbitration foreign-initiator
+// split: when sendRawWithEcho's FIRST write after arbitration receives
+// a wire echo of a master-class byte that is NOT what we wrote, the
+// failure is classified as ErrBusCollision (BusOutcomeCollision +
+// BusEventCollision), NOT as a generic echo_mismatch.
+//
+// Setup: ENH-style escapeFlaggedReader transport with
+// ArbitrationSendsSource=true. Send a frame to slave-class target
+// 0x08. With includeSource=false (set automatically when the transport
+// is an arbitrationTransport with ArbitrationSendsSource()=true) the
+// first byte sendInitiatorTelegram writes is telegram[1]=0x08 (DST).
+// Mock the echo for that byte as 0x31 — a master-class byte (per
+// sourceAddressTableV1: P1 priority Bus interface) — which is the
+// classic "foreign initiator won arbitration, its SOF is on the wire
+// where our DST echo should be" shape.
+//
+// Pre-round-7 result: bus.go's generic `if echo != raw` branch fired,
+// emitting BusEventEchoMismatch and an error containing "echo mismatch".
+// busOutcomeFromError mapped that to BusOutcomeEchoMismatch via the
+// containsEchoMismatch substring check; the retry path still fired
+// (it gates on Is(ErrBusCollision) || ... and gets retry-as-collision)
+// but downstream counters at the gateway recorded the event under
+// echo_mismatch — inflating the echo_mismatch population with what
+// is structurally a collision.
+//
+// Post-round-7 result: the new isFirstByteAfterArbitration branch
+// fires BEFORE the generic value-mismatch branch:
+//   - emits BusEventCollision (not BusEventEchoMismatch)
+//   - error message "first-byte arbitration loss: ..." (NOT containing
+//     "echo mismatch"), so busOutcomeFromError routes to
+//     BusOutcomeCollision via the containsEchoMismatch=false branch.
+func TestFirstByteEchoMismatch_ForeignInitiator_RoutesToCollision(t *testing.T) {
+	t.Parallel()
+
+	// Transport: ENH-style (unescaped=true, ArbitrationSendsSource=true).
+	// The echoF23TestTransport from bus_echo_f23_test.go fits perfectly
+	// — reuse instead of duplicating the transport mock.
+	tr := &echoF23TestTransport{unescaped: true}
+
+	// Capture all bus events for kind/outcome assertions.
+	var observed []protocol.BusEvent
+	var obsMu sync.Mutex
+	observer := protocol.BusObserverFunc(func(ev protocol.BusEvent) error {
+		obsMu.Lock()
+		defer obsMu.Unlock()
+		observed = append(observed, ev)
+		return nil
+	})
+
+	cfg := protocol.DefaultBusConfig()
+	cfg.Observer = observer
+	bus := protocol.NewBus(tr, cfg, 8)
+	runCtx, runCancel := context.WithCancel(context.Background())
+	defer runCancel()
+	bus.Run(runCtx)
+	// Unbounded ctx — see TestBus_EscapeAware_SynEcho_RealWireSynAccepted
+	// for the rationale (collision short-circuits without policy retry
+	// when ctx is unbounded).
+	ctx := context.Background()
+
+	// Build a directed frame to slave-class target 0x08. With ENH +
+	// ArbitrationSendsSource=true, sendInitiatorTelegram skips index 0
+	// (SRC is sent during arbitration) and writes telegram[1]=0x08
+	// (DST) as the FIRST byte after arbitration.
+	frame := protocol.Frame{
+		Source:    0x10,
+		Target:    0x08,
+		Primary:   0xB5,
+		Secondary: 0x16,
+		Data:      nil,
+	}
+
+	// Echo queue: the FIRST echo (for DST=0x08) is the foreign-initiator
+	// byte 0x31 (a master-class P1 address per sourceAddressTableV1).
+	// AddressClassOf(0x31) == AddressClassMaster → new branch fires.
+	tr.mu.Lock()
+	tr.echo = []echoF23Event{
+		{value: 0x31, wasEscaped: false},
+	}
+	tr.mu.Unlock()
+
+	_, err := bus.Send(ctx, frame)
+	if err == nil {
+		t.Fatal("Send returned nil; want wrapped ErrBusCollision (first-byte arbitration loss)")
+	}
+	if !errors.Is(err, ebuserrors.ErrBusCollision) {
+		t.Fatalf("Send err = %v; want wrapped ErrBusCollision", err)
+	}
+
+	// Assertion (a): the error message MUST NOT contain "echo mismatch"
+	// — that substring is what busOutcomeFromError uses to discriminate
+	// echo_mismatch from collision, and the round-7 contract is that
+	// foreign-initiator first-byte cases route as collision.
+	if strings.Contains(err.Error(), "echo mismatch") {
+		t.Errorf("err = %q; MUST NOT contain \"echo mismatch\" substring (busOutcomeFromError would route to BusOutcomeEchoMismatch)", err.Error())
+	}
+	// Assertion (b): the error message MUST contain the arbitration-loss
+	// marker so dashboards / log filters can isolate this class.
+	if !strings.Contains(err.Error(), "first-byte arbitration loss") {
+		t.Errorf("err = %q; want substring \"first-byte arbitration loss\"", err.Error())
+	}
+
+	// Assertion (c): the observer received a BusEventCollision event for
+	// the foreign-initiator byte. There should be NO BusEventEchoMismatch
+	// for this scenario (the new branch fires BEFORE the generic
+	// value-mismatch branch).
+	obsMu.Lock()
+	defer obsMu.Unlock()
+	var sawCollision bool
+	for _, ev := range observed {
+		if ev.Kind == protocol.BusEventCollision {
+			sawCollision = true
+			if ev.Outcome != protocol.BusOutcomeCollision {
+				t.Errorf("BusEventCollision Outcome = %v, want BusOutcomeCollision", ev.Outcome)
+			}
+			if ev.Byte != 0x31 {
+				t.Errorf("BusEventCollision Byte = 0x%02X, want 0x31 (the foreign-initiator wire byte)", ev.Byte)
+			}
+			if ev.EchoWasEscaped {
+				t.Errorf("BusEventCollision EchoWasEscaped = true, want false (the gate requires non-escaped echo)")
+			}
+		}
+		if ev.Kind == protocol.BusEventEchoMismatch {
+			t.Errorf("unexpected BusEventEchoMismatch — round-7 routes first-byte foreign-initiator to BusEventCollision, not echo_mismatch: %+v", ev)
+		}
+	}
+	if !sawCollision {
+		t.Errorf("no BusEventCollision observed; events seen: %d", len(observed))
+		for i, ev := range observed {
+			t.Logf("  [%d] Kind=%v Outcome=%v Byte=0x%02X", i, ev.Kind, ev.Outcome, ev.Byte)
+		}
+	}
+}
+
+// TestFirstByteEchoMismatch_NonFirstByte_StaysEchoMismatch is the
+// negative control for the round-7 split: a value mismatch on a
+// NON-first-byte (mid-frame) write must still route through the
+// existing BusEventEchoMismatch / "echo mismatch" path — the new
+// branch is gated on isFirstByteAfterArbitration to avoid pulling
+// generic mid-frame corruption into the collision bucket.
+//
+// Setup: the same target/source as the positive test, but the FIRST
+// echo (DST=0x08) is correct. The SECOND write (PB=0xB5) gets a
+// foreign master-class echo of 0x31. Round-7's first-byte gate is
+// false at this position → the generic value-mismatch branch fires
+// → BusEventEchoMismatch + "echo mismatch" error string.
+func TestFirstByteEchoMismatch_NonFirstByte_StaysEchoMismatch(t *testing.T) {
+	t.Parallel()
+
+	tr := &echoF23TestTransport{unescaped: true}
+
+	var observed []protocol.BusEvent
+	var obsMu sync.Mutex
+	observer := protocol.BusObserverFunc(func(ev protocol.BusEvent) error {
+		obsMu.Lock()
+		defer obsMu.Unlock()
+		observed = append(observed, ev)
+		return nil
+	})
+
+	cfg := protocol.DefaultBusConfig()
+	cfg.Observer = observer
+	bus := protocol.NewBus(tr, cfg, 8)
+	runCtx, runCancel := context.WithCancel(context.Background())
+	defer runCancel()
+	bus.Run(runCtx)
+	ctx := context.Background()
+
+	frame := protocol.Frame{
+		Source:    0x10,
+		Target:    0x08,
+		Primary:   0xB5,
+		Secondary: 0x16,
+		Data:      nil,
+	}
+
+	// Echo queue: first byte (DST) echoes cleanly; second byte (PB) gets
+	// a foreign master-class echo of 0x31. isFirstByteAfterArbitration
+	// is FALSE at the PB position → new branch does NOT fire → generic
+	// "echo mismatch" path fires.
+	tr.mu.Lock()
+	tr.echo = []echoF23Event{
+		{value: 0x08, wasEscaped: false}, // DST echo clean
+		{value: 0x31, wasEscaped: false}, // PB echo poisoned (mid-frame)
+	}
+	tr.mu.Unlock()
+
+	_, err := bus.Send(ctx, frame)
+	if err == nil {
+		t.Fatal("Send returned nil; want ErrBusCollision wrapping \"echo mismatch\"")
+	}
+	if !errors.Is(err, ebuserrors.ErrBusCollision) {
+		t.Fatalf("Send err = %v; want wrapped ErrBusCollision", err)
+	}
+	if !strings.Contains(err.Error(), "echo mismatch") {
+		t.Errorf("err = %q; mid-frame mismatch must keep \"echo mismatch\" substring (routes to BusOutcomeEchoMismatch)", err.Error())
+	}
+	if strings.Contains(err.Error(), "first-byte arbitration loss") {
+		t.Errorf("err = %q; mid-frame mismatch MUST NOT use first-byte arbitration loss message", err.Error())
+	}
+
+	obsMu.Lock()
+	defer obsMu.Unlock()
+	var sawEchoMismatch bool
+	for _, ev := range observed {
+		if ev.Kind == protocol.BusEventCollision {
+			t.Errorf("unexpected BusEventCollision on mid-frame mismatch — round-7 gate is first-byte-only: %+v", ev)
+		}
+		if ev.Kind == protocol.BusEventEchoMismatch {
+			sawEchoMismatch = true
+		}
+	}
+	if !sawEchoMismatch {
+		t.Errorf("no BusEventEchoMismatch observed; events seen: %d", len(observed))
+	}
+}

--- a/protocol/bus_first_byte_collision_test.go
+++ b/protocol/bus_first_byte_collision_test.go
@@ -15,8 +15,8 @@ import (
 // round-7) verifies the first-byte-after-arbitration foreign-initiator
 // split: when sendRawWithEcho's FIRST write after arbitration receives
 // a wire echo of a master-class byte that is NOT what we wrote, the
-// failure is classified as ErrBusCollision (BusOutcomeCollision +
-// BusEventCollision), NOT as a generic echo_mismatch.
+// failure is classified as ErrBusCollision (BusOutcomeCollision via
+// busOutcomeFromError), NOT as a generic echo_mismatch.
 //
 // Setup: ENH-style escapeFlaggedReader transport with
 // ArbitrationSendsSource=true. Send a frame to slave-class target
@@ -39,10 +39,16 @@ import (
 //
 // Post-round-7 result: the new isFirstByteAfterArbitration branch
 // fires BEFORE the generic value-mismatch branch:
-//   - emits BusEventCollision (not BusEventEchoMismatch)
 //   - error message "first-byte arbitration loss: ..." (NOT containing
 //     "echo mismatch"), so busOutcomeFromError routes to
 //     BusOutcomeCollision via the containsEchoMismatch=false branch.
+//
+// Codex r2 defect 2 (MEDIUM): no separate BusEventCollision is emitted —
+// downstream observability already counts via the existing
+// BusEventRetry / BusOutcomeCollision arm in
+// bus_observability_store.go (busOutcomeFromError on the wrapped
+// error feeds the retry Outcome). The test asserts on the ERROR
+// classification, not on a dedicated BusEvent emission.
 func TestFirstByteEchoMismatch_ForeignInitiator_RoutesToCollision(t *testing.T) {
 	t.Parallel()
 
@@ -51,7 +57,9 @@ func TestFirstByteEchoMismatch_ForeignInitiator_RoutesToCollision(t *testing.T) 
 	// — reuse instead of duplicating the transport mock.
 	tr := &echoF23TestTransport{unescaped: true}
 
-	// Capture all bus events for kind/outcome assertions.
+	// Capture all bus events: post-defect-2 we assert there is NO
+	// BusEventEchoMismatch (the new branch must NOT fall through to
+	// the generic echo_mismatch emit).
 	var observed []protocol.BusEvent
 	var obsMu sync.Mutex
 	observer := protocol.BusObserverFunc(func(ev protocol.BusEvent) error {
@@ -114,34 +122,16 @@ func TestFirstByteEchoMismatch_ForeignInitiator_RoutesToCollision(t *testing.T) 
 		t.Errorf("err = %q; want substring \"first-byte arbitration loss\"", err.Error())
 	}
 
-	// Assertion (c): the observer received a BusEventCollision event for
-	// the foreign-initiator byte. There should be NO BusEventEchoMismatch
-	// for this scenario (the new branch fires BEFORE the generic
-	// value-mismatch branch).
+	// Assertion (c): no BusEventEchoMismatch was emitted — the new
+	// branch returns BEFORE the generic emit, and Codex r2 defect 2
+	// dropped the direct BusEventCollision emit since the standard
+	// outcome path (BusEventRetry with Outcome=BusOutcomeCollision)
+	// is the canonical observability surface.
 	obsMu.Lock()
 	defer obsMu.Unlock()
-	var sawCollision bool
 	for _, ev := range observed {
-		if ev.Kind == protocol.BusEventCollision {
-			sawCollision = true
-			if ev.Outcome != protocol.BusOutcomeCollision {
-				t.Errorf("BusEventCollision Outcome = %v, want BusOutcomeCollision", ev.Outcome)
-			}
-			if ev.Byte != 0x31 {
-				t.Errorf("BusEventCollision Byte = 0x%02X, want 0x31 (the foreign-initiator wire byte)", ev.Byte)
-			}
-			if ev.EchoWasEscaped {
-				t.Errorf("BusEventCollision EchoWasEscaped = true, want false (the gate requires non-escaped echo)")
-			}
-		}
 		if ev.Kind == protocol.BusEventEchoMismatch {
-			t.Errorf("unexpected BusEventEchoMismatch — round-7 routes first-byte foreign-initiator to BusEventCollision, not echo_mismatch: %+v", ev)
-		}
-	}
-	if !sawCollision {
-		t.Errorf("no BusEventCollision observed; events seen: %d", len(observed))
-		for i, ev := range observed {
-			t.Logf("  [%d] Kind=%v Outcome=%v Byte=0x%02X", i, ev.Kind, ev.Outcome, ev.Byte)
+			t.Errorf("unexpected BusEventEchoMismatch — round-7 routes first-byte foreign-initiator to the collision outcome, not echo_mismatch: %+v", ev)
 		}
 	}
 }
@@ -217,14 +207,187 @@ func TestFirstByteEchoMismatch_NonFirstByte_StaysEchoMismatch(t *testing.T) {
 	defer obsMu.Unlock()
 	var sawEchoMismatch bool
 	for _, ev := range observed {
-		if ev.Kind == protocol.BusEventCollision {
-			t.Errorf("unexpected BusEventCollision on mid-frame mismatch — round-7 gate is first-byte-only: %+v", ev)
-		}
 		if ev.Kind == protocol.BusEventEchoMismatch {
 			sawEchoMismatch = true
 		}
 	}
 	if !sawEchoMismatch {
 		t.Errorf("no BusEventEchoMismatch observed; events seen: %d", len(observed))
+	}
+}
+
+// TestFirstByteEchoMismatch_NonMaster_StaysEchoMismatch is the
+// guard-layer test for the AddressClassMaster gate (Codex r2 minor
+// test gap): a first-byte echo that is NOT a master-class byte is
+// NOT an arbitration-loss observation — it is wire corruption or a
+// bit-flip — and MUST still route through the generic
+// BusEventEchoMismatch / "echo mismatch" path.
+//
+// Setup: DST=0x08 is the first byte after arbitration; the mock
+// returns echo 0x55. AddressClassOf(0x55) inspects nibbles (5,5);
+// neither 5 ∈ {0,1,3,7,F}, so the byte is AddressClassSlave (or
+// AddressClassReserved). The round-7 gate
+// `AddressClassOf(echo) == AddressClassMaster` is FALSE → new branch
+// does NOT fire → generic "echo mismatch" path fires.
+func TestFirstByteEchoMismatch_NonMaster_StaysEchoMismatch(t *testing.T) {
+	t.Parallel()
+
+	// Sanity: 0x55 must NOT be master-class for this test to mean
+	// what its name says.
+	if protocol.AddressClassOf(0x55) == protocol.AddressClassMaster {
+		t.Fatalf("test premise broken: AddressClassOf(0x55) = AddressClassMaster; pick a non-master sentinel")
+	}
+
+	tr := &echoF23TestTransport{unescaped: true}
+
+	var observed []protocol.BusEvent
+	var obsMu sync.Mutex
+	observer := protocol.BusObserverFunc(func(ev protocol.BusEvent) error {
+		obsMu.Lock()
+		defer obsMu.Unlock()
+		observed = append(observed, ev)
+		return nil
+	})
+
+	cfg := protocol.DefaultBusConfig()
+	cfg.Observer = observer
+	bus := protocol.NewBus(tr, cfg, 8)
+	runCtx, runCancel := context.WithCancel(context.Background())
+	defer runCancel()
+	bus.Run(runCtx)
+	ctx := context.Background()
+
+	frame := protocol.Frame{
+		Source:    0x10,
+		Target:    0x08,
+		Primary:   0xB5,
+		Secondary: 0x16,
+		Data:      nil,
+	}
+
+	// Echo queue: the FIRST echo (for DST=0x08) is 0x55 — a
+	// non-master-class byte. New branch is gated on
+	// AddressClassMaster; not satisfied → falls through to generic.
+	tr.mu.Lock()
+	tr.echo = []echoF23Event{
+		{value: 0x55, wasEscaped: false},
+	}
+	tr.mu.Unlock()
+
+	_, err := bus.Send(ctx, frame)
+	if err == nil {
+		t.Fatal("Send returned nil; want ErrBusCollision wrapping \"echo mismatch\"")
+	}
+	if !errors.Is(err, ebuserrors.ErrBusCollision) {
+		t.Fatalf("Send err = %v; want wrapped ErrBusCollision", err)
+	}
+	if !strings.Contains(err.Error(), "echo mismatch") {
+		t.Errorf("err = %q; non-master first-byte mismatch must keep \"echo mismatch\" substring (routes to BusOutcomeEchoMismatch)", err.Error())
+	}
+	if strings.Contains(err.Error(), "first-byte arbitration loss") {
+		t.Errorf("err = %q; non-master first-byte mismatch MUST NOT use first-byte arbitration loss message", err.Error())
+	}
+
+	obsMu.Lock()
+	defer obsMu.Unlock()
+	var sawEchoMismatch bool
+	for _, ev := range observed {
+		if ev.Kind == protocol.BusEventEchoMismatch {
+			sawEchoMismatch = true
+		}
+	}
+	if !sawEchoMismatch {
+		t.Errorf("no BusEventEchoMismatch observed for non-master first-byte mismatch; events seen: %d", len(observed))
+	}
+}
+
+// TestFirstByteEchoMismatch_WasEscaped_StaysEchoMismatch is the
+// guard-layer test for the !echoWasEscaped gate (Codex r2 minor
+// test gap): even when the first-byte echo is a master-class byte
+// that does NOT match what we wrote, if it arrived via the
+// escape-decoded path (WasEscaped=true), it cannot be a
+// wire-level arbitration-loss signal — it is an escape-stream
+// payload byte from an unrelated frame, NOT another initiator's SOF.
+//
+// Setup: DST=0x08 is the first byte after arbitration; the mock
+// returns echo 0x10 (a master-class byte, P1 ID 0x10 per
+// sourceAddressTableV1) WITH WasEscaped=true. The round-7 gate
+// `!echoWasEscaped` is FALSE → new branch does NOT fire → falls
+// through to the generic value-mismatch branch (echoes 0x10 vs raw
+// 0x08, so `echo != raw` is true) → BusEventEchoMismatch.
+func TestFirstByteEchoMismatch_WasEscaped_StaysEchoMismatch(t *testing.T) {
+	t.Parallel()
+
+	// Sanity: 0x10 must be master-class for this test to exercise the
+	// !echoWasEscaped gate (otherwise the AddressClassMaster gate
+	// would already exclude it and we'd be testing the wrong axis).
+	if protocol.AddressClassOf(0x10) != protocol.AddressClassMaster {
+		t.Fatalf("test premise broken: AddressClassOf(0x10) ≠ AddressClassMaster; pick a master sentinel")
+	}
+
+	tr := &echoF23TestTransport{unescaped: true}
+
+	var observed []protocol.BusEvent
+	var obsMu sync.Mutex
+	observer := protocol.BusObserverFunc(func(ev protocol.BusEvent) error {
+		obsMu.Lock()
+		defer obsMu.Unlock()
+		observed = append(observed, ev)
+		return nil
+	})
+
+	cfg := protocol.DefaultBusConfig()
+	cfg.Observer = observer
+	bus := protocol.NewBus(tr, cfg, 8)
+	runCtx, runCancel := context.WithCancel(context.Background())
+	defer runCancel()
+	bus.Run(runCtx)
+	ctx := context.Background()
+
+	frame := protocol.Frame{
+		Source:    0x10,
+		Target:    0x08,
+		Primary:   0xB5,
+		Secondary: 0x16,
+		Data:      nil,
+	}
+
+	// Echo queue: the FIRST echo (for DST=0x08) is 0x10 with
+	// WasEscaped=true. Master-class byte (passes AddressClassMaster
+	// gate) but WasEscaped=true defeats the !echoWasEscaped gate →
+	// falls through to generic value-mismatch branch.
+	tr.mu.Lock()
+	tr.echo = []echoF23Event{
+		{value: 0x10, wasEscaped: true},
+	}
+	tr.mu.Unlock()
+
+	_, err := bus.Send(ctx, frame)
+	if err == nil {
+		t.Fatal("Send returned nil; want ErrBusCollision wrapping \"echo mismatch\"")
+	}
+	if !errors.Is(err, ebuserrors.ErrBusCollision) {
+		t.Fatalf("Send err = %v; want wrapped ErrBusCollision", err)
+	}
+	if !strings.Contains(err.Error(), "echo mismatch") {
+		t.Errorf("err = %q; escape-decoded first-byte mismatch must keep \"echo mismatch\" substring (routes to BusOutcomeEchoMismatch)", err.Error())
+	}
+	if strings.Contains(err.Error(), "first-byte arbitration loss") {
+		t.Errorf("err = %q; escape-decoded first-byte mismatch MUST NOT use first-byte arbitration loss message — !echoWasEscaped gate must defeat the collision classification", err.Error())
+	}
+
+	obsMu.Lock()
+	defer obsMu.Unlock()
+	var sawEchoMismatch bool
+	for _, ev := range observed {
+		if ev.Kind == protocol.BusEventEchoMismatch {
+			sawEchoMismatch = true
+			if !ev.EchoWasEscaped {
+				t.Errorf("BusEventEchoMismatch EchoWasEscaped = false, want true (provenance forwarded from the escape-decoded echo)")
+			}
+		}
+	}
+	if !sawEchoMismatch {
+		t.Errorf("no BusEventEchoMismatch observed for escape-decoded first-byte mismatch; events seen: %d", len(observed))
 	}
 }

--- a/protocol/bus_first_byte_collision_test.go
+++ b/protocol/bus_first_byte_collision_test.go
@@ -14,16 +14,16 @@ import (
 // TestFirstByteEchoMismatch_ForeignInitiator_RoutesToCollision (batch-26
 // round-7) verifies the first-byte-after-arbitration foreign-initiator
 // split: when sendRawWithEcho's FIRST write after arbitration receives
-// a wire echo of a master-class byte that is NOT what we wrote, the
+// a wire echo of a initiator-class byte that is NOT what we wrote, the
 // failure is classified as ErrBusCollision (BusOutcomeCollision via
 // busOutcomeFromError), NOT as a generic echo_mismatch.
 //
 // Setup: ENH-style escapeFlaggedReader transport with
-// ArbitrationSendsSource=true. Send a frame to slave-class target
+// ArbitrationSendsSource=true. Send a frame to responder-class target
 // 0x08. With includeSource=false (set automatically when the transport
 // is an arbitrationTransport with ArbitrationSendsSource()=true) the
 // first byte sendInitiatorTelegram writes is telegram[1]=0x08 (DST).
-// Mock the echo for that byte as 0x31 — a master-class byte (per
+// Mock the echo for that byte as 0x31 — a initiator-class byte (per
 // sourceAddressTableV1: P1 priority Bus interface) — which is the
 // classic "foreign initiator won arbitration, its SOF is on the wire
 // where our DST echo should be" shape.
@@ -80,7 +80,7 @@ func TestFirstByteEchoMismatch_ForeignInitiator_RoutesToCollision(t *testing.T) 
 	// when ctx is unbounded).
 	ctx := context.Background()
 
-	// Build a directed frame to slave-class target 0x08. With ENH +
+	// Build a directed frame to responder-class target 0x08. With ENH +
 	// ArbitrationSendsSource=true, sendInitiatorTelegram skips index 0
 	// (SRC is sent during arbitration) and writes telegram[1]=0x08
 	// (DST) as the FIRST byte after arbitration.
@@ -93,7 +93,7 @@ func TestFirstByteEchoMismatch_ForeignInitiator_RoutesToCollision(t *testing.T) 
 	}
 
 	// Echo queue: the FIRST echo (for DST=0x08) is the foreign-initiator
-	// byte 0x31 (a master-class P1 address per sourceAddressTableV1).
+	// byte 0x31 (a initiator-class P1 address per sourceAddressTableV1).
 	// AddressClassOf(0x31) == AddressClassMaster → new branch fires.
 	tr.mu.Lock()
 	tr.echo = []echoF23Event{
@@ -145,7 +145,7 @@ func TestFirstByteEchoMismatch_ForeignInitiator_RoutesToCollision(t *testing.T) 
 //
 // Setup: the same target/source as the positive test, but the FIRST
 // echo (DST=0x08) is correct. The SECOND write (PB=0xB5) gets a
-// foreign master-class echo of 0x31. Round-7's first-byte gate is
+// foreign initiator-class echo of 0x31. Round-7's first-byte gate is
 // false at this position → the generic value-mismatch branch fires
 // → BusEventEchoMismatch + "echo mismatch" error string.
 func TestFirstByteEchoMismatch_NonFirstByte_StaysEchoMismatch(t *testing.T) {
@@ -179,7 +179,7 @@ func TestFirstByteEchoMismatch_NonFirstByte_StaysEchoMismatch(t *testing.T) {
 	}
 
 	// Echo queue: first byte (DST) echoes cleanly; second byte (PB) gets
-	// a foreign master-class echo of 0x31. isFirstByteAfterArbitration
+	// a foreign initiator-class echo of 0x31. isFirstByteAfterArbitration
 	// is FALSE at the PB position → new branch does NOT fire → generic
 	// "echo mismatch" path fires.
 	tr.mu.Lock()
@@ -218,7 +218,7 @@ func TestFirstByteEchoMismatch_NonFirstByte_StaysEchoMismatch(t *testing.T) {
 
 // TestFirstByteEchoMismatch_NonMaster_StaysEchoMismatch is the
 // guard-layer test for the AddressClassMaster gate (Codex r2 minor
-// test gap): a first-byte echo that is NOT a master-class byte is
+// test gap): a first-byte echo that is NOT a initiator-class byte is
 // NOT an arbitration-loss observation — it is wire corruption or a
 // bit-flip — and MUST still route through the generic
 // BusEventEchoMismatch / "echo mismatch" path.
@@ -232,10 +232,10 @@ func TestFirstByteEchoMismatch_NonFirstByte_StaysEchoMismatch(t *testing.T) {
 func TestFirstByteEchoMismatch_NonMaster_StaysEchoMismatch(t *testing.T) {
 	t.Parallel()
 
-	// Sanity: 0x55 must NOT be master-class for this test to mean
+	// Sanity: 0x55 must NOT be initiator-class for this test to mean
 	// what its name says.
 	if protocol.AddressClassOf(0x55) == protocol.AddressClassMaster {
-		t.Fatalf("test premise broken: AddressClassOf(0x55) = AddressClassMaster; pick a non-master sentinel")
+		t.Fatalf("test premise broken: AddressClassOf(0x55) = AddressClassMaster; pick a non-initiator sentinel")
 	}
 
 	tr := &echoF23TestTransport{unescaped: true}
@@ -266,7 +266,7 @@ func TestFirstByteEchoMismatch_NonMaster_StaysEchoMismatch(t *testing.T) {
 	}
 
 	// Echo queue: the FIRST echo (for DST=0x08) is 0x55 — a
-	// non-master-class byte. New branch is gated on
+	// non-initiator-class byte. New branch is gated on
 	// AddressClassMaster; not satisfied → falls through to generic.
 	tr.mu.Lock()
 	tr.echo = []echoF23Event{
@@ -282,10 +282,10 @@ func TestFirstByteEchoMismatch_NonMaster_StaysEchoMismatch(t *testing.T) {
 		t.Fatalf("Send err = %v; want wrapped ErrBusCollision", err)
 	}
 	if !strings.Contains(err.Error(), "echo mismatch") {
-		t.Errorf("err = %q; non-master first-byte mismatch must keep \"echo mismatch\" substring (routes to BusOutcomeEchoMismatch)", err.Error())
+		t.Errorf("err = %q; non-initiator first-byte mismatch must keep \"echo mismatch\" substring (routes to BusOutcomeEchoMismatch)", err.Error())
 	}
 	if strings.Contains(err.Error(), "first-byte arbitration loss") {
-		t.Errorf("err = %q; non-master first-byte mismatch MUST NOT use first-byte arbitration loss message", err.Error())
+		t.Errorf("err = %q; non-initiator first-byte mismatch MUST NOT use first-byte arbitration loss message", err.Error())
 	}
 
 	obsMu.Lock()
@@ -297,20 +297,20 @@ func TestFirstByteEchoMismatch_NonMaster_StaysEchoMismatch(t *testing.T) {
 		}
 	}
 	if !sawEchoMismatch {
-		t.Errorf("no BusEventEchoMismatch observed for non-master first-byte mismatch; events seen: %d", len(observed))
+		t.Errorf("no BusEventEchoMismatch observed for non-initiator first-byte mismatch; events seen: %d", len(observed))
 	}
 }
 
 // TestFirstByteEchoMismatch_WasEscaped_StaysEchoMismatch is the
 // guard-layer test for the !echoWasEscaped gate (Codex r2 minor
-// test gap): even when the first-byte echo is a master-class byte
+// test gap): even when the first-byte echo is a initiator-class byte
 // that does NOT match what we wrote, if it arrived via the
 // escape-decoded path (WasEscaped=true), it cannot be a
 // wire-level arbitration-loss signal — it is an escape-stream
 // payload byte from an unrelated frame, NOT another initiator's SOF.
 //
 // Setup: DST=0x08 is the first byte after arbitration; the mock
-// returns echo 0x10 (a master-class byte, P1 ID 0x10 per
+// returns echo 0x10 (a initiator-class byte, P1 ID 0x10 per
 // sourceAddressTableV1) WITH WasEscaped=true. The round-7 gate
 // `!echoWasEscaped` is FALSE → new branch does NOT fire → falls
 // through to the generic value-mismatch branch (echoes 0x10 vs raw
@@ -318,11 +318,11 @@ func TestFirstByteEchoMismatch_NonMaster_StaysEchoMismatch(t *testing.T) {
 func TestFirstByteEchoMismatch_WasEscaped_StaysEchoMismatch(t *testing.T) {
 	t.Parallel()
 
-	// Sanity: 0x10 must be master-class for this test to exercise the
-	// !echoWasEscaped gate (otherwise the AddressClassMaster gate
+	// Sanity: 0x10 must be initiator-class for this test to exercise
+	// the !echoWasEscaped gate (otherwise the AddressClassMaster gate
 	// would already exclude it and we'd be testing the wrong axis).
 	if protocol.AddressClassOf(0x10) != protocol.AddressClassMaster {
-		t.Fatalf("test premise broken: AddressClassOf(0x10) ≠ AddressClassMaster; pick a master sentinel")
+		t.Fatalf("test premise broken: AddressClassOf(0x10) ≠ AddressClassMaster; pick an initiator-class sentinel")
 	}
 
 	tr := &echoF23TestTransport{unescaped: true}
@@ -353,7 +353,7 @@ func TestFirstByteEchoMismatch_WasEscaped_StaysEchoMismatch(t *testing.T) {
 	}
 
 	// Echo queue: the FIRST echo (for DST=0x08) is 0x10 with
-	// WasEscaped=true. Master-class byte (passes AddressClassMaster
+	// WasEscaped=true. Initiator-class byte (passes AddressClassMaster
 	// gate) but WasEscaped=true defeats the !echoWasEscaped gate →
 	// falls through to generic value-mismatch branch.
 	tr.mu.Lock()
@@ -378,16 +378,28 @@ func TestFirstByteEchoMismatch_WasEscaped_StaysEchoMismatch(t *testing.T) {
 
 	obsMu.Lock()
 	defer obsMu.Unlock()
+	// Note: bus.go fires TWO BusEventEchoMismatch for a value-mismatch path:
+	// (1) the direct emit at the value-mismatch site with EchoWasEscaped
+	//     forwarded from the actual echo, and
+	// (2) the centralized emit in emitOutcomeEvent's BusOutcomeEchoMismatch
+	//     case (zero-valued Byte / EchoWasEscaped — known artifact, tracked
+	//     as a future cleanup; see batch-23 round-4 Codex review).
+	// The test asserts AT LEAST ONE event carries the provenance flag set;
+	// the centralized zero-valued emit is the artifact we tolerate.
 	var sawEchoMismatch bool
+	var sawProvenance bool
 	for _, ev := range observed {
 		if ev.Kind == protocol.BusEventEchoMismatch {
 			sawEchoMismatch = true
-			if !ev.EchoWasEscaped {
-				t.Errorf("BusEventEchoMismatch EchoWasEscaped = false, want true (provenance forwarded from the escape-decoded echo)")
+			if ev.EchoWasEscaped {
+				sawProvenance = true
 			}
 		}
 	}
 	if !sawEchoMismatch {
 		t.Errorf("no BusEventEchoMismatch observed for escape-decoded first-byte mismatch; events seen: %d", len(observed))
+	}
+	if !sawProvenance {
+		t.Errorf("no BusEventEchoMismatch with EchoWasEscaped=true observed; the direct value-mismatch emit must forward the escape-decoded provenance")
 	}
 }

--- a/protocol/observer.go
+++ b/protocol/observer.go
@@ -25,19 +25,6 @@ const (
 	BusEventRequestComplete
 	BusEventObserverFault
 	BusEventAdapterReset
-	// BusEventCollision is emitted when bus.Send observes evidence of an
-	// arbitration-class loss DURING a send sequence — i.e. distinct from
-	// the BusEventArbitration emitted at StartArbitration time. The
-	// canonical case is first-byte-after-arbitration foreign-initiator
-	// echo (round-7 / batch-26): we wrote raw=X expecting echo=X, but
-	// the wire echoed a master-class byte (per AddressClassMaster) that
-	// is not X. Pre-round-7 this fired BusEventEchoMismatch and was
-	// routed by the gateway P10 classifier to the echo_mismatch bucket;
-	// post-round-7 it routes through BusOutcomeCollision so retry
-	// behavior (which only fires on Is(ErrBusCollision) WITHOUT the
-	// "echo mismatch" substring) classifies arbitration losses
-	// distinctly from genuine echo mismatches.
-	BusEventCollision
 )
 
 // BusOutcomeClass is the bounded transaction outcome vocabulary exposed to

--- a/protocol/observer.go
+++ b/protocol/observer.go
@@ -25,6 +25,19 @@ const (
 	BusEventRequestComplete
 	BusEventObserverFault
 	BusEventAdapterReset
+	// BusEventCollision is emitted when bus.Send observes evidence of an
+	// arbitration-class loss DURING a send sequence — i.e. distinct from
+	// the BusEventArbitration emitted at StartArbitration time. The
+	// canonical case is first-byte-after-arbitration foreign-initiator
+	// echo (round-7 / batch-26): we wrote raw=X expecting echo=X, but
+	// the wire echoed a master-class byte (per AddressClassMaster) that
+	// is not X. Pre-round-7 this fired BusEventEchoMismatch and was
+	// routed by the gateway P10 classifier to the echo_mismatch bucket;
+	// post-round-7 it routes through BusOutcomeCollision so retry
+	// behavior (which only fires on Is(ErrBusCollision) WITHOUT the
+	// "echo mismatch" substring) classifies arbitration losses
+	// distinctly from genuine echo mismatches.
+	BusEventCollision
 )
 
 // BusOutcomeClass is the bounded transaction outcome vocabulary exposed to


### PR DESCRIPTION
## Summary

Round-7 of the echo_mismatch investigation. Pairs with helianthus-ebusgateway PR (to be opened).

The 4.76% per-frame echo_mismatch ratio on the live HA bus has a small but distinct contributor: first-byte after arbitration where the wire echo is a foreign initiator-class byte (not 0x71 gateway). This is **arbitration loss masquerading as echo_mismatch** — semantically a collision, not an echo problem.

## What changes

\`sendInitiatorTelegram → sendSymbolWithEcho → sendRawWithEcho\` now plumb \`isFirstByteAfterArbitration bool\`. When set AND \`!echoWasEscaped && AddressClassOf(echo) == AddressClassMaster && raw != echo\`, the function returns an error wrapping \`ErrBusCollision\` (NOT a generic echo_mismatch).

Downstream effect: counter routing flows naturally via \`busOutcomeFromError\` → \`BusOutcomeCollision\` → \`BusEventRetry\` → \`ebus_errors_total{class=\"collision\",scope=\"active\"}\` increments. The \`sendWithRetries\` loop already retries on \`ErrBusCollision\`. NO new event Kind needed (BusEventCollision was considered then dropped per Codex review).

## Constraints honored

- ONE PR per repo (operator directive after batch-24 multi-PR mess).
- No version bump.
- No new event-kind that downstream consumers would need to learn.

## Live evidence motivation

Pre-batch-25 baseline measured 4.76% per-active-frame echo_mismatch on the live HA test bus. Of those, an unmeasured but observable subset are arbitration losses (gateway thought it won, wire shows a foreign initiator's frame). This change re-routes those events from \`echo_mismatch\` to \`collision\` for accurate forensics.

The DOMINANT contributor (Attack 3 inter-write empty-queue leak) is closed by the paired helianthus-ebusgateway round-7 PR.

## Test plan

- [x] 4 unit tests pass (positive collision, non-first-byte negative, non-master negative, WasEscaped negative)
- [ ] CI green
- [ ] Live HA: after pair-PR deploy, per-frame ratio drops AND \`ebus_errors_total{class=\"collision\"}\` increments visibly

## Pairs with

helianthus-ebusgateway PR (Attack 3 closure via \`queueJustDrained\` sentinel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)