### PR TITLE
fix(protocol): absorb wire AUTO-SYN during payload-0xAA write per ENS-transmit-token invariant (round 9)

### DIFF
--- a/protocol/bus.go
+++ b/protocol/bus.go
@@ -112,6 +112,24 @@ type Bus struct {
 
 	outCap             int
 	unescapedTransport bool // true when transport delivers pre-unescaped bytes (ENH)
+
+	// batch-26 round-9 (2026-05-18): bounded-absorption counters for the
+	// payload-0xAA echo path. When the gateway writes a payload byte
+	// equal to SymbolSyn (0xAA, wire-escaped as `A9 01`) and a real wire
+	// SYN arrives at the echo position with WasEscaped=false, the wire
+	// SYN is bus-idle interference that fired BEFORE the adapter's
+	// buffered escape pair reached the wire (TCP latency between
+	// gateway→adapter→wire). Per the user's ENS-transmit-token invariant,
+	// while the gateway holds the transmit token, AUTO-SYNs from the wire
+	// must be DROPPED rather than propagated as echo failures. The fix
+	// absorbs up to maxPayloadAaAutoSynDrains intervening wire SYNs and
+	// retries the echo read; if the real escape-decoded payload echo
+	// arrives within the cap, the transaction succeeds normally with no
+	// error. These three counters surface drain frequency, recovery
+	// success, and cap-exhaustion for downstream observability.
+	payloadAaAutoSynAbsorbed       atomic.Uint64
+	payloadAaAutoSynRecovered      atomic.Uint64
+	payloadAaAutoSynDrainExhausted atomic.Uint64
 }
 
 // NewBus initializes a Bus with transport, config, and optional queue capacity.
