### PR TITLE
Step B2 part 1: shared telegram-phase FSM library (active write path)

### DIFF
--- a/protocol/telegram_fsm/fsm.go
+++ b/protocol/telegram_fsm/fsm.go
@@ -19,8 +19,10 @@
 //
 //   - **Pure**. No I/O, no goroutines, no clocks. Transitions are
 //     synchronous functions of (current state, input byte).
-//   - **Allocation-free** on the hot path. No slices grown per byte,
-//     no maps, no fmt.Sprintf.
+//   - **Allocation-free in the Feed hot path**. No slices grown per
+//     byte, no maps, no fmt.Sprintf inside Feed. The String() methods
+//     do use fmt.Sprintf as a fallback for unknown enum values; those
+//     are not on the hot path.
 //   - **Single-byte serial**. Callers feed one decoded byte at a time
 //     per v8 invariant I9 (classify under current phase, then
 //     transition).
@@ -35,10 +37,14 @@ package telegram_fsm
 
 import "fmt"
 
-// State enumerates the phases of an eBUS telegram per v6 §3 plus the
-// v8 PASSIVE_TRACKING composite state. Each State has a fixed
-// per-byte classifier (see Classify) and a deterministic next-state
-// transition (see TransitionAfterConsumed).
+// State enumerates the phases of an eBUS telegram per v6 §3. Each
+// State has a per-phase rule inside Machine.Feed; the transition to
+// the next state is committed inside Feed after the per-byte
+// classification per v8 invariant I9 (classify under current phase,
+// then transition).
+//
+// v8's PASSIVE_TRACKING composite state and the SLAVE_* phases land
+// in subsequent commits.
 type State uint8
 
 const (
@@ -66,11 +72,11 @@ const (
 
 	// StateMasterCRC consumes the single CRC byte that follows
 	// MASTER_DATA. Per v8 §1.6 the proxy can validate the CRC against
-	// the master-frame bytes it observed; mismatch is admin-logged.
+	// the initiator-frame bytes it observed; mismatch is admin-logged.
 	StateMasterCRC
 
 	// StateWaitMasterAck waits for the target's ACK (0x00) or NACK
-	// (0xFF) after the master CRC. ACK leads to SLAVE_LENGTH for
+	// (0xFF) after the initiator CRC. ACK leads to SLAVE_LENGTH for
 	// initiator-target, WAIT_TERMINATOR_SYN for initiator-initiator
 	// or broadcast (ZZ=0xFE). NACK with retx_count<1 leads to
 	// MASTER_RETX; NACK with retx_count>=1 leads to ABORTED. Per v8
@@ -118,15 +124,18 @@ func (s State) IsTerminal() bool {
 }
 
 // Decision describes the action the FSM dictates for a single input
-// byte. The classifier (Classify) returns this; callers act on it
-// before calling TransitionAfterConsumed.
+// byte. Machine.Feed returns this; callers act on it (forward, drop,
+// or admin-event-and-forward) before feeding the next byte.
 //
-// Decisions are tagged with their interpretive role so the caller can
-// route the byte to:
+// Decisions are tagged with their interpretive role so the caller
+// can route the byte to:
 //
 //   - The session's TCP egress queue (DecisionForward).
-//   - The bit bucket (DecisionDropAaInjection or DecisionDropMalformed).
-//   - The protocol-fault admin channel (DecisionProtocolFault).
+//   - The bit bucket (DecisionDropAaInjection).
+//   - The byte stream AND the protocol-fault admin channel
+//     (DecisionProtocolFault — per v8 invariant I10, the byte is
+//     forwarded to preserve wire fidelity AND an admin event is
+//     surfaced for operator visibility).
 type Decision uint8
 
 const (
@@ -188,25 +197,25 @@ type Machine struct {
 	// otherwise → WAIT_MASTER_ACK.
 	masterDest byte
 
-	// masterRetxCount counts master-frame retransmissions per v8
+	// masterRetxCount counts initiator-frame retransmissions per v8
 	// invariant I6. Bounded at MaxRetxPerPhase = 1 per eBUS V1.3.1.
 	masterRetxCount byte
 }
 
 // MaxRetxPerPhase is the eBUS V1.3.1 single-retransmit cap per phase
-// (v8 I6). The master may retransmit its frame once on NACK from
+// (v8 I6). The initiator may retransmit its frame once on NACK from
 // target; the target may retransmit its response once on NACK from
 // the initiator. After one retransmit, the next NACK aborts the
 // telegram.
 const MaxRetxPerPhase byte = 1
 
 // BroadcastDestination is the eBUS broadcast ZZ value (0xFE). Per
-// v6 §3 a master frame with ZZ=0xFE skips the WAIT_MASTER_ACK / slave
+// v6 §3 an initiator frame with ZZ=0xFE skips the WAIT_MASTER_ACK / target
 // phases and goes directly to WAIT_TERMINATOR_SYN.
 const BroadcastDestination byte = 0xFE
 
 // ACKByte (0x00) is the target's positive acknowledgement after
-// receiving a valid master CRC. Per v6 §3 it leads to either
+// receiving a valid initiator CRC. Per v6 §3 it leads to either
 // SLAVE_LENGTH (for initiator-target frames) or WAIT_TERMINATOR_SYN
 // (for initiator-initiator frames).
 const ACKByte byte = 0x00
@@ -247,9 +256,11 @@ func (m *Machine) ResetToIdle() {
 
 // Feed consumes one decoded byte and returns the Decision for that
 // byte. Per v8 invariant I9, the Decision is classified under the
-// CURRENT state before any transition is committed. If the byte
-// completes the phase (e.g., the 5th MASTER_HEADER byte), the
-// Machine transitions to the next phase AFTER Feed returns.
+// CURRENT state, then (if the byte completes the phase, e.g., the
+// 5th MASTER_HEADER byte) the Machine transitions to the next phase
+// before Feed returns. Callers see the Decision computed against
+// the phase that owned the byte; subsequent State() calls reflect
+// the post-transition state.
 //
 // The boolean wasEscaped distinguishes a wire-emitted 0xAA byte
 // (wasEscaped=false, the AUTO-SYN) from an escape-decoded logical
@@ -424,7 +435,7 @@ func (m *Machine) feedWaitMasterAck(b byte, wasEscaped bool) Decision {
 	case ACKByte:
 		// ACK accepted. Next state in v6 §3 is SLAVE_LENGTH for
 		// initiator-target or WAIT_TERMINATOR_SYN for
-		// initiator-initiator. Slave phases land in a follow-up
+		// initiator-initiator. Target phases land in a follow-up
 		// commit; for now ABORT to IDLE so behavior is well-defined.
 		m.ResetToIdle()
 		return DecisionForward

--- a/protocol/telegram_fsm/fsm.go
+++ b/protocol/telegram_fsm/fsm.go
@@ -1,0 +1,452 @@
+// Package telegram_fsm implements the per-telegram phase state machine
+// described in helianthus-docs-ebus/architecture/adaptermux/
+// frame-atomic-visibility-v8.md §3 + v6 §3.
+//
+// This is the shared library for v8 §1.11: "modelled-on (not literal
+// reuse of) the existing passive_transaction_reconstructor.go in
+// helianthus-ebusgateway." The FSM transition logic is the same as
+// what the passive reconstructor already implements, but extracted
+// into a self-contained pure-state-machine package consumable by:
+//
+//   - The proxy classifier in helianthus-ebus-adapter-proxy (Step B3,
+//     wiring the AA-aware escape decoder + per-session staging buffer
+//   - this FSM into the adapter-facing read path).
+//   - The gateway's own bus.go for active-client echo matching
+//     (future work, not in v8 scope).
+//   - Future passive observers.
+//
+// The FSM is intentionally:
+//
+//   - **Pure**. No I/O, no goroutines, no clocks. Transitions are
+//     synchronous functions of (current state, input byte).
+//   - **Allocation-free** on the hot path. No slices grown per byte,
+//     no maps, no fmt.Sprintf.
+//   - **Single-byte serial**. Callers feed one decoded byte at a time
+//     per v8 invariant I9 (classify under current phase, then
+//     transition).
+//   - **NOT thread-safe**. Per v8 invariant I11, callers serialize
+//     access on a per-session goroutine.
+//
+// This first iteration (Step B2) covers the active write-out path:
+// IDLE, ARBITRATING, MASTER_HEADER, MASTER_DATA, MASTER_CRC,
+// WAIT_MASTER_ACK. Subsequent iterations will add SLAVE_* phases,
+// MASTER_RETX / SLAVE_RETX, PASSIVE_TRACKING, and WAIT_TERMINATOR_SYN.
+package telegram_fsm
+
+import "fmt"
+
+// State enumerates the phases of an eBUS telegram per v6 §3 plus the
+// v8 PASSIVE_TRACKING composite state. Each State has a fixed
+// per-byte classifier (see Classify) and a deterministic next-state
+// transition (see TransitionAfterConsumed).
+type State uint8
+
+const (
+	// StateIdle is the genuinely-quiet phase between telegrams. The
+	// proxy forwards every byte unconditionally; AA-injection during
+	// IDLE is forwarded as wire AUTO-SYN by design (per v8 §3 IDLE
+	// pass-through, honest residual §14).
+	StateIdle State = iota
+
+	// StateArbitrating is the brief window between an ENH STARTED
+	// event for an active session and the first echo byte. Per v8
+	// §4: raw 0xAA in ARBITRATING is adapter-spurious AA-injection
+	// (no real wire bytes should arrive in this window besides the
+	// arbitration result), so it is dropped.
+	StateArbitrating
+
+	// StateMasterHeader consumes the 5 initiator-frame header bytes:
+	// QQ (source address), ZZ (destination address), PB (primary
+	// command), SB (secondary command), NN (data length).
+	StateMasterHeader
+
+	// StateMasterData consumes the NN data bytes after the header,
+	// where NN was the 5th MASTER_HEADER byte.
+	StateMasterData
+
+	// StateMasterCRC consumes the single CRC byte that follows
+	// MASTER_DATA. Per v8 §1.6 the proxy can validate the CRC against
+	// the master-frame bytes it observed; mismatch is admin-logged.
+	StateMasterCRC
+
+	// StateWaitMasterAck waits for the target's ACK (0x00) or NACK
+	// (0xFF) after the master CRC. ACK leads to SLAVE_LENGTH for
+	// initiator-target, WAIT_TERMINATOR_SYN for initiator-initiator
+	// or broadcast (ZZ=0xFE). NACK with retx_count<1 leads to
+	// MASTER_RETX; NACK with retx_count>=1 leads to ABORTED. Per v8
+	// invariant I6 (retx cap = 1 per phase).
+	StateWaitMasterAck
+
+	// StateAborted is a terminal state reached on protocol fault or
+	// NACK exhaustion. Per v8 §8 the FSM emits an admin event and
+	// returns to IDLE without injecting synthetic byte-stream events.
+	StateAborted
+)
+
+// String returns a short identifier suitable for admin logs.
+func (s State) String() string {
+	switch s {
+	case StateIdle:
+		return "IDLE"
+	case StateArbitrating:
+		return "ARBITRATING"
+	case StateMasterHeader:
+		return "MASTER_HEADER"
+	case StateMasterData:
+		return "MASTER_DATA"
+	case StateMasterCRC:
+		return "MASTER_CRC"
+	case StateWaitMasterAck:
+		return "WAIT_MASTER_ACK"
+	case StateAborted:
+		return "ABORTED"
+	default:
+		return fmt.Sprintf("State(%d)", s)
+	}
+}
+
+// IsTerminal reports whether the state is a terminal one (telegram
+// has either successfully completed or aborted). Terminal states
+// must transition back to IDLE before the next telegram begins.
+//
+// In this initial implementation only ABORTED is terminal; DONE
+// (success terminator) is represented by a transition back to IDLE
+// after WAIT_TERMINATOR_SYN sees its SYN (added in a later Step B2
+// iteration once WAIT_TERMINATOR_SYN is wired).
+func (s State) IsTerminal() bool {
+	return s == StateAborted
+}
+
+// Decision describes the action the FSM dictates for a single input
+// byte. The classifier (Classify) returns this; callers act on it
+// before calling TransitionAfterConsumed.
+//
+// Decisions are tagged with their interpretive role so the caller can
+// route the byte to:
+//
+//   - The session's TCP egress queue (DecisionForward).
+//   - The bit bucket (DecisionDropAaInjection or DecisionDropMalformed).
+//   - The protocol-fault admin channel (DecisionProtocolFault).
+type Decision uint8
+
+const (
+	// DecisionForward means the byte is a legitimate part of the
+	// telegram in its current phase and should be emitted to all
+	// downstream observers.
+	DecisionForward Decision = iota
+
+	// DecisionDropAaInjection means the byte is an adapter-spurious
+	// 0xAA that should not reach any observer. The FSM does NOT
+	// advance; the next byte is still classified under the same
+	// phase. Per v8 §4 (AA-injection filter).
+	DecisionDropAaInjection
+
+	// DecisionProtocolFault means the byte is neither a legitimate
+	// phase byte nor an absorbable AA-injection. Callers should
+	// emit an admin event AND forward the byte (per v8 invariant I10:
+	// PROTOCOL_FAULT visibility — drop nothing from the byte stream,
+	// admin-log the fault). The FSM transitions to ABORTED.
+	DecisionProtocolFault
+)
+
+// String returns a short identifier suitable for admin logs.
+func (d Decision) String() string {
+	switch d {
+	case DecisionForward:
+		return "forward"
+	case DecisionDropAaInjection:
+		return "drop_aa_injection"
+	case DecisionProtocolFault:
+		return "protocol_fault"
+	default:
+		return fmt.Sprintf("Decision(%d)", d)
+	}
+}
+
+// Machine is a single-telegram FSM instance. Construct with New().
+//
+// Machine is NOT thread-safe. Per v8 invariant I11, callers must
+// serialize Feed() on a per-session goroutine.
+//
+// The zero value is NOT usable; use New().
+type Machine struct {
+	state State
+
+	// masterNN holds the data-length byte observed in MASTER_HEADER.
+	// Used by MASTER_DATA to count down bytes to consume before
+	// transitioning to MASTER_CRC.
+	masterNN byte
+
+	// masterBytesConsumed counts bytes consumed in the current phase.
+	// Reset on every phase transition. Used by MASTER_HEADER
+	// (counting to 5), MASTER_DATA (counting to masterNN), and
+	// MASTER_CRC (counting to 1).
+	masterBytesConsumed byte
+
+	// masterDest is the ZZ byte from MASTER_HEADER. Determines
+	// post-MASTER_CRC routing: broadcast (0xFE) → terminator;
+	// otherwise → WAIT_MASTER_ACK.
+	masterDest byte
+
+	// masterRetxCount counts master-frame retransmissions per v8
+	// invariant I6. Bounded at MaxRetxPerPhase = 1 per eBUS V1.3.1.
+	masterRetxCount byte
+}
+
+// MaxRetxPerPhase is the eBUS V1.3.1 single-retransmit cap per phase
+// (v8 I6). The master may retransmit its frame once on NACK from
+// target; the target may retransmit its response once on NACK from
+// the initiator. After one retransmit, the next NACK aborts the
+// telegram.
+const MaxRetxPerPhase byte = 1
+
+// BroadcastDestination is the eBUS broadcast ZZ value (0xFE). Per
+// v6 §3 a master frame with ZZ=0xFE skips the WAIT_MASTER_ACK / slave
+// phases and goes directly to WAIT_TERMINATOR_SYN.
+const BroadcastDestination byte = 0xFE
+
+// ACKByte (0x00) is the target's positive acknowledgement after
+// receiving a valid master CRC. Per v6 §3 it leads to either
+// SLAVE_LENGTH (for initiator-target frames) or WAIT_TERMINATOR_SYN
+// (for initiator-initiator frames).
+const ACKByte byte = 0x00
+
+// NACKByte (0xFF) is the target's negative acknowledgement. Per v6
+// §3 / v8 I6 it triggers a MASTER_RETX (if retx_count<1) or ABORTED
+// (if retx_count>=1).
+const NACKByte byte = 0xFF
+
+// SynByte (0xAA) is the eBUS AUTO-SYN value. Per v8 §4, raw 0xAA
+// (was_escaped=false) in active-write phases is AA-injection from
+// adapter buffering and is dropped; escape-decoded 0xAA
+// (was_escaped=true) is a legitimate payload byte.
+const SynByte byte = 0xAA
+
+// New returns a Machine in StateIdle, ready to accept its first
+// byte via Feed().
+func New() *Machine {
+	return &Machine{state: StateIdle}
+}
+
+// State returns the Machine's current state. Useful for admin
+// observability and tests.
+func (m *Machine) State() State {
+	return m.state
+}
+
+// ResetToIdle returns the Machine to StateIdle and clears all
+// per-telegram state. Useful after a transport RESETTED event (v8
+// invariant I5) or after consuming a WAIT_TERMINATOR_SYN.
+func (m *Machine) ResetToIdle() {
+	m.state = StateIdle
+	m.masterNN = 0
+	m.masterBytesConsumed = 0
+	m.masterDest = 0
+	m.masterRetxCount = 0
+}
+
+// Feed consumes one decoded byte and returns the Decision for that
+// byte. Per v8 invariant I9, the Decision is classified under the
+// CURRENT state before any transition is committed. If the byte
+// completes the phase (e.g., the 5th MASTER_HEADER byte), the
+// Machine transitions to the next phase AFTER Feed returns.
+//
+// The boolean wasEscaped distinguishes a wire-emitted 0xAA byte
+// (wasEscaped=false, the AUTO-SYN) from an escape-decoded logical
+// 0xAA byte (wasEscaped=true, payload). Per v8 §4 the AA-injection
+// filter uses this provenance.
+//
+// Feed is NOT safe for concurrent use; callers must serialize per
+// v8 invariant I11.
+func (m *Machine) Feed(b byte, wasEscaped bool) Decision {
+	switch m.state {
+	case StateIdle:
+		return m.feedIdle(b, wasEscaped)
+	case StateArbitrating:
+		return m.feedArbitrating(b, wasEscaped)
+	case StateMasterHeader:
+		return m.feedMasterHeader(b, wasEscaped)
+	case StateMasterData:
+		return m.feedMasterData(b, wasEscaped)
+	case StateMasterCRC:
+		return m.feedMasterCRC(b, wasEscaped)
+	case StateWaitMasterAck:
+		return m.feedWaitMasterAck(b, wasEscaped)
+	case StateAborted:
+		// Per v8 §8: after ABORTED, callers should ResetToIdle
+		// before feeding more bytes. Feeding while ABORTED is a
+		// caller bug; report PROTOCOL_FAULT to surface it.
+		return DecisionProtocolFault
+	default:
+		// Defensive: unreachable for the current State enum.
+		return DecisionProtocolFault
+	}
+}
+
+// EnterArbitrating transitions the Machine from IDLE to ARBITRATING
+// in response to an ENH STARTED control event for this session. The
+// next Feed() call will be classified under STATE_ARBITRATING.
+//
+// Per v6 §3 the STARTED→ARBITRATING transition is event-driven (not
+// byte-driven), so it lives outside Feed.
+func (m *Machine) EnterArbitrating() {
+	m.state = StateArbitrating
+}
+
+// feedIdle handles the IDLE state. Per v8 §3 IDLE pass-through, every
+// byte is forwarded regardless of value. Wire AUTO-SYNs and
+// adapter-spurious AA-injection are indistinguishable in IDLE without
+// wire-time information (honest residual §14).
+func (m *Machine) feedIdle(b byte, wasEscaped bool) Decision {
+	_ = b
+	_ = wasEscaped
+	return DecisionForward
+}
+
+// feedArbitrating handles the ARBITRATING state. Per v8 §4: no real
+// wire bytes should arrive in this window (the adapter holds the wire
+// for arbitration outcome resolution). Any byte that does is either
+// adapter-spurious AA-injection (drop) or a genuine fault (admin).
+func (m *Machine) feedArbitrating(b byte, wasEscaped bool) Decision {
+	if b == SynByte && !wasEscaped {
+		return DecisionDropAaInjection
+	}
+	// Some adapters may emit the resolved-source byte here as a normal
+	// echo when arbitration succeeds. For now treat any non-SYN byte
+	// as the first MASTER_HEADER byte (QQ): forward, transition to
+	// MASTER_HEADER, and arrange for the byte to count in MASTER_HEADER.
+	//
+	// The transition is committed AFTER returning (v8 I9: classify
+	// under current state first); the next state advance happens in
+	// transitionAfterArbitrating.
+	m.transitionAfterArbitrating(b)
+	return DecisionForward
+}
+
+// transitionAfterArbitrating commits the post-classification state
+// change for the ARBITRATING state. The byte that triggered the
+// transition is the first MASTER_HEADER byte (QQ); record it as
+// consumed inside the new state.
+func (m *Machine) transitionAfterArbitrating(b byte) {
+	m.state = StateMasterHeader
+	m.masterBytesConsumed = 1
+	// QQ is recorded but not validated here; v8 §1.7's
+	// initiator-class validation happens in a future iteration that
+	// wires the AddressClassOf check.
+	_ = b
+}
+
+// feedMasterHeader handles the MASTER_HEADER state. The state
+// consumes 5 bytes: QQ, ZZ, PB, SB, NN. The 2nd byte (ZZ) is
+// remembered to route post-CRC; the 5th byte (NN) is the data length.
+func (m *Machine) feedMasterHeader(b byte, wasEscaped bool) Decision {
+	if b == SynByte && !wasEscaped {
+		// Raw 0xAA during MASTER_HEADER is AA-injection (v8 §4).
+		return DecisionDropAaInjection
+	}
+	// Consume byte. masterBytesConsumed reflects bytes already
+	// consumed BEFORE this one (initialized to 1 by ARBITRATING for
+	// QQ; or 0 for direct entry — kept compatible with both paths).
+	switch m.masterBytesConsumed {
+	case 1:
+		// 2nd byte is ZZ (destination).
+		m.masterDest = b
+	case 4:
+		// 5th byte is NN (data length).
+		m.masterNN = b
+		if b > 16 {
+			// Per v8 §1.7: NN > 16 violates eBUS V1.3.1 spec (max 16
+			// data bytes). Fault.
+			m.state = StateAborted
+			return DecisionProtocolFault
+		}
+	}
+	m.masterBytesConsumed++
+
+	if m.masterBytesConsumed >= 5 {
+		// MASTER_HEADER complete. Decide next state based on NN.
+		if m.masterNN == 0 {
+			// No data bytes; skip MASTER_DATA, go straight to CRC.
+			m.state = StateMasterCRC
+			m.masterBytesConsumed = 0
+		} else {
+			m.state = StateMasterData
+			m.masterBytesConsumed = 0
+		}
+	}
+	return DecisionForward
+}
+
+// feedMasterData handles the MASTER_DATA state. Consumes masterNN
+// bytes then transitions to MASTER_CRC.
+func (m *Machine) feedMasterData(b byte, wasEscaped bool) Decision {
+	if b == SynByte && !wasEscaped {
+		return DecisionDropAaInjection
+	}
+	m.masterBytesConsumed++
+	if m.masterBytesConsumed >= m.masterNN {
+		m.state = StateMasterCRC
+		m.masterBytesConsumed = 0
+	}
+	return DecisionForward
+}
+
+// feedMasterCRC handles the MASTER_CRC state. Consumes the single
+// CRC byte. Per v6 §3: if ZZ == 0xFE (broadcast) the FSM goes to
+// WAIT_TERMINATOR_SYN; otherwise to WAIT_MASTER_ACK. In this initial
+// Step B2 iteration WAIT_TERMINATOR_SYN is not yet wired, so the
+// broadcast path falls back to IDLE (caller is expected to forward
+// the post-CRC SYN as terminator) — this will be tightened in a
+// subsequent commit when WAIT_TERMINATOR_SYN is added.
+func (m *Machine) feedMasterCRC(b byte, wasEscaped bool) Decision {
+	if b == SynByte && !wasEscaped {
+		return DecisionDropAaInjection
+	}
+	_ = b // CRC validation deferred to v8 §1.6 implementation.
+	if m.masterDest == BroadcastDestination {
+		// Broadcast: skip ACK phase, return to IDLE pending terminator.
+		// (WAIT_TERMINATOR_SYN added in a later commit.)
+		m.ResetToIdle()
+	} else {
+		m.state = StateWaitMasterAck
+	}
+	return DecisionForward
+}
+
+// feedWaitMasterAck handles the WAIT_MASTER_ACK state. Expects ACK
+// (0x00), NACK (0xFF), or AA-injection. Any other byte is a protocol
+// fault.
+func (m *Machine) feedWaitMasterAck(b byte, wasEscaped bool) Decision {
+	if b == SynByte && !wasEscaped {
+		return DecisionDropAaInjection
+	}
+	switch b {
+	case ACKByte:
+		// ACK accepted. Next state in v6 §3 is SLAVE_LENGTH for
+		// initiator-target or WAIT_TERMINATOR_SYN for
+		// initiator-initiator. Slave phases land in a follow-up
+		// commit; for now ABORT to IDLE so behavior is well-defined.
+		m.ResetToIdle()
+		return DecisionForward
+	case NACKByte:
+		if m.masterRetxCount < MaxRetxPerPhase {
+			m.masterRetxCount++
+			// Per v6 §3, MASTER_RETX state resets header tracking
+			// and waits for the resend of QQ. In this initial
+			// iteration, restart MASTER_HEADER directly (MASTER_RETX
+			// state added in a follow-up commit).
+			m.state = StateMasterHeader
+			m.masterBytesConsumed = 0
+			m.masterNN = 0
+			m.masterDest = 0
+			return DecisionForward
+		}
+		// Retx budget exhausted (v8 invariant I6).
+		m.state = StateAborted
+		return DecisionForward
+	default:
+		// Any other byte during ACK wait is malformed.
+		m.state = StateAborted
+		return DecisionProtocolFault
+	}
+}

--- a/protocol/telegram_fsm/fsm_test.go
+++ b/protocol/telegram_fsm/fsm_test.go
@@ -1,0 +1,418 @@
+package telegram_fsm
+
+import "testing"
+
+// feedStep describes one byte to feed plus the expected outcome.
+type feedStep struct {
+	b          byte
+	wasEscaped bool
+	want       Decision
+	wantState  State // expected state AFTER this byte is consumed
+}
+
+func runFeedSequence(t *testing.T, m *Machine, steps []feedStep) {
+	t.Helper()
+	for i, step := range steps {
+		got := m.Feed(step.b, step.wasEscaped)
+		if got != step.want {
+			t.Fatalf("step %d (b=0x%02X esc=%v): decision %v, want %v",
+				i, step.b, step.wasEscaped, got, step.want)
+		}
+		if m.State() != step.wantState {
+			t.Fatalf("step %d (b=0x%02X esc=%v): state %v, want %v",
+				i, step.b, step.wasEscaped, m.State(), step.wantState)
+		}
+	}
+}
+
+// TestNewIsIdle verifies New returns a Machine in StateIdle.
+func TestNewIsIdle(t *testing.T) {
+	t.Parallel()
+	m := New()
+	if m.State() != StateIdle {
+		t.Fatalf("New().State() = %v, want StateIdle", m.State())
+	}
+}
+
+// TestIdleForwardsEverything verifies v8 §3 IDLE pass-through: every
+// byte in IDLE is forwarded regardless of value or was_escaped.
+func TestIdleForwardsEverything(t *testing.T) {
+	t.Parallel()
+	m := New()
+	runFeedSequence(t, m, []feedStep{
+		{b: 0xAA, wasEscaped: false, want: DecisionForward, wantState: StateIdle},
+		{b: 0xAA, wasEscaped: true, want: DecisionForward, wantState: StateIdle},
+		{b: 0x00, wasEscaped: false, want: DecisionForward, wantState: StateIdle},
+		{b: 0xFF, wasEscaped: false, want: DecisionForward, wantState: StateIdle},
+	})
+}
+
+// TestEnterArbitrating transitions IDLE → ARBITRATING on the
+// STARTED event (not on a byte feed). The state advance is purely
+// event-driven per v6 §3.
+func TestEnterArbitrating(t *testing.T) {
+	t.Parallel()
+	m := New()
+	m.EnterArbitrating()
+	if m.State() != StateArbitrating {
+		t.Fatalf("State after EnterArbitrating = %v, want StateArbitrating", m.State())
+	}
+}
+
+// TestArbitratingDropsRawSyn verifies v8 §4: raw 0xAA in ARBITRATING
+// is adapter-spurious AA-injection. Drop, do not advance.
+func TestArbitratingDropsRawSyn(t *testing.T) {
+	t.Parallel()
+	m := New()
+	m.EnterArbitrating()
+	got := m.Feed(0xAA, false)
+	if got != DecisionDropAaInjection {
+		t.Fatalf("decision = %v, want DecisionDropAaInjection", got)
+	}
+	if m.State() != StateArbitrating {
+		t.Fatalf("state = %v, want StateArbitrating (no advance on drop)", m.State())
+	}
+}
+
+// TestArbitratingFirstByteEntersMasterHeader verifies the
+// ARBITRATING → MASTER_HEADER transition on the first non-SYN byte.
+// The first byte is QQ; it counts as byte 1 of the 5-byte header.
+func TestArbitratingFirstByteEntersMasterHeader(t *testing.T) {
+	t.Parallel()
+	m := New()
+	m.EnterArbitrating()
+	got := m.Feed(0x10, false) // QQ
+	if got != DecisionForward {
+		t.Fatalf("decision = %v, want DecisionForward", got)
+	}
+	if m.State() != StateMasterHeader {
+		t.Fatalf("state = %v, want StateMasterHeader", m.State())
+	}
+}
+
+// TestMasterHeaderConsumes5BytesThenMasterData verifies the full
+// MASTER_HEADER consumption for NN > 0, transitioning to MASTER_DATA.
+func TestMasterHeaderConsumes5BytesThenMasterData(t *testing.T) {
+	t.Parallel()
+	m := New()
+	m.EnterArbitrating()
+	runFeedSequence(t, m, []feedStep{
+		{b: 0x10, want: DecisionForward, wantState: StateMasterHeader}, // QQ
+		{b: 0x08, want: DecisionForward, wantState: StateMasterHeader}, // ZZ
+		{b: 0xB5, want: DecisionForward, wantState: StateMasterHeader}, // PB
+		{b: 0x09, want: DecisionForward, wantState: StateMasterHeader}, // SB
+		{b: 0x03, want: DecisionForward, wantState: StateMasterData},   // NN=3
+	})
+}
+
+// TestMasterHeaderZeroDataGoesDirectToCRC verifies NN=0 short-circuit
+// to MASTER_CRC.
+func TestMasterHeaderZeroDataGoesDirectToCRC(t *testing.T) {
+	t.Parallel()
+	m := New()
+	m.EnterArbitrating()
+	runFeedSequence(t, m, []feedStep{
+		{b: 0x10, want: DecisionForward, wantState: StateMasterHeader},
+		{b: 0x08, want: DecisionForward, wantState: StateMasterHeader},
+		{b: 0xB5, want: DecisionForward, wantState: StateMasterHeader},
+		{b: 0x09, want: DecisionForward, wantState: StateMasterHeader},
+		{b: 0x00, want: DecisionForward, wantState: StateMasterCRC}, // NN=0 → skip to CRC
+	})
+}
+
+// TestMasterHeaderRejectsNNAbove16 verifies v8 §1.7: NN > 16 is a
+// spec violation per eBUS V1.3.1, immediately aborting.
+func TestMasterHeaderRejectsNNAbove16(t *testing.T) {
+	t.Parallel()
+	m := New()
+	m.EnterArbitrating()
+	runFeedSequence(t, m, []feedStep{
+		{b: 0x10, want: DecisionForward, wantState: StateMasterHeader},
+		{b: 0x08, want: DecisionForward, wantState: StateMasterHeader},
+		{b: 0xB5, want: DecisionForward, wantState: StateMasterHeader},
+		{b: 0x09, want: DecisionForward, wantState: StateMasterHeader},
+		{b: 0x11, want: DecisionProtocolFault, wantState: StateAborted}, // NN=17 spec violation
+	})
+}
+
+// TestMasterDataDropsRawSyn verifies v8 §4: raw 0xAA in MASTER_DATA
+// is AA-injection. Drop, stay in MASTER_DATA.
+func TestMasterDataDropsRawSyn(t *testing.T) {
+	t.Parallel()
+	m := New()
+	m.EnterArbitrating()
+	for _, b := range []byte{0x10, 0x08, 0xB5, 0x09, 0x03} {
+		m.Feed(b, false)
+	}
+	if m.State() != StateMasterData {
+		t.Fatalf("setup state = %v, want StateMasterData", m.State())
+	}
+	got := m.Feed(0xAA, false)
+	if got != DecisionDropAaInjection {
+		t.Fatalf("decision = %v, want DecisionDropAaInjection", got)
+	}
+	if m.State() != StateMasterData {
+		t.Fatalf("state = %v, want StateMasterData (no advance on drop)", m.State())
+	}
+}
+
+// TestMasterDataAcceptsEscapedAA verifies that an escape-decoded
+// logical 0xAA (was_escaped=true) is a legitimate payload byte and
+// advances MASTER_DATA's byte counter.
+func TestMasterDataAcceptsEscapedAA(t *testing.T) {
+	t.Parallel()
+	m := New()
+	m.EnterArbitrating()
+	// QQ ZZ PB SB NN=1 (single data byte)
+	for _, b := range []byte{0x10, 0x08, 0xB5, 0x09, 0x01} {
+		m.Feed(b, false)
+	}
+	// Single data byte is a logical 0xAA (escape-decoded).
+	got := m.Feed(0xAA, true)
+	if got != DecisionForward {
+		t.Fatalf("decision = %v, want DecisionForward (escape-decoded AA is legit payload)", got)
+	}
+	if m.State() != StateMasterCRC {
+		t.Fatalf("state = %v, want StateMasterCRC (NN=1 satisfied)", m.State())
+	}
+}
+
+// TestMasterCRCBroadcastReturnsToIdle verifies broadcast (ZZ=0xFE)
+// short-circuit: post-CRC the FSM returns to IDLE (skipping ACK).
+// Note: WAIT_TERMINATOR_SYN is not yet wired in this iteration; the
+// CRC byte itself is forwarded and the FSM resets.
+func TestMasterCRCBroadcastReturnsToIdle(t *testing.T) {
+	t.Parallel()
+	m := New()
+	m.EnterArbitrating()
+	// QQ ZZ=0xFE PB SB NN=1
+	for _, b := range []byte{0x10, 0xFE, 0xB5, 0x09, 0x01} {
+		m.Feed(b, false)
+	}
+	m.Feed(0xCC, false) // data byte
+	if m.State() != StateMasterCRC {
+		t.Fatalf("pre-CRC state = %v, want StateMasterCRC", m.State())
+	}
+	got := m.Feed(0x55, false) // CRC byte
+	if got != DecisionForward {
+		t.Fatalf("CRC decision = %v, want DecisionForward", got)
+	}
+	if m.State() != StateIdle {
+		t.Fatalf("post-CRC broadcast state = %v, want StateIdle", m.State())
+	}
+}
+
+// TestMasterCRCNonBroadcastGoesToWaitAck verifies non-broadcast frames
+// transition MASTER_CRC → WAIT_MASTER_ACK.
+func TestMasterCRCNonBroadcastGoesToWaitAck(t *testing.T) {
+	t.Parallel()
+	m := New()
+	m.EnterArbitrating()
+	for _, b := range []byte{0x10, 0x08, 0xB5, 0x09, 0x00} { // NN=0
+		m.Feed(b, false)
+	}
+	if m.State() != StateMasterCRC {
+		t.Fatalf("pre-CRC state = %v, want StateMasterCRC", m.State())
+	}
+	got := m.Feed(0x42, false) // CRC byte
+	if got != DecisionForward {
+		t.Fatalf("CRC decision = %v, want DecisionForward", got)
+	}
+	if m.State() != StateWaitMasterAck {
+		t.Fatalf("post-CRC state = %v, want StateWaitMasterAck", m.State())
+	}
+}
+
+// TestWaitMasterAckDropsRawSyn verifies v8 §4: raw 0xAA in
+// WAIT_MASTER_ACK is AA-injection. Drop, stay.
+func TestWaitMasterAckDropsRawSyn(t *testing.T) {
+	t.Parallel()
+	m := setupAtWaitMasterAck(t)
+	got := m.Feed(0xAA, false)
+	if got != DecisionDropAaInjection {
+		t.Fatalf("decision = %v, want DecisionDropAaInjection", got)
+	}
+	if m.State() != StateWaitMasterAck {
+		t.Fatalf("state = %v, want StateWaitMasterAck (no advance)", m.State())
+	}
+}
+
+// TestWaitMasterAckAcceptsAck verifies ACK advances toward the next
+// phase. In this initial iteration, ACK returns to IDLE (slave phases
+// not yet wired).
+func TestWaitMasterAckAcceptsAck(t *testing.T) {
+	t.Parallel()
+	m := setupAtWaitMasterAck(t)
+	got := m.Feed(ACKByte, false)
+	if got != DecisionForward {
+		t.Fatalf("decision = %v, want DecisionForward", got)
+	}
+	if m.State() != StateIdle {
+		t.Fatalf("post-ACK state = %v, want StateIdle (slave phases not yet wired)", m.State())
+	}
+}
+
+// TestWaitMasterAckNackTriggersRetx verifies v8 invariant I6:
+// first NACK triggers MASTER_RETX (FSM returns to MASTER_HEADER for
+// the resend; retx_count increments).
+func TestWaitMasterAckNackTriggersRetx(t *testing.T) {
+	t.Parallel()
+	m := setupAtWaitMasterAck(t)
+	got := m.Feed(NACKByte, false)
+	if got != DecisionForward {
+		t.Fatalf("decision = %v, want DecisionForward", got)
+	}
+	if m.State() != StateMasterHeader {
+		t.Fatalf("state = %v, want StateMasterHeader (retx restarts header)", m.State())
+	}
+}
+
+// TestWaitMasterAckSecondNackAborts verifies v8 invariant I6: after
+// the spec-mandated single retx, a second NACK aborts the telegram.
+func TestWaitMasterAckSecondNackAborts(t *testing.T) {
+	t.Parallel()
+	m := setupAtWaitMasterAck(t)
+	// First NACK → MASTER_RETX
+	m.Feed(NACKByte, false)
+	// Resend full header
+	for _, b := range []byte{0x10, 0x08, 0xB5, 0x09, 0x00} {
+		m.Feed(b, false)
+	}
+	// CRC
+	m.Feed(0x42, false)
+	if m.State() != StateWaitMasterAck {
+		t.Fatalf("post-retx state = %v, want StateWaitMasterAck", m.State())
+	}
+	// Second NACK
+	got := m.Feed(NACKByte, false)
+	if got != DecisionForward {
+		t.Fatalf("decision = %v, want DecisionForward", got)
+	}
+	if m.State() != StateAborted {
+		t.Fatalf("state = %v, want StateAborted (retx budget exhausted)", m.State())
+	}
+}
+
+// TestWaitMasterAckMalformedByteAborts verifies any byte other than
+// ACK / NACK / AA in WAIT_MASTER_ACK is a protocol fault.
+func TestWaitMasterAckMalformedByteAborts(t *testing.T) {
+	t.Parallel()
+	m := setupAtWaitMasterAck(t)
+	got := m.Feed(0x42, false)
+	if got != DecisionProtocolFault {
+		t.Fatalf("decision = %v, want DecisionProtocolFault", got)
+	}
+	if m.State() != StateAborted {
+		t.Fatalf("state = %v, want StateAborted", m.State())
+	}
+}
+
+// TestAbortedFedReportsFault verifies that feeding bytes while in
+// ABORTED returns DecisionProtocolFault (caller bug to feed without
+// ResetToIdle first).
+func TestAbortedFedReportsFault(t *testing.T) {
+	t.Parallel()
+	m := setupAtWaitMasterAck(t)
+	m.Feed(0x42, false) // → ABORTED
+	if m.State() != StateAborted {
+		t.Fatalf("setup state = %v, want StateAborted", m.State())
+	}
+	got := m.Feed(0x10, false)
+	if got != DecisionProtocolFault {
+		t.Fatalf("decision = %v, want DecisionProtocolFault (feed while ABORTED)", got)
+	}
+}
+
+// TestResetToIdleClearsState verifies ResetToIdle returns to IDLE
+// and clears all per-telegram state, allowing the same Machine to
+// be reused for the next telegram.
+func TestResetToIdleClearsState(t *testing.T) {
+	t.Parallel()
+	m := setupAtWaitMasterAck(t)
+	m.ResetToIdle()
+	if m.State() != StateIdle {
+		t.Fatalf("post-reset state = %v, want StateIdle", m.State())
+	}
+	// Machine should work normally for a fresh telegram.
+	m.EnterArbitrating()
+	got := m.Feed(0x10, false)
+	if got != DecisionForward {
+		t.Fatalf("post-reset arbitration → header: decision = %v, want DecisionForward", got)
+	}
+	if m.State() != StateMasterHeader {
+		t.Fatalf("post-reset arbitration → header: state = %v, want StateMasterHeader", m.State())
+	}
+}
+
+// TestRetxCapMatchesSpec drift-guards the MaxRetxPerPhase constant
+// against the v8 I6 spec value.
+func TestRetxCapMatchesSpec(t *testing.T) {
+	t.Parallel()
+	if MaxRetxPerPhase != 1 {
+		t.Fatalf("MaxRetxPerPhase = %d, want 1 (per spec V1.3.1, v8 I6)", MaxRetxPerPhase)
+	}
+}
+
+// TestStateAndDecisionStringsAreReadable verifies the String()
+// methods produce labels suitable for admin logs.
+func TestStateAndDecisionStringsAreReadable(t *testing.T) {
+	t.Parallel()
+	stateCases := map[State]string{
+		StateIdle:          "IDLE",
+		StateArbitrating:   "ARBITRATING",
+		StateMasterHeader:  "MASTER_HEADER",
+		StateMasterData:    "MASTER_DATA",
+		StateMasterCRC:     "MASTER_CRC",
+		StateWaitMasterAck: "WAIT_MASTER_ACK",
+		StateAborted:       "ABORTED",
+	}
+	for s, want := range stateCases {
+		if got := s.String(); got != want {
+			t.Errorf("State(%d).String() = %q, want %q", s, got, want)
+		}
+	}
+	decisionCases := map[Decision]string{
+		DecisionForward:         "forward",
+		DecisionDropAaInjection: "drop_aa_injection",
+		DecisionProtocolFault:   "protocol_fault",
+	}
+	for d, want := range decisionCases {
+		if got := d.String(); got != want {
+			t.Errorf("Decision(%d).String() = %q, want %q", d, got, want)
+		}
+	}
+}
+
+// TestStateIsTerminal verifies IsTerminal reports ABORTED as
+// terminal and all other states as non-terminal.
+func TestStateIsTerminal(t *testing.T) {
+	t.Parallel()
+	if !StateAborted.IsTerminal() {
+		t.Error("StateAborted.IsTerminal() = false, want true")
+	}
+	nonTerminal := []State{StateIdle, StateArbitrating, StateMasterHeader, StateMasterData, StateMasterCRC, StateWaitMasterAck}
+	for _, s := range nonTerminal {
+		if s.IsTerminal() {
+			t.Errorf("%v.IsTerminal() = true, want false", s)
+		}
+	}
+}
+
+// setupAtWaitMasterAck constructs a Machine that has progressed
+// through IDLE → ARBITRATING → MASTER_HEADER (NN=0) → MASTER_CRC →
+// WAIT_MASTER_ACK with a non-broadcast frame.
+func setupAtWaitMasterAck(t *testing.T) *Machine {
+	t.Helper()
+	m := New()
+	m.EnterArbitrating()
+	// QQ ZZ PB SB NN=0 then CRC. ZZ != 0xFE so the FSM goes to
+	// WAIT_MASTER_ACK after CRC.
+	for _, b := range []byte{0x10, 0x08, 0xB5, 0x09, 0x00} {
+		m.Feed(b, false)
+	}
+	m.Feed(0x42, false) // CRC
+	if m.State() != StateWaitMasterAck {
+		t.Fatalf("setup pre-condition: state = %v, want StateWaitMasterAck", m.State())
+	}
+	return m
+}

--- a/protocol/telegram_fsm/fsm_test.go
+++ b/protocol/telegram_fsm/fsm_test.go
@@ -135,6 +135,64 @@ func TestMasterHeaderRejectsNNAbove16(t *testing.T) {
 	})
 }
 
+// TestMasterHeaderAcceptsNNExactly16 verifies the boundary case: NN=16
+// is the maximum valid data length per eBUS V1.3.1, must NOT abort.
+// Pins the `>` comparison in fsm.go against silent regression to `>=`.
+func TestMasterHeaderAcceptsNNExactly16(t *testing.T) {
+	t.Parallel()
+	m := New()
+	m.EnterArbitrating()
+	runFeedSequence(t, m, []feedStep{
+		{b: 0x10, want: DecisionForward, wantState: StateMasterHeader},
+		{b: 0x08, want: DecisionForward, wantState: StateMasterHeader},
+		{b: 0xB5, want: DecisionForward, wantState: StateMasterHeader},
+		{b: 0x09, want: DecisionForward, wantState: StateMasterHeader},
+		{b: 0x10, want: DecisionForward, wantState: StateMasterData}, // NN=16 boundary
+	})
+}
+
+// TestMasterHeaderDropsRawSyn verifies v8 §4: raw 0xAA in MASTER_HEADER
+// (any of the 5 header bytes after QQ) is AA-injection. Drop, stay.
+func TestMasterHeaderDropsRawSyn(t *testing.T) {
+	t.Parallel()
+	m := New()
+	m.EnterArbitrating()
+	m.Feed(0x10, false) // QQ — now in MASTER_HEADER
+	if m.State() != StateMasterHeader {
+		t.Fatalf("setup state = %v, want StateMasterHeader", m.State())
+	}
+	got := m.Feed(0xAA, false)
+	if got != DecisionDropAaInjection {
+		t.Fatalf("decision = %v, want DecisionDropAaInjection", got)
+	}
+	if m.State() != StateMasterHeader {
+		t.Fatalf("state = %v, want StateMasterHeader (no advance)", m.State())
+	}
+}
+
+// TestMasterCRCDropsRawSyn verifies v8 §4: raw 0xAA in MASTER_CRC is
+// AA-injection (the CRC byte should never be 0xAA raw — payload-0xAA
+// encodes as escape-pair, and the actual wire AUTO-SYN only marks
+// terminator AFTER WAIT_TERMINATOR_SYN). Drop, stay in MASTER_CRC.
+func TestMasterCRCDropsRawSyn(t *testing.T) {
+	t.Parallel()
+	m := New()
+	m.EnterArbitrating()
+	for _, b := range []byte{0x10, 0x08, 0xB5, 0x09, 0x00} {
+		m.Feed(b, false)
+	}
+	if m.State() != StateMasterCRC {
+		t.Fatalf("setup state = %v, want StateMasterCRC", m.State())
+	}
+	got := m.Feed(0xAA, false)
+	if got != DecisionDropAaInjection {
+		t.Fatalf("decision = %v, want DecisionDropAaInjection", got)
+	}
+	if m.State() != StateMasterCRC {
+		t.Fatalf("state = %v, want StateMasterCRC (no advance)", m.State())
+	}
+}
+
 // TestMasterDataDropsRawSyn verifies v8 §4: raw 0xAA in MASTER_DATA
 // is AA-injection. Drop, stay in MASTER_DATA.
 func TestMasterDataDropsRawSyn(t *testing.T) {
@@ -238,7 +296,7 @@ func TestWaitMasterAckDropsRawSyn(t *testing.T) {
 }
 
 // TestWaitMasterAckAcceptsAck verifies ACK advances toward the next
-// phase. In this initial iteration, ACK returns to IDLE (slave phases
+// phase. In this initial iteration, ACK returns to IDLE (target phases
 // not yet wired).
 func TestWaitMasterAckAcceptsAck(t *testing.T) {
 	t.Parallel()
@@ -248,7 +306,7 @@ func TestWaitMasterAckAcceptsAck(t *testing.T) {
 		t.Fatalf("decision = %v, want DecisionForward", got)
 	}
 	if m.State() != StateIdle {
-		t.Fatalf("post-ACK state = %v, want StateIdle (slave phases not yet wired)", m.State())
+		t.Fatalf("post-ACK state = %v, want StateIdle (target phases not yet wired)", m.State())
 	}
 }
 


### PR DESCRIPTION
## Summary

Step B2 of the v8 migration ([frame-atomic-visibility-v8.md §1.11](../../helianthus-docs-ebus/blob/frame-atomic-visibility/architecture/adaptermux/frame-atomic-visibility-v8.md)). New package `helianthus-ebusgo/protocol/telegram_fsm` — a pure, allocation-free, single-byte serial telegram-phase state machine consumable by:

- The proxy classifier (Step B3 / task #4).
- The gateway's bus.go for future active-client echo matching.
- Future passive observers.

Per v8 §1.11 "modelled-on, not literal reuse": logic mirrors the existing `helianthus-ebusgateway/passive_transaction_reconstructor.go` (1791 LOC) but extracted as a self-contained state machine. The existing reconstructor is **unchanged**.

## Scope of this first iteration (Part 1)

**Active write-out path only**: IDLE, ARBITRATING, MASTER_HEADER, MASTER_DATA, MASTER_CRC, WAIT_MASTER_ACK, ABORTED.

Follow-up commits in this same PR (or stacked PRs) will add:
- SLAVE_LENGTH / SLAVE_DATA / SLAVE_CRC / WAIT_SLAVE_ACK
- MASTER_RETX / SLAVE_RETX as explicit states (currently collapsed into header-restart)
- WAIT_TERMINATOR_SYN (currently broadcast / post-ACK skip directly to IDLE)
- PASSIVE_TRACKING composite state for foreign-initiator telegrams

The library is **usable now** for the proxy's active-session classification (write-out path), which is the most common operational case.

## API

```go
type State uint8     // 7 states for active write path
type Decision uint8  // forward / drop_aa_injection / protocol_fault
type Machine struct{ ... }
func New() *Machine
func (m *Machine) Feed(b byte, wasEscaped bool) Decision
func (m *Machine) EnterArbitrating()    // event-driven: STARTED
func (m *Machine) ResetToIdle()          // event-driven: RESETTED
func (m *Machine) State() State
```

## Invariants implemented

- **I9** (classify-then-transition): Feed classifies under CURRENT state, applies decision, THEN commits phase transition. The ARBITRATING→MASTER_HEADER transition carries the first byte (QQ) as byte 1 of the header.
- **I6** (retx cap): `MaxRetxPerPhase = 1` via `masterRetxCount`. First NACK → MASTER_RETX (header restart). Second NACK → ABORTED.
- **§1.7 NN spec check**: NN > 16 immediately aborts (per eBUS V1.3.1).
- **§4 AA-injection filter**: raw 0xAA (was_escaped=false) in ARBITRATING / MASTER_HEADER / MASTER_DATA / MASTER_CRC / WAIT_MASTER_ACK is dropped without advancing.
- **§3 IDLE pass-through**: every byte in IDLE forwarded (honest residual §14).
- **§4 broadcast short-circuit**: ZZ=0xFE from MASTER_HEADER → MASTER_CRC → IDLE (skipping ACK).
- **I11** (per-session goroutine): Machine is NOT thread-safe; callers serialize.

## Tests (17 cases)

| Coverage |
|---|
| New() returns IDLE |
| IDLE forwards all bytes including raw 0xAA |
| EnterArbitrating() transitions IDLE→ARBITRATING |
| ARBITRATING drops raw 0xAA, stays |
| ARBITRATING + non-SYN → MASTER_HEADER with byte counted |
| MASTER_HEADER consumes 5 bytes → MASTER_DATA (NN>0) |
| MASTER_HEADER NN=0 → MASTER_CRC (skip data) |
| NN > 16 → ABORTED + PROTOCOL_FAULT |
| MASTER_DATA drops raw 0xAA |
| MASTER_DATA accepts escape-decoded 0xAA as payload |
| MASTER_CRC broadcast (ZZ=0xFE) → IDLE |
| MASTER_CRC non-broadcast → WAIT_MASTER_ACK |
| WAIT_MASTER_ACK drops raw 0xAA |
| WAIT_MASTER_ACK ACK → IDLE |
| WAIT_MASTER_ACK NACK → MASTER_RETX (header restart) |
| Second NACK → ABORTED (retx cap) |
| Malformed byte in ACK wait → PROTOCOL_FAULT + ABORTED |
| Feed while ABORTED → PROTOCOL_FAULT (caller bug) |
| ResetToIdle clears state |
| Constant drift guard (MaxRetxPerPhase) |
| State.String() + Decision.String() readability |
| IsTerminal classification |

## Test plan

- [x] `go build ./protocol/telegram_fsm/...` clean
- [x] `go test ./protocol/telegram_fsm/...` all pass
- [x] terminology gate clean (CamelCase state names exempted as protocol-layer)
- [x] gofmt clean
- [x] public symbol gate clean
- [x] No touch to existing passive_transaction_reconstructor.go

## Next

- Step B2 part 2: SLAVE_* phases + MASTER_RETX/SLAVE_RETX explicit states + WAIT_TERMINATOR_SYN.
- Step B2 part 3: PASSIVE_TRACKING composite state.
- Step B3 (task #4): wire FSM + escape decoder + per-session pacer + L_rtt into the proxy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)