@@ -1110,10 +1128,86 @@ func (b *Bus) sendRawWithEcho(runCtx, reqCtx context.Context, raw byte, expectRa
 	// initiator's structural marker). Pre-F-23 the wire bytes for
 	// our payload would have been `A9, 01` (first one ≠ 0xAA so
 	// the bare-value match would fail). Post-F-23 our payload
-	// echo is logical 0xAA with WasEscaped=true; we must reject
-	// any 0xAA with WasEscaped=false as a real wire SYN intrusion
-	// that we accidentally let through the value check below.
+	// echo is logical 0xAA with WasEscaped=true.
+	//
+	// batch-26 round-9 (2026-05-18, user architectural insight):
+	// the gateway holds the ENS transmit token while sendRawWithEcho
+	// is active. A wire SYN echo arriving with WasEscaped=false on a
+	// payload-0xAA write means an AUTO-SYN fired on the bus (the
+	// adapter buffers the full escape pair before writing it to wire
+	// due to TCP latency between gateway→adapter→wire — the AUTO-SYN
+	// we see is bus-idle interference BEFORE our `A9 01` pair reaches
+	// the wire). The REAL echo (0xAA wasEscaped=true) follows
+	// immediately.
+	//
+	// Per the invariant: while holding the transmit token, AUTO-SYNs
+	// must be dropped, not propagated as failures. Absorb the wire-SYN
+	// and re-read the next byte; if it matches our expected escape-
+	// decoded echo, the transaction succeeds normally with no
+	// observable error and no retry. The drain is bounded at
+	// maxPayloadAaAutoSynDrains (3 — typical AUTO-SYN bursts are 1-2
+	// bytes; cap prevents unbounded blocking on a hung adapter). If the
+	// drained byte is a non-SYN value, the next-byte echo is treated as
+	// the real (mismatched) echo and falls through to the existing
+	// emit + ErrBusCollision return; if the cap is reached without
+	// recovery, the original payload-0xAA echo_mismatch fires.
+	//
+	// Round-8 forensic data (100% of residual pre_echo_syn_raw events
+	// fire here, all mid-frame, never at the line-1066 plain/F-23
+	// SYN-intrusion guard) drove this scoping: the absorb is applied
+	// only at this site. The sibling guard at ~1066 (non-payload-0xAA
+	// path) is not modified — round-8 measurements showed it has zero
+	// production fires, and absorbing wire SYNs there would mask
+	// legitimate arbitration collisions where we wrote a non-SYN and
+	// the bus is idle (a real defect, not buffering interference).
 	if flagged != nil && !expectRawSyn && raw == SymbolSyn && echo == SymbolSyn && !echoWasEscaped {
+		const maxPayloadAaAutoSynDrains = 3
+		absorbed := 0
+		drainExhausted := true // assume cap-exhausted; flipped to false on any non-SYN break
+		for absorbed < maxPayloadAaAutoSynDrains {
+			nextEcho, nextWasEscaped, drainErr := b.readByteWithEscape(runCtx, reqCtx, flagged)
+			if drainErr != nil {
+				// Read error during drain (timeout, transport close,
+				// ctx cancel): propagate AS-IS without classifying as
+				// echo mismatch — it is a transport-layer fault, not
+				// an echo discrepancy.
+				b.emitOutcomeEvent(Frame{}, FrameTypeUnknown, 0, drainErr)
+				return drainErr
+			}
+			absorbed++
+			b.payloadAaAutoSynAbsorbed.Add(1)
+			if nextEcho == SymbolSyn && nextWasEscaped {
+				// The real escape-decoded payload echo arrived — the
+				// preceding wire SYN(s) were AUTO-SYN buffering
+				// interference. Transaction succeeds normally with no
+				// error emitted and no retry triggered.
+				b.payloadAaAutoSynRecovered.Add(1)
+				return nil
+			}
+			if nextEcho == SymbolSyn && !nextWasEscaped {
+				// Another AUTO-SYN: continue draining within the cap.
+				continue
+			}
+			// Non-SYN drained byte: this is a real echo mismatch (e.g.
+			// adapter corruption or a missed arbitration race). Update
+			// `echo` and `echoWasEscaped` so the downstream emit reflects
+			// what we actually observed; the exhaustion counter MUST NOT
+			// increment for this path (we exited on a real mismatch, not
+			// on running out of cap), so flip drainExhausted to false.
+			echo = nextEcho
+			echoWasEscaped = nextWasEscaped
+			drainExhausted = false
+			break
+		}
+		if drainExhausted {
+			// All `absorbed` iterations were wire-SYN continues and the
+			// loop bound was reached without finding the real echo —
+			// surface the exhaustion counter, then fall through to emit
+			// the payload-0xAA echo_mismatch as before. This preserves
+			// the pre-round-9 collision-error invariant for adapter-
+			// genuinely-stuck cases.
+			b.payloadAaAutoSynDrainExhausted.Add(1)
+		}
 		b.emitObserverEvent(BusEvent{
 			Kind:           BusEventEchoMismatch,
 			Outcome:        BusOutcomeEchoMismatch,
@@ -1320,6 +1414,36 @@ func (b *Bus) ObserverFaultSnapshot() ObserverFaultSnapshot {
 	b.observerFaultMu.Lock()
 	defer b.observerFaultMu.Unlock()
 	return b.observerFault
+}
+
+// PayloadAaAutoSynAbsorbed returns the cumulative count of wire SYN bytes
+// absorbed by the round-9 AUTO-SYN drain at the payload-0xAA echo site in
+// sendRawWithEcho. Each increment represents one ReadByteWithEscape call
+// whose result was an unexpected wire SYN (WasEscaped=false) and was
+// dropped per the ENS-transmit-token invariant. Surface as a Prometheus
+// gauge/counter for observability.
+func (b *Bus) PayloadAaAutoSynAbsorbed() uint64 {
+	return b.payloadAaAutoSynAbsorbed.Load()
+}
+
+// PayloadAaAutoSynRecovered returns the cumulative count of transactions
+// rescued by the round-9 AUTO-SYN drain — i.e. cases where the absorb
+// loop found the real escape-decoded payload echo within the cap and the
+// transaction succeeded without emitting an echo_mismatch or returning
+// ErrBusCollision. The ratio Recovered / (Absorbed events) approximates
+// the round-9 retry-rate reduction.
+func (b *Bus) PayloadAaAutoSynRecovered() uint64 {
+	return b.payloadAaAutoSynRecovered.Load()
+}
+
+// PayloadAaAutoSynDrainExhausted returns the cumulative count of
+// transactions where the round-9 absorb loop reached
+// maxPayloadAaAutoSynDrains intervening wire SYNs without finding the
+// real payload echo. These fall through to the original payload-0xAA
+// echo_mismatch + ErrBusCollision retry path, preserving the pre-round-9
+// behavior for adapter-genuinely-stuck cases.
+func (b *Bus) PayloadAaAutoSynDrainExhausted() uint64 {
+	return b.payloadAaAutoSynDrainExhausted.Load()
 }
 
 func (b *Bus) emitAttemptComplete(request Frame, response *Frame, frameType FrameType, attempt uint16, startedAt time.Time) {

--- a/protocol/bus.go
+++ b/protocol/bus.go
@@ -1202,21 +1202,33 @@ func (b *Bus) sendRawWithEcho(runCtx, reqCtx context.Context, raw byte, expectRa
 		if drainExhausted {
 			// All `absorbed` iterations were wire-SYN continues and the
 			// loop bound was reached without finding the real echo —
-			// surface the exhaustion counter, then fall through to emit
-			// the payload-0xAA echo_mismatch as before. This preserves
-			// the pre-round-9 collision-error invariant for adapter-
-			// genuinely-stuck cases.
+			// surface the exhaustion counter, then emit the payload-
+			// 0xAA "received real wire SYN" error which routes through
+			// BusOutcomeCollision (preserves the pre-round-9
+			// adapter-genuinely-stuck classification).
 			b.payloadAaAutoSynDrainExhausted.Add(1)
+			b.emitObserverEvent(BusEvent{
+				Kind:           BusEventEchoMismatch,
+				Outcome:        BusOutcomeEchoMismatch,
+				Byte:           echo,
+				EchoWasEscaped: echoWasEscaped,
+			})
+			err := fmt.Errorf("echo for payload 0xAA expected escape-decoded WasEscaped=true but received real wire SYN: %w", ebuserrors.ErrBusCollision)
+			b.emitOutcomeEvent(Frame{}, FrameTypeUnknown, 0, err)
+			return err
 		}
-		b.emitObserverEvent(BusEvent{
-			Kind:           BusEventEchoMismatch,
-			Outcome:        BusOutcomeEchoMismatch,
-			Byte:           echo,
-			EchoWasEscaped: echoWasEscaped, // 2026-05-17 batch-23: split P10 pre_echo_syn (escape-decoded data byte vs raw SYN)
-		})
-		err := fmt.Errorf("echo for payload 0xAA expected escape-decoded WasEscaped=true but received real wire SYN: %w", ebuserrors.ErrBusCollision)
-		b.emitOutcomeEvent(Frame{}, FrameTypeUnknown, 0, err)
-		return err
+		// Non-SYN drained byte path (drainExhausted=false): `echo` and
+		// `echoWasEscaped` were updated above to reflect the drained
+		// byte. FALL THROUGH past the payload-0xAA-specific guard so
+		// the generic `if echo != raw` value-mismatch branch below
+		// fires with the actual drained byte — its error message
+		// contains "echo mismatch" which routes to
+		// BusOutcomeEchoMismatch via busOutcomeFromError, matching
+		// the user invariant that "non-SYN drained byte routes to
+		// generic value-mismatch". (Codex r6 P1, batch-26 round-9:
+		// prior version of this guard returned the "received real
+		// wire SYN" error even on the non-SYN-drain break path,
+		// misclassifying as Collision.)
 	}
 	if echo != raw {
 		// batch-26 round-7 — first-byte-after-arbitration foreign-

--- a/protocol/bus_echo_f23_test.go
+++ b/protocol/bus_echo_f23_test.go
@@ -312,18 +312,21 @@ func TestBus_EscapeAware_PayloadAAEcho_WithWasEscapedAccepted(t *testing.T) {
 }
 
 // TestBus_EscapeAware_PayloadAAEcho_RealWireSynIsCollision pins the
-// Codex bot r4 finding on PR #154: symmetric to the round-3
-// PayloadAAEcho_WithWasEscapedAccepted test. We write a TELEGRAM
-// PAYLOAD byte equal to 0xAA (expectRawSyn=false). The legitimate
-// echo would arrive WasEscaped=true (adapter wire-escaped). Instead,
-// a real wire SYN (WasEscaped=false) arrives first — this is an
-// unrelated bus event, NOT our payload echo, and MUST be rejected
-// as ErrBusCollision.
+// Codex bot r4 finding on PR #154 (original intent): a real wire SYN
+// arriving where the escape-decoded payload-0xAA echo was expected
+// MUST be rejected as ErrBusCollision so the bus is not silently
+// false-accepted.
 //
-// Pre-r4 fix, all four existing guards skipped: the ENH SYN-intrusion
-// guard requires raw != SymbolSyn; the structural-SYN rejection
-// requires expectRawSyn=true; the value-mismatch check has echo ==
-// raw == 0xAA. Result: false accept. The new guard plugs that hole.
+// batch-26 round-9 update (2026-05-18): per the ENS-transmit-token
+// invariant, ONE intervening wire SYN is now absorbed by the bounded
+// drain in sendRawWithEcho — it is bus-idle interference from the
+// adapter's TCP buffering, not our payload echo. The "real-wire-SYN
+// means collision" contract is now expressed as: when the drain cap is
+// reached (≥maxPayloadAaAutoSynDrains=3 consecutive wire SYNs with no
+// real escape-decoded echo following), the original ErrBusCollision +
+// echo_mismatch path fires. This test pins the cap-exhausted boundary
+// at 4 wire SYNs — one more than the cap — which exercises the
+// PayloadAaAutoSynDrainExhausted counter increment.
 func TestBus_EscapeAware_PayloadAAEcho_RealWireSynIsCollision(t *testing.T) {
 	t.Parallel()
 
@@ -350,20 +353,22 @@ func TestBus_EscapeAware_PayloadAAEcho_RealWireSynIsCollision(t *testing.T) {
 
 	tr.mu.Lock()
 	tr.echo = nil
-	// First four bytes echo normally (DST PB SB LEN). The fifth
-	// echo (DATA[0]=0xAA) is poisoned: a real wire SYN arrives
-	// where the escape-decoded payload echo should have been. Bus
-	// must reject as collision before reaching the value check.
-	for i, b := range telegram[:4] {
-		_ = i
+	// First four bytes echo normally (DST PB SB LEN). The fifth echo
+	// position (DATA[0]=0xAA) and three more are all real wire SYNs:
+	// the round-9 drain absorbs the first three, hits the cap, and
+	// falls through to the original ErrBusCollision emit using the
+	// fourth SYN's byte/escape provenance.
+	for _, b := range telegram[:4] {
 		tr.echo = append(tr.echo, echoF23Event{value: b, wasEscaped: false})
 	}
-	tr.echo = append(tr.echo, echoF23Event{value: protocol.SymbolSyn, wasEscaped: false})
+	for i := 0; i < 4; i++ {
+		tr.echo = append(tr.echo, echoF23Event{value: protocol.SymbolSyn, wasEscaped: false})
+	}
 	tr.mu.Unlock()
 
 	_, err := bus.Send(ctx, frame)
 	if err == nil {
-		t.Fatalf("Send err = nil; want ErrBusCollision (real wire SYN where escape-decoded payload 0xAA was expected MUST be a collision)")
+		t.Fatalf("Send err = nil; want ErrBusCollision (drain cap exhausted on real wire SYN MUST be a collision)")
 	}
 	if !errors.Is(err, ebuserrors.ErrBusCollision) {
 		t.Fatalf("Send err = %v; want wrapped ErrBusCollision", err)
@@ -379,10 +384,11 @@ func TestBus_EscapeAware_PayloadAAEcho_RealWireSynIsCollision(t *testing.T) {
 // decoded-data subclasses.
 //
 // Scenario: we write a TELEGRAM PAYLOAD byte 0xAA (expectRawSyn=
-// false). Echo arrives as a REAL wire SYN (WasEscaped=false) —
-// this is the round-4 round-4 guard at bus.go ~1054, which emits
-// BusEventEchoMismatch with EchoWasEscaped=false (forwarded from
-// the echoWasEscaped local).
+// false). Echo position is poisoned by ≥4 real wire SYNs — the
+// round-9 drain (cap=3) absorbs the first three, hits exhaustion,
+// and emits BusEventEchoMismatch using the drained provenance
+// (Byte=0xAA, EchoWasEscaped=false). This pins both the round-4
+// emission shape AND the round-9 drain-exhausted boundary.
 func TestBus_EchoMismatchEvent_PropagatesEchoWasEscaped_False(t *testing.T) {
 	t.Parallel()
 
@@ -423,8 +429,11 @@ func TestBus_EchoMismatchEvent_PropagatesEchoWasEscaped_False(t *testing.T) {
 	for _, b := range telegram[:4] {
 		tr.echo = append(tr.echo, echoF23Event{value: b, wasEscaped: false})
 	}
-	// Payload 0xAA position poisoned by real wire SYN.
-	tr.echo = append(tr.echo, echoF23Event{value: protocol.SymbolSyn, wasEscaped: false})
+	// Payload 0xAA position poisoned by 4 real wire SYNs (cap+1):
+	// drain absorbs 3, then the 4th surfaces as the mismatch byte.
+	for i := 0; i < 4; i++ {
+		tr.echo = append(tr.echo, echoF23Event{value: protocol.SymbolSyn, wasEscaped: false})
+	}
 	tr.mu.Unlock()
 
 	_, err := bus.Send(ctx, frame)
@@ -441,9 +450,10 @@ func TestBus_EchoMismatchEvent_PropagatesEchoWasEscaped_False(t *testing.T) {
 		t.Fatal("no BusEventEchoMismatch observed")
 	}
 	// The FIRST echo-mismatch event is the per-byte emission from
-	// sendRawWithEcho's r4 guard. Subsequent ones may come from
-	// emitOutcomeEvent's centralized re-emit; we assert on the
-	// first one (the per-byte direct emission).
+	// sendRawWithEcho's r4 guard (now post-drain-exhausted).
+	// Subsequent ones may come from emitOutcomeEvent's centralized
+	// re-emit; we assert on the first one (the per-byte direct
+	// emission).
 	first := observed[0]
 	if first.Byte != protocol.SymbolSyn {
 		t.Fatalf("first event Byte = 0x%02X, want 0xAA", first.Byte)

--- a/protocol/bus_payload_aa_auto_syn_absorb_test.go
+++ b/protocol/bus_payload_aa_auto_syn_absorb_test.go
@@ -330,7 +330,7 @@ func TestPayloadAaAutoSynAbsorb_DrainHitsNonSynMismatch_RoutesToValueMismatch(t 
 		tr.echo = append(tr.echo, echoF23Event{value: b, wasEscaped: false})
 	}
 	// Byte 4 echo: AUTO-SYN absorbed, then drained byte is 0x55 (a
-	// non-SYN, non-master-class byte). break path runs; emit uses the
+	// non-SYN, non-initiator-class byte). break path runs; emit uses the
 	// drained byte's provenance.
 	tr.echo = append(tr.echo,
 		echoF23Event{value: protocol.SymbolSyn, wasEscaped: false},

--- a/protocol/bus_payload_aa_auto_syn_absorb_test.go
+++ b/protocol/bus_payload_aa_auto_syn_absorb_test.go
@@ -3,6 +3,7 @@ package protocol_test
 import (
 	"context"
 	"errors"
+	"strings"
 	"sync"
 	"testing"
 
@@ -343,6 +344,14 @@ func TestPayloadAaAutoSynAbsorb_DrainHitsNonSynMismatch_RoutesToValueMismatch(t 
 	}
 	if !errors.Is(err, ebuserrors.ErrBusCollision) {
 		t.Fatalf("Send err = %v; want wrapped ErrBusCollision", err)
+	}
+	// Codex r6 P1 (batch-26 round-9): non-SYN drain break must route
+	// to BusOutcomeEchoMismatch via busOutcomeFromError. The
+	// fall-through path lets the generic `if echo != raw` branch fire,
+	// whose error message contains "echo mismatch" and triggers the
+	// containsEchoMismatch substring check.
+	if !strings.Contains(err.Error(), "echo mismatch") {
+		t.Errorf("err = %q; want substring \"echo mismatch\" so busOutcomeFromError routes to BusOutcomeEchoMismatch (non-SYN drain break)", err.Error())
 	}
 
 	if got := bus.PayloadAaAutoSynAbsorbed(); got != 1 {

--- a/protocol/bus_payload_aa_auto_syn_absorb_test.go
+++ b/protocol/bus_payload_aa_auto_syn_absorb_test.go
@@ -1,0 +1,437 @@
+package protocol_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	ebuserrors "github.com/Project-Helianthus/helianthus-ebusgo/errors"
+	"github.com/Project-Helianthus/helianthus-ebusgo/protocol"
+)
+
+// batch-26 round-9 (2026-05-18) — bounded AUTO-SYN absorption at the
+// payload-0xAA echo site in sendRawWithEcho. The user's architectural
+// insight: while the gateway holds the ENS transmit token, AUTO-SYNs
+// on the wire are bus-idle interference from the adapter's TCP-buffered
+// write timing, NOT real echoes of our payload-0xAA write. The escape
+// pair `A9 01` lands on the wire AFTER the wire AUTO-SYN, so the first
+// byte the gateway reads is the AUTO-SYN; the real escape-decoded echo
+// (0xAA wasEscaped=true) follows immediately.
+//
+// Round-8 forensic measurement on live HA bus: 100% of residual
+// `pre_echo_syn_raw` events fire at the line-1116 guard in bus.go,
+// 100% are mid-frame, never at the first-byte-after-arbitration site.
+// The fix absorbs up to maxPayloadAaAutoSynDrains (3) intervening
+// wire SYNs and retries the echo read; success eliminates the
+// echo_mismatch + ErrBusCollision + retry round-trip.
+
+// TestPayloadAaAutoSynAbsorb_SingleAutoSynThenRealEcho pins the most
+// common production shape: ONE wire AUTO-SYN absorbed, the very next
+// byte is the real escape-decoded payload echo, transaction succeeds
+// with no error and no echo_mismatch event emitted.
+func TestPayloadAaAutoSynAbsorb_SingleAutoSynThenRealEcho(t *testing.T) {
+	t.Parallel()
+
+	tr := &echoF23TestTransport{unescaped: true}
+
+	var observed []protocol.BusEvent
+	var obsMu sync.Mutex
+	observer := protocol.BusObserverFunc(func(ev protocol.BusEvent) error {
+		obsMu.Lock()
+		defer obsMu.Unlock()
+		observed = append(observed, ev)
+		return nil
+	})
+
+	cfg := protocol.DefaultBusConfig()
+	cfg.Observer = observer
+	bus := protocol.NewBus(tr, cfg, 8)
+	runCtx, runCancel := context.WithCancel(context.Background())
+	defer runCancel()
+	bus.Run(runCtx)
+	ctx := context.Background()
+
+	// Broadcast frame with a PAYLOAD byte equal to SymbolSyn (0xAA).
+	// Wire transmission: DST PB SB LEN DATA[0]=0xAA CRC, then trailing
+	// end-of-message SYN. The DATA[0] echo position will be poisoned by
+	// a wire AUTO-SYN (wasEscaped=false), then the real escape-decoded
+	// payload echo (wasEscaped=true) follows.
+	frame := protocol.Frame{
+		Source:    0x10,
+		Target:    protocol.AddressBroadcast,
+		Primary:   0xB5,
+		Secondary: 0x16,
+		Data:      []byte{protocol.SymbolSyn},
+	}
+	telegram := []byte{
+		protocol.AddressBroadcast, 0xB5, 0x16, 0x01, protocol.SymbolSyn,
+	}
+	telegram = append(telegram, protocol.CRC(append([]byte{0x10}, telegram...)))
+
+	tr.mu.Lock()
+	tr.echo = nil
+	// Bytes 0..3 (DST PB SB LEN) — clean echoes.
+	for _, b := range telegram[:4] {
+		tr.echo = append(tr.echo, echoF23Event{value: b, wasEscaped: false})
+	}
+	// Byte 4 (DATA[0]=0xAA) echo SLOT — first byte read is the wire
+	// AUTO-SYN (wasEscaped=false), second byte is the real escape-
+	// decoded payload echo (wasEscaped=true). Round-9 absorbs the first
+	// and accepts the second as the legitimate echo.
+	tr.echo = append(tr.echo,
+		echoF23Event{value: protocol.SymbolSyn, wasEscaped: false},
+		echoF23Event{value: protocol.SymbolSyn, wasEscaped: true},
+	)
+	// Byte 5 (CRC) — clean echo.
+	tr.echo = append(tr.echo, echoF23Event{value: telegram[5], wasEscaped: false})
+	// End-of-message structural SYN — real wire SYN.
+	tr.echo = append(tr.echo, echoF23Event{value: protocol.SymbolSyn, wasEscaped: false})
+	tr.mu.Unlock()
+
+	_, err := bus.Send(ctx, frame)
+	if err != nil {
+		t.Fatalf("Send error = %v; want nil (single AUTO-SYN must be absorbed, real echo accepted)", err)
+	}
+
+	if got := bus.PayloadAaAutoSynAbsorbed(); got != 1 {
+		t.Errorf("PayloadAaAutoSynAbsorbed() = %d; want 1", got)
+	}
+	if got := bus.PayloadAaAutoSynRecovered(); got != 1 {
+		t.Errorf("PayloadAaAutoSynRecovered() = %d; want 1", got)
+	}
+	if got := bus.PayloadAaAutoSynDrainExhausted(); got != 0 {
+		t.Errorf("PayloadAaAutoSynDrainExhausted() = %d; want 0", got)
+	}
+
+	obsMu.Lock()
+	defer obsMu.Unlock()
+	for _, ev := range observed {
+		if ev.Kind == protocol.BusEventEchoMismatch {
+			t.Errorf("unexpected BusEventEchoMismatch — absorb path must NOT emit echo_mismatch on recovery: %+v", ev)
+		}
+	}
+}
+
+// TestPayloadAaAutoSynAbsorb_TwoAutoSynsThenRealEcho exercises the
+// drain loop with TWO intervening wire AUTO-SYNs before the real echo.
+// Verifies absorbed counter increments per drain (not per recovery) and
+// recovery still succeeds within the cap.
+func TestPayloadAaAutoSynAbsorb_TwoAutoSynsThenRealEcho(t *testing.T) {
+	t.Parallel()
+
+	tr := &echoF23TestTransport{unescaped: true}
+
+	var observed []protocol.BusEvent
+	var obsMu sync.Mutex
+	observer := protocol.BusObserverFunc(func(ev protocol.BusEvent) error {
+		obsMu.Lock()
+		defer obsMu.Unlock()
+		observed = append(observed, ev)
+		return nil
+	})
+
+	cfg := protocol.DefaultBusConfig()
+	cfg.Observer = observer
+	bus := protocol.NewBus(tr, cfg, 8)
+	runCtx, runCancel := context.WithCancel(context.Background())
+	defer runCancel()
+	bus.Run(runCtx)
+	ctx := context.Background()
+
+	frame := protocol.Frame{
+		Source:    0x10,
+		Target:    protocol.AddressBroadcast,
+		Primary:   0xB5,
+		Secondary: 0x16,
+		Data:      []byte{protocol.SymbolSyn},
+	}
+	telegram := []byte{
+		protocol.AddressBroadcast, 0xB5, 0x16, 0x01, protocol.SymbolSyn,
+	}
+	telegram = append(telegram, protocol.CRC(append([]byte{0x10}, telegram...)))
+
+	tr.mu.Lock()
+	tr.echo = nil
+	for _, b := range telegram[:4] {
+		tr.echo = append(tr.echo, echoF23Event{value: b, wasEscaped: false})
+	}
+	// Byte 4 echo slot: two wire AUTO-SYNs (wasEscaped=false), then real
+	// escape-decoded echo (wasEscaped=true).
+	tr.echo = append(tr.echo,
+		echoF23Event{value: protocol.SymbolSyn, wasEscaped: false},
+		echoF23Event{value: protocol.SymbolSyn, wasEscaped: false},
+		echoF23Event{value: protocol.SymbolSyn, wasEscaped: true},
+	)
+	tr.echo = append(tr.echo, echoF23Event{value: telegram[5], wasEscaped: false})
+	tr.echo = append(tr.echo, echoF23Event{value: protocol.SymbolSyn, wasEscaped: false})
+	tr.mu.Unlock()
+
+	_, err := bus.Send(ctx, frame)
+	if err != nil {
+		t.Fatalf("Send error = %v; want nil (two AUTO-SYNs within cap MUST be absorbed)", err)
+	}
+
+	if got := bus.PayloadAaAutoSynAbsorbed(); got != 2 {
+		t.Errorf("PayloadAaAutoSynAbsorbed() = %d; want 2", got)
+	}
+	if got := bus.PayloadAaAutoSynRecovered(); got != 1 {
+		t.Errorf("PayloadAaAutoSynRecovered() = %d; want 1", got)
+	}
+	if got := bus.PayloadAaAutoSynDrainExhausted(); got != 0 {
+		t.Errorf("PayloadAaAutoSynDrainExhausted() = %d; want 0", got)
+	}
+
+	obsMu.Lock()
+	defer obsMu.Unlock()
+	for _, ev := range observed {
+		if ev.Kind == protocol.BusEventEchoMismatch {
+			t.Errorf("unexpected BusEventEchoMismatch — absorb path must NOT emit on recovery: %+v", ev)
+		}
+	}
+}
+
+// TestPayloadAaAutoSynAbsorb_DrainCapExhausted_StillEchoMismatch pins
+// the safety boundary: when the drain cap (3) is reached without
+// finding the real echo, the original payload-0xAA echo_mismatch path
+// fires (ErrBusCollision returned, BusEventEchoMismatch emitted,
+// PayloadAaAutoSynDrainExhausted increments).
+func TestPayloadAaAutoSynAbsorb_DrainCapExhausted_StillEchoMismatch(t *testing.T) {
+	t.Parallel()
+
+	tr := &echoF23TestTransport{unescaped: true}
+
+	var observed []protocol.BusEvent
+	var obsMu sync.Mutex
+	observer := protocol.BusObserverFunc(func(ev protocol.BusEvent) error {
+		obsMu.Lock()
+		defer obsMu.Unlock()
+		observed = append(observed, ev)
+		return nil
+	})
+
+	cfg := protocol.DefaultBusConfig()
+	cfg.Observer = observer
+	bus := protocol.NewBus(tr, cfg, 8)
+	runCtx, runCancel := context.WithCancel(context.Background())
+	defer runCancel()
+	bus.Run(runCtx)
+	ctx := context.Background()
+
+	frame := protocol.Frame{
+		Source:    0x10,
+		Target:    protocol.AddressBroadcast,
+		Primary:   0xB5,
+		Secondary: 0x16,
+		Data:      []byte{protocol.SymbolSyn},
+	}
+	telegram := []byte{
+		protocol.AddressBroadcast, 0xB5, 0x16, 0x01, protocol.SymbolSyn,
+	}
+	telegram = append(telegram, protocol.CRC(append([]byte{0x10}, telegram...)))
+
+	tr.mu.Lock()
+	tr.echo = nil
+	for _, b := range telegram[:4] {
+		tr.echo = append(tr.echo, echoF23Event{value: b, wasEscaped: false})
+	}
+	// Byte 4 echo slot poisoned with 4 wire AUTO-SYNs in a row (cap+1):
+	// the first absorbs into the initial echo, three more are drained,
+	// the third drain reaches the cap → fall through to echo_mismatch
+	// with the third drained byte's provenance (wire SYN, !wasEscaped).
+	for i := 0; i < 4; i++ {
+		tr.echo = append(tr.echo, echoF23Event{value: protocol.SymbolSyn, wasEscaped: false})
+	}
+	tr.mu.Unlock()
+
+	_, err := bus.Send(ctx, frame)
+	if err == nil {
+		t.Fatal("Send err = nil; want ErrBusCollision (cap exhausted)")
+	}
+	if !errors.Is(err, ebuserrors.ErrBusCollision) {
+		t.Fatalf("Send err = %v; want wrapped ErrBusCollision", err)
+	}
+
+	if got := bus.PayloadAaAutoSynAbsorbed(); got != 3 {
+		t.Errorf("PayloadAaAutoSynAbsorbed() = %d; want 3 (cap)", got)
+	}
+	if got := bus.PayloadAaAutoSynRecovered(); got != 0 {
+		t.Errorf("PayloadAaAutoSynRecovered() = %d; want 0 (no recovery)", got)
+	}
+	if got := bus.PayloadAaAutoSynDrainExhausted(); got != 1 {
+		t.Errorf("PayloadAaAutoSynDrainExhausted() = %d; want 1", got)
+	}
+
+	obsMu.Lock()
+	defer obsMu.Unlock()
+	var sawEchoMismatch bool
+	for _, ev := range observed {
+		if ev.Kind == protocol.BusEventEchoMismatch {
+			sawEchoMismatch = true
+			// The emitted event provenance must be the drained byte
+			// (wire SYN, wasEscaped=false) NOT the original echo.
+			if ev.Byte != protocol.SymbolSyn {
+				t.Errorf("emit Byte = 0x%02X; want 0xAA (drained wire SYN)", ev.Byte)
+			}
+			if ev.EchoWasEscaped {
+				t.Errorf("emit EchoWasEscaped = true; want false (drained wire SYN has wasEscaped=false)")
+			}
+			break
+		}
+	}
+	if !sawEchoMismatch {
+		t.Error("no BusEventEchoMismatch emitted on drain exhaustion; want emit (caller observability)")
+	}
+}
+
+// TestPayloadAaAutoSynAbsorb_DrainHitsNonSynMismatch_RoutesToValueMismatch
+// pins the inner-loop break path: when a drained byte is NOT a wire SYN,
+// it is treated as the (mismatched) real echo and falls through to the
+// emit + ErrBusCollision return, with the BusEventEchoMismatch carrying
+// the DRAINED byte's value/provenance (not the original 0xAA).
+func TestPayloadAaAutoSynAbsorb_DrainHitsNonSynMismatch_RoutesToValueMismatch(t *testing.T) {
+	t.Parallel()
+
+	tr := &echoF23TestTransport{unescaped: true}
+
+	var observed []protocol.BusEvent
+	var obsMu sync.Mutex
+	observer := protocol.BusObserverFunc(func(ev protocol.BusEvent) error {
+		obsMu.Lock()
+		defer obsMu.Unlock()
+		observed = append(observed, ev)
+		return nil
+	})
+
+	cfg := protocol.DefaultBusConfig()
+	cfg.Observer = observer
+	bus := protocol.NewBus(tr, cfg, 8)
+	runCtx, runCancel := context.WithCancel(context.Background())
+	defer runCancel()
+	bus.Run(runCtx)
+	ctx := context.Background()
+
+	frame := protocol.Frame{
+		Source:    0x10,
+		Target:    protocol.AddressBroadcast,
+		Primary:   0xB5,
+		Secondary: 0x16,
+		Data:      []byte{protocol.SymbolSyn},
+	}
+	telegram := []byte{
+		protocol.AddressBroadcast, 0xB5, 0x16, 0x01, protocol.SymbolSyn,
+	}
+	telegram = append(telegram, protocol.CRC(append([]byte{0x10}, telegram...)))
+
+	tr.mu.Lock()
+	tr.echo = nil
+	for _, b := range telegram[:4] {
+		tr.echo = append(tr.echo, echoF23Event{value: b, wasEscaped: false})
+	}
+	// Byte 4 echo: AUTO-SYN absorbed, then drained byte is 0x55 (a
+	// non-SYN, non-master-class byte). break path runs; emit uses the
+	// drained byte's provenance.
+	tr.echo = append(tr.echo,
+		echoF23Event{value: protocol.SymbolSyn, wasEscaped: false},
+		echoF23Event{value: 0x55, wasEscaped: false},
+	)
+	tr.mu.Unlock()
+
+	_, err := bus.Send(ctx, frame)
+	if err == nil {
+		t.Fatal("Send err = nil; want ErrBusCollision (non-SYN drained byte is a real mismatch)")
+	}
+	if !errors.Is(err, ebuserrors.ErrBusCollision) {
+		t.Fatalf("Send err = %v; want wrapped ErrBusCollision", err)
+	}
+
+	if got := bus.PayloadAaAutoSynAbsorbed(); got != 1 {
+		t.Errorf("PayloadAaAutoSynAbsorbed() = %d; want 1", got)
+	}
+	if got := bus.PayloadAaAutoSynRecovered(); got != 0 {
+		t.Errorf("PayloadAaAutoSynRecovered() = %d; want 0", got)
+	}
+	if got := bus.PayloadAaAutoSynDrainExhausted(); got != 0 {
+		t.Errorf("PayloadAaAutoSynDrainExhausted() = %d; want 0 (break path, not cap)", got)
+	}
+
+	obsMu.Lock()
+	defer obsMu.Unlock()
+	var sawEchoMismatch bool
+	for _, ev := range observed {
+		if ev.Kind == protocol.BusEventEchoMismatch {
+			sawEchoMismatch = true
+			// The emit MUST reflect the DRAINED byte (0x55), not the
+			// original 0xAA. This is load-bearing for downstream P10
+			// classification: the classifier sees the byte that
+			// actually mismatched, not the AUTO-SYN that we absorbed.
+			if ev.Byte != 0x55 {
+				t.Errorf("emit Byte = 0x%02X; want 0x55 (drained byte, NOT the absorbed AUTO-SYN)", ev.Byte)
+			}
+			if ev.EchoWasEscaped {
+				t.Errorf("emit EchoWasEscaped = true; want false (drained 0x55 has wasEscaped=false)")
+			}
+			break
+		}
+	}
+	if !sawEchoMismatch {
+		t.Error("no BusEventEchoMismatch emitted on non-SYN drain break; want emit")
+	}
+}
+
+// TestPayloadAaAutoSynAbsorb_NoEffect_OnNonPayloadAaPath is the negative
+// control: the round-9 absorb is gated on `!expectRawSyn && raw ==
+// SymbolSyn`. On a NON-payload-0xAA path (the line-1066 plain/F-23 SYN-
+// intrusion guard, where raw != SymbolSyn and echo == wire-SYN), the
+// drain MUST NOT run — payloadAaAutoSyn* counters stay zero.
+//
+// Setup: broadcast frame with NO payload 0xAA (Data=nil). First echo
+// (DST=0xFE) poisoned by real wire SYN. This hits the line-1066 guard,
+// not the line-1163 guard. Counters must remain zero.
+func TestPayloadAaAutoSynAbsorb_NoEffect_OnNonPayloadAaPath(t *testing.T) {
+	t.Parallel()
+
+	tr := &echoF23TestTransport{unescaped: true}
+
+	cfg := protocol.DefaultBusConfig()
+	bus := protocol.NewBus(tr, cfg, 8)
+	runCtx, runCancel := context.WithCancel(context.Background())
+	defer runCancel()
+	bus.Run(runCtx)
+	ctx := context.Background()
+
+	frame := protocol.Frame{
+		Source:    0x10,
+		Target:    protocol.AddressBroadcast,
+		Primary:   0xB5,
+		Secondary: 0x16,
+		Data:      nil, // no payload 0xAA — round-9 path inactive
+	}
+
+	tr.mu.Lock()
+	// First echo (DST=AddressBroadcast=0xFE expected): we get a real wire
+	// SYN instead → line-1066 guard fires, raw != SymbolSyn so round-9
+	// absorb is NOT entered.
+	tr.echo = []echoF23Event{
+		{value: protocol.SymbolSyn, wasEscaped: false},
+	}
+	tr.mu.Unlock()
+
+	_, err := bus.Send(ctx, frame)
+	if err == nil {
+		t.Fatal("Send err = nil; want ErrBusCollision (line-1066 SYN intrusion path)")
+	}
+	if !errors.Is(err, ebuserrors.ErrBusCollision) {
+		t.Fatalf("Send err = %v; want wrapped ErrBusCollision", err)
+	}
+
+	if got := bus.PayloadAaAutoSynAbsorbed(); got != 0 {
+		t.Errorf("PayloadAaAutoSynAbsorbed() = %d; want 0 (non-payload-0xAA path MUST NOT trigger absorb)", got)
+	}
+	if got := bus.PayloadAaAutoSynRecovered(); got != 0 {
+		t.Errorf("PayloadAaAutoSynRecovered() = %d; want 0", got)
+	}
+	if got := bus.PayloadAaAutoSynDrainExhausted(); got != 0 {
+		t.Errorf("PayloadAaAutoSynDrainExhausted() = %d; want 0", got)
+	}
+}


### PR DESCRIPTION
## Summary

Round 9 — **the actual root-cause fix** based on live forensic data + user's architectural invariant.

## Live forensic data (round-8 instrumentation, 55 min on HA bus)

- `r3NonSynRaw_observed` = 0 (Codex's first-byte hypothesis falsified)
- `r3PayloadAa_observed` = 275 (100% of leaks fire at line 1192)
- `r3PayloadAa_midFrame` = 275 (100% mid-frame, NOT first-byte)
- Rate: 5/min = exactly the ~5% per-active-frame echo_mismatch ratio

## Root cause

1. Gateway writes payload byte 0xAA (e.g., B524 register value 170)
2. Adapter wire-encodes as `A9 01`
3. TCP latency gateway→adapter means the pair isn't immediately on wire
4. Bus emits AUTO-SYN (idle >35ms) BEFORE our `A9 01` pair reaches wire
5. Wire sequence: `AA A9 01`
6. Adapter forwards `0xAA wasEscaped=false` (AUTO-SYN) FIRST, then `0xAA wasEscaped=true` (our actual echo)
7. Gateway reads first byte → mismatch with expected `0xAA wasEscaped=true` → fires `pre_echo_syn_raw` → ErrBusCollision → sendWithRetries

## User's architectural invariant

> While the gateway holds the ENS transmit token, AUTO-SYNs on the wire should be DROPPED, not propagated as echo failures. The wire-SYN we see is bus-idle interference BEFORE our escape pair reaches the wire — NOT an echo of our write.

## Fix

In `sendRawWithEcho` at the line-1192 payload-0xAA guard, replace immediate emit+return with a bounded drain loop (cap 3):
- Drain wire-SYN bytes (counter increments)
- If escape-decoded `0xAA wasEscaped=true` arrives → recovery success, return nil (txn proceeds normally)
- If non-SYN byte arrives → fall through to generic value-mismatch branch (correct echo_mismatch routing via Codex r6 P1)
- If cap reached → exhaustion counter increments, emit payload-0xAA-specific collision (preserves pre-round-9 stuck-adapter classification)

3 new counters: `payloadAaAutoSynAbsorbed`, `payloadAaAutoSynRecovered`, `payloadAaAutoSynDrainExhausted`.

## Test plan

- [x] 5 new unit tests (single AUTO-SYN recovery, two AUTO-SYNs recovery, drain-cap exhaustion, non-SYN drain break routes to value-mismatch, no-effect on non-payload-0xAA path)
- [x] 2 existing tests in bus_echo_f23_test.go updated for cap+1 boundary
- [x] Codex r5 review passed (1 P1 finding addressed in r6 commit)
- [ ] CI green
- [ ] Live HA deploy: per-frame echo_mismatch ratio drops from ~5% to near zero; `payloadAaAutoSynRecovered` non-zero

🤖 Generated with [Claude Code](https://claude.com/claude-code)