### PR TITLE
Phase 1 Step B4: gate round-9 absorb on inSendRawWithEchoActiveEchoWait

### DIFF
--- a/protocol/bus.go
+++ b/protocol/bus.go
@@ -132,27 +132,34 @@ type Bus struct {
 	payloadAaAutoSynDrainExhausted atomic.Uint64
 
 	// Phase 1 Step B4 (frame-atomic-v8 §1.8 / §1.12, retained per v8 I8):
-	// activeEchoWaits counts goroutines currently inside the active
-	// echo-wait phase of sendRawWithEcho — i.e. between the successful
-	// raw-byte write and the resolution of its echo (success, mismatch,
-	// or absorb-loop exit). The counter serves as the runtime predicate
-	// inSendRawWithEchoActiveEchoWait(): it MUST be > 0 at any code
-	// location that pretends to be operating on an in-flight echo.
+	// activeEchoWaits is a bus-wide phase predicate counter — it is >0
+	// whenever ONE OR MORE goroutines on this Bus are inside the active
+	// echo-wait phase of sendRawWithEcho (between a successful raw-byte
+	// Write and the resolution of its echo). It is NOT goroutine-local;
+	// the predicate inSendRawWithEchoActiveEchoWait() answers "is any
+	// goroutine on this Bus currently in echo wait?", not "did THIS
+	// caller arrive via sendRawWithEcho?". For the only current call
+	// site (round-9 absorb entry, also inside sendRawWithEcho), this
+	// distinction is moot — the answer is always true. The predicate
+	// exists to document the phase invariant and to give the Prometheus
+	// alert a runtime hook; future call sites that try to count round-9
+	// fires from outside sendRawWithEcho would need a different
+	// per-call mechanism (e.g. an explicit token argument).
 	//
-	// round9AbsorbFiredProxyMediated counts how many times the round-9
-	// AUTO-SYN absorb predicate fired while the active-echo-wait
-	// predicate held — i.e. legitimate round-9 fires from the
-	// sendRawWithEcho call-stack. Per v8 I8 the round-9 absorb code
-	// stays as a legacy fallback for direct-adapter mode; once the v8
-	// adaptermux classifier is enabled in `enforce`, the proxy MUST
-	// filter wire AUTO-SYNs before they reach the gateway's echo
-	// position, so this counter is expected to stay at zero. The
-	// Prometheus alert `HelianthusRound9FiredUnderProxy` (defined in
-	// helianthus-docs-ebus → gateway deploy manifest, NOT in this
-	// repo) watches the rate of this counter under proxy-mediated
-	// mode; any non-zero rate indicates a v8 invariant violation.
-	activeEchoWaits                atomic.Int32
-	round9AbsorbFiredProxyMediated atomic.Uint64
+	// round9AbsorbEntered counts how many times the round-9 AUTO-SYN
+	// absorb predicate fired while the active-echo-wait predicate held.
+	// The counter is deliberately named neutrally: this code has no
+	// notion of whether a proxy is mediating wire AUTO-SYNs. The
+	// Prometheus alert HelianthusRound9FiredUnderProxy (defined in the
+	// gateway deploy manifest — see helianthus-docs-ebus →
+	// deployment/prometheus-alerts.md, NOT in this repo) is the layer
+	// that AND-s this counter with the adaptermux classifier_mode label
+	// to derive "round-9 fired while proxy SHOULD have filtered". Per
+	// v8 I8 the round-9 absorb code itself is retained as the legacy
+	// fallback for direct-adapter mode; expected steady-state under
+	// classifier_mode == enforce is counter rate == 0.
+	activeEchoWaits     atomic.Int32
+	round9AbsorbEntered atomic.Uint64
 }
 
 // NewBus initializes a Bus with transport, config, and optional queue capacity.
@@ -1196,19 +1203,19 @@ func (b *Bus) sendRawWithEcho(runCtx, reqCtx context.Context, raw byte, expectRa
 	// the bus is idle (a real defect, not buffering interference).
 	if flagged != nil && !expectRawSyn && raw == SymbolSyn && echo == SymbolSyn && !echoWasEscaped {
 		// Phase 1 Step B4 (frame-atomic-v8 §1.8): the round-9 absorb
-		// predicate just fired. Gate the proxy-mediated alert counter on
-		// inSendRawWithEchoActiveEchoWait() — true here by construction
-		// (we are inside sendRawWithEcho between Write and echo
-		// resolution), but the explicit predicate documents the
-		// invariant and protects against future refactors that lift
-		// this absorb block out of the active-echo-wait call-stack.
+		// predicate just fired. The neutrally-named round9AbsorbEntered
+		// counter increments here, gated on the runtime phase predicate
+		// inSendRawWithEchoActiveEchoWait(). At this call site the
+		// predicate is always true by construction (we are inside
+		// sendRawWithEcho between Write and echo resolution); the gate
+		// is kept as a phase assertion, not as proof of any cross-repo
+		// state (this code has zero proxy-awareness — the
+		// proxy-mediated interpretation lives in the Prometheus alert
+		// HelianthusRound9FiredUnderProxy, not in the counter name).
 		// Round-9 absorb itself is RETAINED per v8 I8 as the legacy
-		// fallback for direct-adapter mode; this counter exists ONLY
-		// to power the HelianthusRound9FiredUnderProxy alert (v8 §1.12)
-		// which trips when the adaptermux classifier is in `enforce`
-		// and round-9 still fires (a v8 invariant violation).
+		// fallback for direct-adapter mode.
 		if b.inSendRawWithEchoActiveEchoWait() {
-			b.round9AbsorbFiredProxyMediated.Add(1)
+			b.round9AbsorbEntered.Add(1)
 		}
 		const maxPayloadAaAutoSynDrains = 3
 		absorbed := 0
@@ -1507,45 +1514,40 @@ func (b *Bus) PayloadAaAutoSynDrainExhausted() uint64 {
 	return b.payloadAaAutoSynDrainExhausted.Load()
 }
 
-// inSendRawWithEchoActiveEchoWait reports whether the current bus has
-// at least one goroutine currently inside the active echo-wait phase
-// of sendRawWithEcho — i.e. between a successful raw-byte Write and
-// the resolution of its echo. Phase 1 Step B4 (frame-atomic-v8 §1.8)
-// uses this predicate to gate the round-9 proxy-mediated alert
-// counter, ensuring that only round-9 absorb fires originating from
-// the sendRawWithEcho call-stack count toward the
-// HelianthusRound9FiredUnderProxy alert (v8 §1.12). The predicate is
-// always true at the round-9 absorb site by construction; making it
-// explicit documents the invariant and provides defense-in-depth
-// against future refactors that might move the absorb block out of
-// the active-echo-wait context.
+// inSendRawWithEchoActiveEchoWait reports whether at least one
+// goroutine on this Bus is currently inside the active echo-wait
+// phase of sendRawWithEcho — i.e. between a successful raw-byte
+// Write and the resolution of its echo. The predicate is bus-wide,
+// not goroutine-local; it answers "is any goroutine in echo wait?",
+// not "did the caller arrive via sendRawWithEcho?". For the only
+// current call site (the round-9 absorb predicate, itself inside
+// sendRawWithEcho) the predicate is always true and the gate is a
+// no-op assertion. The hook exists for Prometheus / future call
+// sites and documents the phase invariant explicitly.
 func (b *Bus) inSendRawWithEchoActiveEchoWait() bool {
 	return b.activeEchoWaits.Load() > 0
 }
 
-// Round9AbsorbFiredProxyMediated returns the cumulative count of
-// round-9 AUTO-SYN absorb predicate fires that occurred while the
-// bus was in the active echo-wait phase of sendRawWithEcho. Per
-// frame-atomic-v8 I8, the round-9 absorb code is RETAINED as the
-// legacy fallback for direct-adapter mode (where no proxy is
-// mediating wire AUTO-SYNs); this counter exists ONLY to power the
-// Prometheus alert `HelianthusRound9FiredUnderProxy` (v8 §1.12) which
-// fires when the adaptermux classifier is in `enforce` mode and
-// round-9 still fires (a v8 invariant violation indicating the proxy
-// is not correctly filtering wire AUTO-SYNs before they reach the
-// gateway's echo position).
+// Round9AbsorbEntered returns the cumulative count of round-9
+// AUTO-SYN absorb predicate fires that occurred while the bus was in
+// the active echo-wait phase of sendRawWithEcho. The counter is
+// deliberately named neutrally: this code has no notion of whether a
+// proxy is mediating wire AUTO-SYNs, so it counts every entry
+// regardless of deployment mode. The Prometheus alert that AND-s
+// this counter with the adaptermux classifier-mode label
+// (HelianthusRound9FiredUnderProxy — see helianthus-docs-ebus →
+// deployment/prometheus-alerts.md) is what makes the round-9-under-
+// proxy interpretation. Per frame-atomic-v8 I8 the round-9 absorb
+// code itself is RETAINED as the legacy fallback for direct-adapter
+// mode; expected steady-state under classifier_mode == enforce is
+// counter rate == 0.
 //
-// Operators MUST configure the alert in the gateway deployment
-// manifest (see helianthus-docs-ebus → deployment/prometheus-alerts)
-// with expression:
-//
-//	rate(helianthus_round9_absorb_fired_proxy_mediated_total[5m]) > 0
-//	  AND helianthus_adaptermux_classifier_mode == "enforce"
-//
-// The counter is safe to expose via Prometheus regardless of mode;
-// the gating happens in the alert rule, not in the code.
-func (b *Bus) Round9AbsorbFiredProxyMediated() uint64 {
-	return b.round9AbsorbFiredProxyMediated.Load()
+// Suggested Prometheus name: helianthus_round9_absorb_entered_total.
+// Pair with PayloadAaAutoSynAbsorbed / PayloadAaAutoSynRecovered /
+// PayloadAaAutoSynDrainExhausted for severity dashboards (per-byte
+// drained, recovery rate, cap exhaustion).
+func (b *Bus) Round9AbsorbEntered() uint64 {
+	return b.round9AbsorbEntered.Load()
 }
 
 func (b *Bus) emitAttemptComplete(request Frame, response *Frame, frameType FrameType, attempt uint16, startedAt time.Time) {

--- a/protocol/bus.go
+++ b/protocol/bus.go
@@ -130,6 +130,29 @@ type Bus struct {
 	payloadAaAutoSynAbsorbed       atomic.Uint64
 	payloadAaAutoSynRecovered      atomic.Uint64
 	payloadAaAutoSynDrainExhausted atomic.Uint64
+
+	// Phase 1 Step B4 (frame-atomic-v8 §1.8 / §1.12, retained per v8 I8):
+	// activeEchoWaits counts goroutines currently inside the active
+	// echo-wait phase of sendRawWithEcho — i.e. between the successful
+	// raw-byte write and the resolution of its echo (success, mismatch,
+	// or absorb-loop exit). The counter serves as the runtime predicate
+	// inSendRawWithEchoActiveEchoWait(): it MUST be > 0 at any code
+	// location that pretends to be operating on an in-flight echo.
+	//
+	// round9AbsorbFiredProxyMediated counts how many times the round-9
+	// AUTO-SYN absorb predicate fired while the active-echo-wait
+	// predicate held — i.e. legitimate round-9 fires from the
+	// sendRawWithEcho call-stack. Per v8 I8 the round-9 absorb code
+	// stays as a legacy fallback for direct-adapter mode; once the v8
+	// adaptermux classifier is enabled in `enforce`, the proxy MUST
+	// filter wire AUTO-SYNs before they reach the gateway's echo
+	// position, so this counter is expected to stay at zero. The
+	// Prometheus alert `HelianthusRound9FiredUnderProxy` (defined in
+	// helianthus-docs-ebus → gateway deploy manifest, NOT in this
+	// repo) watches the rate of this counter under proxy-mediated
+	// mode; any non-zero rate indicates a v8 invariant violation.
+	activeEchoWaits                atomic.Int32
+	round9AbsorbFiredProxyMediated atomic.Uint64
 }
 
 // NewBus initializes a Bus with transport, config, and optional queue capacity.
@@ -1019,6 +1042,17 @@ func (b *Bus) sendRawWithEcho(runCtx, reqCtx context.Context, raw byte, expectRa
 		Byte:    raw,
 	})
 
+	// Phase 1 Step B4 (frame-atomic-v8 §1.8): mark the bus as being in
+	// the active echo-wait phase from here until this call returns.
+	// inSendRawWithEchoActiveEchoWait() must hold for any round-9
+	// AUTO-SYN absorb fire to count toward the proxy-mediated alert
+	// counter — gating the increment on this predicate prevents future
+	// callers that mimic the absorb shape from outside the
+	// sendRawWithEcho call-stack from tripping the
+	// HelianthusRound9FiredUnderProxy alert (v8 §1.12).
+	b.activeEchoWaits.Add(1)
+	defer b.activeEchoWaits.Add(-1)
+
 	// F-23 (batch-19, Codex bot follow-up review on PR #154): for
 	// ENH-class transports, read the echo via the EscapeFlaggedReader
 	// path so we can distinguish a real wire SYN from an escape-
@@ -1161,6 +1195,21 @@ func (b *Bus) sendRawWithEcho(runCtx, reqCtx context.Context, raw byte, expectRa
 	// legitimate arbitration collisions where we wrote a non-SYN and
 	// the bus is idle (a real defect, not buffering interference).
 	if flagged != nil && !expectRawSyn && raw == SymbolSyn && echo == SymbolSyn && !echoWasEscaped {
+		// Phase 1 Step B4 (frame-atomic-v8 §1.8): the round-9 absorb
+		// predicate just fired. Gate the proxy-mediated alert counter on
+		// inSendRawWithEchoActiveEchoWait() — true here by construction
+		// (we are inside sendRawWithEcho between Write and echo
+		// resolution), but the explicit predicate documents the
+		// invariant and protects against future refactors that lift
+		// this absorb block out of the active-echo-wait call-stack.
+		// Round-9 absorb itself is RETAINED per v8 I8 as the legacy
+		// fallback for direct-adapter mode; this counter exists ONLY
+		// to power the HelianthusRound9FiredUnderProxy alert (v8 §1.12)
+		// which trips when the adaptermux classifier is in `enforce`
+		// and round-9 still fires (a v8 invariant violation).
+		if b.inSendRawWithEchoActiveEchoWait() {
+			b.round9AbsorbFiredProxyMediated.Add(1)
+		}
 		const maxPayloadAaAutoSynDrains = 3
 		absorbed := 0
 		drainExhausted := true // assume cap-exhausted; flipped to false on any non-SYN break
@@ -1456,6 +1505,47 @@ func (b *Bus) PayloadAaAutoSynRecovered() uint64 {
 // behavior for adapter-genuinely-stuck cases.
 func (b *Bus) PayloadAaAutoSynDrainExhausted() uint64 {
 	return b.payloadAaAutoSynDrainExhausted.Load()
+}
+
+// inSendRawWithEchoActiveEchoWait reports whether the current bus has
+// at least one goroutine currently inside the active echo-wait phase
+// of sendRawWithEcho — i.e. between a successful raw-byte Write and
+// the resolution of its echo. Phase 1 Step B4 (frame-atomic-v8 §1.8)
+// uses this predicate to gate the round-9 proxy-mediated alert
+// counter, ensuring that only round-9 absorb fires originating from
+// the sendRawWithEcho call-stack count toward the
+// HelianthusRound9FiredUnderProxy alert (v8 §1.12). The predicate is
+// always true at the round-9 absorb site by construction; making it
+// explicit documents the invariant and provides defense-in-depth
+// against future refactors that might move the absorb block out of
+// the active-echo-wait context.
+func (b *Bus) inSendRawWithEchoActiveEchoWait() bool {
+	return b.activeEchoWaits.Load() > 0
+}
+
+// Round9AbsorbFiredProxyMediated returns the cumulative count of
+// round-9 AUTO-SYN absorb predicate fires that occurred while the
+// bus was in the active echo-wait phase of sendRawWithEcho. Per
+// frame-atomic-v8 I8, the round-9 absorb code is RETAINED as the
+// legacy fallback for direct-adapter mode (where no proxy is
+// mediating wire AUTO-SYNs); this counter exists ONLY to power the
+// Prometheus alert `HelianthusRound9FiredUnderProxy` (v8 §1.12) which
+// fires when the adaptermux classifier is in `enforce` mode and
+// round-9 still fires (a v8 invariant violation indicating the proxy
+// is not correctly filtering wire AUTO-SYNs before they reach the
+// gateway's echo position).
+//
+// Operators MUST configure the alert in the gateway deployment
+// manifest (see helianthus-docs-ebus → deployment/prometheus-alerts)
+// with expression:
+//
+//	rate(helianthus_round9_absorb_fired_proxy_mediated_total[5m]) > 0
+//	  AND helianthus_adaptermux_classifier_mode == "enforce"
+//
+// The counter is safe to expose via Prometheus regardless of mode;
+// the gating happens in the alert rule, not in the code.
+func (b *Bus) Round9AbsorbFiredProxyMediated() uint64 {
+	return b.round9AbsorbFiredProxyMediated.Load()
 }
 
 func (b *Bus) emitAttemptComplete(request Frame, response *Frame, frameType FrameType, attempt uint16, startedAt time.Time) {

--- a/protocol/bus_round9_proxy_mediated_counter_test.go
+++ b/protocol/bus_round9_proxy_mediated_counter_test.go
@@ -1,0 +1,371 @@
+package protocol_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/Project-Helianthus/helianthus-ebusgo/protocol"
+)
+
+// Phase 1 Step B4 (frame-atomic-v8 §1.8, §1.12, retained per v8 I8):
+// the round-9 AUTO-SYN absorb code at the payload-0xAA echo site in
+// sendRawWithEcho stays as a legacy fallback for direct-adapter mode.
+// In adaptermux's `enforce` mode, the proxy MUST filter wire AUTO-SYNs
+// before they reach the gateway's echo position; if round-9 still fires
+// under that mode, the Prometheus alert HelianthusRound9FiredUnderProxy
+// trips. The Round9AbsorbFiredProxyMediated counter exposes the fires
+// from the gateway's perspective so the alert can be evaluated against
+// it AND classifier-mode label (the gating is in the alert rule, not in
+// the Go code — the counter just increments any time the round-9
+// absorb predicate fires within sendRawWithEcho's active echo-wait).
+//
+// These tests assert:
+//   - the new counter increments by exactly 1 per round-9 entry;
+//   - it stays at zero when round-9 never fires (clean echo path);
+//   - it tracks the existing PayloadAaAutoSynAbsorbed counter shape
+//     (per-fire, not per-byte-drained);
+//   - the inSendRawWithEchoActiveEchoWait() predicate is true at the
+//     absorb site by construction.
+
+// TestRound9AbsorbFiredProxyMediated_SingleEntry asserts that one
+// round-9 absorb entry (regardless of how many bytes are drained
+// inside the loop) increments the proxy-mediated counter exactly once.
+func TestRound9AbsorbFiredProxyMediated_SingleEntry(t *testing.T) {
+	t.Parallel()
+
+	tr := &echoF23TestTransport{unescaped: true}
+
+	bus := protocol.NewBus(tr, protocol.DefaultBusConfig(), 8)
+	runCtx, runCancel := context.WithCancel(context.Background())
+	defer runCancel()
+	bus.Run(runCtx)
+	ctx := context.Background()
+
+	frame := protocol.Frame{
+		Source:    0x10,
+		Target:    protocol.AddressBroadcast,
+		Primary:   0xB5,
+		Secondary: 0x16,
+		Data:      []byte{protocol.SymbolSyn},
+	}
+	telegram := []byte{
+		protocol.AddressBroadcast, 0xB5, 0x16, 0x01, protocol.SymbolSyn,
+	}
+	telegram = append(telegram, protocol.CRC(append([]byte{0x10}, telegram...)))
+
+	tr.mu.Lock()
+	tr.echo = nil
+	for _, b := range telegram[:4] {
+		tr.echo = append(tr.echo, echoF23Event{value: b, wasEscaped: false})
+	}
+	// Byte 4 echo slot: one wire AUTO-SYN, then real escape-decoded
+	// payload echo. Round-9 absorb predicate fires once.
+	tr.echo = append(tr.echo,
+		echoF23Event{value: protocol.SymbolSyn, wasEscaped: false},
+		echoF23Event{value: protocol.SymbolSyn, wasEscaped: true},
+	)
+	tr.echo = append(tr.echo, echoF23Event{value: telegram[5], wasEscaped: false})
+	tr.echo = append(tr.echo, echoF23Event{value: protocol.SymbolSyn, wasEscaped: false})
+	tr.mu.Unlock()
+
+	if _, err := bus.Send(ctx, frame); err != nil {
+		t.Fatalf("Send error = %v; want nil", err)
+	}
+
+	if got := bus.Round9AbsorbFiredProxyMediated(); got != 1 {
+		t.Errorf("Round9AbsorbFiredProxyMediated() = %d; want 1 (single round-9 entry)", got)
+	}
+	if got := bus.PayloadAaAutoSynAbsorbed(); got != 1 {
+		t.Errorf("PayloadAaAutoSynAbsorbed() = %d; want 1", got)
+	}
+}
+
+// TestRound9AbsorbFiredProxyMediated_PerEntryNotPerByte asserts that
+// when the absorb loop drains multiple bytes within a single entry,
+// the proxy-mediated counter still increments by ONE (per-fire
+// semantics, not per-byte). This distinguishes it from
+// PayloadAaAutoSynAbsorbed which counts per drained byte.
+func TestRound9AbsorbFiredProxyMediated_PerEntryNotPerByte(t *testing.T) {
+	t.Parallel()
+
+	tr := &echoF23TestTransport{unescaped: true}
+
+	bus := protocol.NewBus(tr, protocol.DefaultBusConfig(), 8)
+	runCtx, runCancel := context.WithCancel(context.Background())
+	defer runCancel()
+	bus.Run(runCtx)
+	ctx := context.Background()
+
+	frame := protocol.Frame{
+		Source:    0x10,
+		Target:    protocol.AddressBroadcast,
+		Primary:   0xB5,
+		Secondary: 0x16,
+		Data:      []byte{protocol.SymbolSyn},
+	}
+	telegram := []byte{
+		protocol.AddressBroadcast, 0xB5, 0x16, 0x01, protocol.SymbolSyn,
+	}
+	telegram = append(telegram, protocol.CRC(append([]byte{0x10}, telegram...)))
+
+	tr.mu.Lock()
+	tr.echo = nil
+	for _, b := range telegram[:4] {
+		tr.echo = append(tr.echo, echoF23Event{value: b, wasEscaped: false})
+	}
+	// Byte 4 echo slot: two wire AUTO-SYNs (one entry + one drain
+	// iteration), then real escape-decoded echo. The absorb predicate
+	// is checked once on entry — the loop drains the second AUTO-SYN
+	// internally without re-firing the predicate.
+	tr.echo = append(tr.echo,
+		echoF23Event{value: protocol.SymbolSyn, wasEscaped: false},
+		echoF23Event{value: protocol.SymbolSyn, wasEscaped: false},
+		echoF23Event{value: protocol.SymbolSyn, wasEscaped: true},
+	)
+	tr.echo = append(tr.echo, echoF23Event{value: telegram[5], wasEscaped: false})
+	tr.echo = append(tr.echo, echoF23Event{value: protocol.SymbolSyn, wasEscaped: false})
+	tr.mu.Unlock()
+
+	if _, err := bus.Send(ctx, frame); err != nil {
+		t.Fatalf("Send error = %v; want nil", err)
+	}
+
+	if got := bus.Round9AbsorbFiredProxyMediated(); got != 1 {
+		t.Errorf("Round9AbsorbFiredProxyMediated() = %d; want 1 (per-entry, not per-byte)", got)
+	}
+	// Per-byte counter should report 2 — the predicate fires once on
+	// entry, but two AUTO-SYN bytes are drained.
+	if got := bus.PayloadAaAutoSynAbsorbed(); got != 2 {
+		t.Errorf("PayloadAaAutoSynAbsorbed() = %d; want 2 (per-byte)", got)
+	}
+}
+
+// TestRound9AbsorbFiredProxyMediated_StaysZeroOnCleanEcho asserts the
+// expected steady-state under the v8 enforce contract: when the proxy
+// correctly filters wire AUTO-SYNs (no round-9 entry is needed), the
+// counter stays at zero and the HelianthusRound9FiredUnderProxy alert
+// remains silent.
+func TestRound9AbsorbFiredProxyMediated_StaysZeroOnCleanEcho(t *testing.T) {
+	t.Parallel()
+
+	tr := &echoF23TestTransport{unescaped: true}
+
+	bus := protocol.NewBus(tr, protocol.DefaultBusConfig(), 8)
+	runCtx, runCancel := context.WithCancel(context.Background())
+	defer runCancel()
+	bus.Run(runCtx)
+	ctx := context.Background()
+
+	frame := protocol.Frame{
+		Source:    0x10,
+		Target:    protocol.AddressBroadcast,
+		Primary:   0xB5,
+		Secondary: 0x16,
+		Data:      []byte{protocol.SymbolSyn},
+	}
+	telegram := []byte{
+		protocol.AddressBroadcast, 0xB5, 0x16, 0x01, protocol.SymbolSyn,
+	}
+	telegram = append(telegram, protocol.CRC(append([]byte{0x10}, telegram...)))
+
+	tr.mu.Lock()
+	tr.echo = nil
+	for _, b := range telegram[:4] {
+		tr.echo = append(tr.echo, echoF23Event{value: b, wasEscaped: false})
+	}
+	// Byte 4 echo slot: real escape-decoded echo arrives immediately,
+	// no wire AUTO-SYN interference. Round-9 absorb predicate stays
+	// false — counter must remain at zero.
+	tr.echo = append(tr.echo,
+		echoF23Event{value: protocol.SymbolSyn, wasEscaped: true},
+	)
+	tr.echo = append(tr.echo, echoF23Event{value: telegram[5], wasEscaped: false})
+	tr.echo = append(tr.echo, echoF23Event{value: protocol.SymbolSyn, wasEscaped: false})
+	tr.mu.Unlock()
+
+	if _, err := bus.Send(ctx, frame); err != nil {
+		t.Fatalf("Send error = %v; want nil", err)
+	}
+
+	if got := bus.Round9AbsorbFiredProxyMediated(); got != 0 {
+		t.Errorf("Round9AbsorbFiredProxyMediated() = %d; want 0 (no round-9 entry under clean echo)", got)
+	}
+	if got := bus.PayloadAaAutoSynAbsorbed(); got != 0 {
+		t.Errorf("PayloadAaAutoSynAbsorbed() = %d; want 0", got)
+	}
+}
+
+// TestRound9AbsorbFiredProxyMediated_CapExhaustedStillCounts asserts
+// that even when the absorb loop reaches its cap without recovery
+// (drainExhausted path), the counter still increments — the predicate
+// fires regardless of the absorb outcome. This is critical for the
+// alert: a failing round-9 entry is still a v8 invariant violation
+// under proxy-mediated mode.
+func TestRound9AbsorbFiredProxyMediated_CapExhaustedStillCounts(t *testing.T) {
+	t.Parallel()
+
+	tr := &echoF23TestTransport{unescaped: true}
+
+	bus := protocol.NewBus(tr, protocol.DefaultBusConfig(), 8)
+	runCtx, runCancel := context.WithCancel(context.Background())
+	defer runCancel()
+	bus.Run(runCtx)
+	ctx := context.Background()
+
+	frame := protocol.Frame{
+		Source:    0x10,
+		Target:    protocol.AddressBroadcast,
+		Primary:   0xB5,
+		Secondary: 0x16,
+		Data:      []byte{protocol.SymbolSyn},
+	}
+	telegram := []byte{
+		protocol.AddressBroadcast, 0xB5, 0x16, 0x01, protocol.SymbolSyn,
+	}
+	telegram = append(telegram, protocol.CRC(append([]byte{0x10}, telegram...)))
+
+	tr.mu.Lock()
+	tr.echo = nil
+	for _, b := range telegram[:4] {
+		tr.echo = append(tr.echo, echoF23Event{value: b, wasEscaped: false})
+	}
+	// Byte 4 echo slot: cap+1 wire AUTO-SYNs in a row. Round-9
+	// predicate fires on entry, drain loop exhausts the cap (3) without
+	// finding the real echo, falls through to echo_mismatch /
+	// ErrBusCollision.
+	for i := 0; i < 4; i++ {
+		tr.echo = append(tr.echo, echoF23Event{value: protocol.SymbolSyn, wasEscaped: false})
+	}
+	tr.mu.Unlock()
+
+	if _, err := bus.Send(ctx, frame); err == nil {
+		t.Fatalf("Send error = nil; want non-nil (cap exhausted should error)")
+	}
+
+	// Counter must increment EVEN when the absorb attempt fails — the
+	// fire happened, the alert should observe it.
+	if got := bus.Round9AbsorbFiredProxyMediated(); got != 1 {
+		t.Errorf("Round9AbsorbFiredProxyMediated() = %d; want 1 (predicate fired even on exhaustion)", got)
+	}
+	if got := bus.PayloadAaAutoSynDrainExhausted(); got != 1 {
+		t.Errorf("PayloadAaAutoSynDrainExhausted() = %d; want 1", got)
+	}
+}
+
+// TestRound9AbsorbFiredProxyMediated_AccumulatesAcrossSends asserts
+// monotonic accumulation across multiple Send() calls — each round-9
+// entry adds 1, and the counter never decrements.
+func TestRound9AbsorbFiredProxyMediated_AccumulatesAcrossSends(t *testing.T) {
+	t.Parallel()
+
+	tr := &echoF23TestTransport{unescaped: true}
+
+	bus := protocol.NewBus(tr, protocol.DefaultBusConfig(), 8)
+	runCtx, runCancel := context.WithCancel(context.Background())
+	defer runCancel()
+	bus.Run(runCtx)
+	ctx := context.Background()
+
+	makeFrame := func() protocol.Frame {
+		return protocol.Frame{
+			Source:    0x10,
+			Target:    protocol.AddressBroadcast,
+			Primary:   0xB5,
+			Secondary: 0x16,
+			Data:      []byte{protocol.SymbolSyn},
+		}
+	}
+	makeTelegram := func() []byte {
+		t := []byte{
+			protocol.AddressBroadcast, 0xB5, 0x16, 0x01, protocol.SymbolSyn,
+		}
+		return append(t, protocol.CRC(append([]byte{0x10}, t...)))
+	}
+
+	for i := 0; i < 3; i++ {
+		telegram := makeTelegram()
+		tr.mu.Lock()
+		tr.echo = nil
+		for _, b := range telegram[:4] {
+			tr.echo = append(tr.echo, echoF23Event{value: b, wasEscaped: false})
+		}
+		tr.echo = append(tr.echo,
+			echoF23Event{value: protocol.SymbolSyn, wasEscaped: false},
+			echoF23Event{value: protocol.SymbolSyn, wasEscaped: true},
+		)
+		tr.echo = append(tr.echo, echoF23Event{value: telegram[5], wasEscaped: false})
+		tr.echo = append(tr.echo, echoF23Event{value: protocol.SymbolSyn, wasEscaped: false})
+		tr.mu.Unlock()
+
+		if _, err := bus.Send(ctx, makeFrame()); err != nil {
+			t.Fatalf("Send #%d error = %v; want nil", i, err)
+		}
+	}
+
+	if got := bus.Round9AbsorbFiredProxyMediated(); got != 3 {
+		t.Errorf("Round9AbsorbFiredProxyMediated() = %d; want 3 (one fire per Send)", got)
+	}
+}
+
+// TestRound9AbsorbFiredProxyMediated_ConcurrentSendsRaceFree exercises
+// the atomic counter under concurrent senders. We don't claim
+// strict ordering — only that the final count equals the number of
+// expected round-9 entries with no torn reads/writes.
+func TestRound9AbsorbFiredProxyMediated_ConcurrentSendsRaceFree(t *testing.T) {
+	t.Parallel()
+
+	tr := &echoF23TestTransport{unescaped: true}
+
+	// Pre-seed enough echo slots for 5 sequential Send() calls. The
+	// transport mutex serializes Write→Read pairs at the test harness
+	// level, so even with concurrent goroutines the sequencing is
+	// well-defined; we only verify the counter accumulates correctly.
+	telegramBase := []byte{
+		protocol.AddressBroadcast, 0xB5, 0x16, 0x01, protocol.SymbolSyn,
+	}
+	telegramBase = append(telegramBase, protocol.CRC(append([]byte{0x10}, telegramBase...)))
+
+	const n = 5
+	tr.mu.Lock()
+	tr.echo = nil
+	for i := 0; i < n; i++ {
+		for _, b := range telegramBase[:4] {
+			tr.echo = append(tr.echo, echoF23Event{value: b, wasEscaped: false})
+		}
+		tr.echo = append(tr.echo,
+			echoF23Event{value: protocol.SymbolSyn, wasEscaped: false},
+			echoF23Event{value: protocol.SymbolSyn, wasEscaped: true},
+		)
+		tr.echo = append(tr.echo, echoF23Event{value: telegramBase[5], wasEscaped: false})
+		tr.echo = append(tr.echo, echoF23Event{value: protocol.SymbolSyn, wasEscaped: false})
+	}
+	tr.mu.Unlock()
+
+	bus := protocol.NewBus(tr, protocol.DefaultBusConfig(), 16)
+	runCtx, runCancel := context.WithCancel(context.Background())
+	defer runCancel()
+	bus.Run(runCtx)
+	ctx := context.Background()
+
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func() {
+			defer wg.Done()
+			frame := protocol.Frame{
+				Source:    0x10,
+				Target:    protocol.AddressBroadcast,
+				Primary:   0xB5,
+				Secondary: 0x16,
+				Data:      []byte{protocol.SymbolSyn},
+			}
+			_, _ = bus.Send(ctx, frame)
+		}()
+	}
+	wg.Wait()
+
+	if got := bus.Round9AbsorbFiredProxyMediated(); got != n {
+		t.Errorf("Round9AbsorbFiredProxyMediated() = %d; want %d (concurrent monotonic)", got, n)
+	}
+}

--- a/protocol/bus_round9_proxy_mediated_counter_test.go
+++ b/protocol/bus_round9_proxy_mediated_counter_test.go
@@ -2,11 +2,57 @@ package protocol_test
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"testing"
 
+	ebuserrors "github.com/Project-Helianthus/helianthus-ebusgo/errors"
 	"github.com/Project-Helianthus/helianthus-ebusgo/protocol"
+	"github.com/Project-Helianthus/helianthus-ebusgo/transport"
 )
+
+// writeFailTransport returns an error from Write after a configured
+// number of successful writes. Used to assert that a Write-phase
+// error in sendRawWithEcho does NOT increment Round9AbsorbEntered
+// and leaves no lingering active-echo-wait state on the Bus.
+type writeFailTransport struct {
+	mu          sync.Mutex
+	writes      int
+	failOnWrite int // 1 = fail on the FIRST write (no successful writes), 2 = fail on the 2nd, ...
+}
+
+var (
+	_ transport.RawTransport        = (*writeFailTransport)(nil)
+	_ transport.EscapeAware         = (*writeFailTransport)(nil)
+	_ transport.EscapeFlaggedReader = (*writeFailTransport)(nil)
+)
+
+var errSyntheticWriteFailure = errors.New("synthetic write failure")
+
+func (t *writeFailTransport) ReadByte() (byte, error) {
+	// Never expected to be invoked — Write errors before any echo wait.
+	return 0, ebuserrors.ErrTimeout
+}
+
+func (t *writeFailTransport) ReadByteWithEscape() (byte, bool, error) {
+	return 0, false, ebuserrors.ErrTimeout
+}
+
+func (t *writeFailTransport) Write(payload []byte) (int, error) {
+	t.mu.Lock()
+	t.writes++
+	w := t.writes
+	t.mu.Unlock()
+	if t.failOnWrite > 0 && w >= t.failOnWrite {
+		return 0, errSyntheticWriteFailure
+	}
+	return len(payload), nil
+}
+
+func (t *writeFailTransport) Close() error                  { return nil }
+func (t *writeFailTransport) BytesAreUnescaped() bool       { return true }
+func (t *writeFailTransport) StartArbitration(byte) error   { return nil }
+func (t *writeFailTransport) ArbitrationSendsSource() bool  { return true }
 
 // Phase 1 Step B4 (frame-atomic-v8 §1.8, §1.12, retained per v8 I8):
 // the round-9 AUTO-SYN absorb code at the payload-0xAA echo site in
@@ -14,7 +60,7 @@ import (
 // In adaptermux's `enforce` mode, the proxy MUST filter wire AUTO-SYNs
 // before they reach the gateway's echo position; if round-9 still fires
 // under that mode, the Prometheus alert HelianthusRound9FiredUnderProxy
-// trips. The Round9AbsorbFiredProxyMediated counter exposes the fires
+// trips. The Round9AbsorbEntered counter exposes the fires
 // from the gateway's perspective so the alert can be evaluated against
 // it AND classifier-mode label (the gating is in the alert rule, not in
 // the Go code — the counter just increments any time the round-9
@@ -28,10 +74,10 @@ import (
 //   - the inSendRawWithEchoActiveEchoWait() predicate is true at the
 //     absorb site by construction.
 
-// TestRound9AbsorbFiredProxyMediated_SingleEntry asserts that one
+// TestRound9AbsorbEntered_SingleEntry asserts that one
 // round-9 absorb entry (regardless of how many bytes are drained
 // inside the loop) increments the proxy-mediated counter exactly once.
-func TestRound9AbsorbFiredProxyMediated_SingleEntry(t *testing.T) {
+func TestRound9AbsorbEntered_SingleEntry(t *testing.T) {
 	t.Parallel()
 
 	tr := &echoF23TestTransport{unescaped: true}
@@ -73,20 +119,20 @@ func TestRound9AbsorbFiredProxyMediated_SingleEntry(t *testing.T) {
 		t.Fatalf("Send error = %v; want nil", err)
 	}
 
-	if got := bus.Round9AbsorbFiredProxyMediated(); got != 1 {
-		t.Errorf("Round9AbsorbFiredProxyMediated() = %d; want 1 (single round-9 entry)", got)
+	if got := bus.Round9AbsorbEntered(); got != 1 {
+		t.Errorf("Round9AbsorbEntered() = %d; want 1 (single round-9 entry)", got)
 	}
 	if got := bus.PayloadAaAutoSynAbsorbed(); got != 1 {
 		t.Errorf("PayloadAaAutoSynAbsorbed() = %d; want 1", got)
 	}
 }
 
-// TestRound9AbsorbFiredProxyMediated_PerEntryNotPerByte asserts that
+// TestRound9AbsorbEntered_PerEntryNotPerByte asserts that
 // when the absorb loop drains multiple bytes within a single entry,
 // the proxy-mediated counter still increments by ONE (per-fire
 // semantics, not per-byte). This distinguishes it from
 // PayloadAaAutoSynAbsorbed which counts per drained byte.
-func TestRound9AbsorbFiredProxyMediated_PerEntryNotPerByte(t *testing.T) {
+func TestRound9AbsorbEntered_PerEntryNotPerByte(t *testing.T) {
 	t.Parallel()
 
 	tr := &echoF23TestTransport{unescaped: true}
@@ -131,8 +177,8 @@ func TestRound9AbsorbFiredProxyMediated_PerEntryNotPerByte(t *testing.T) {
 		t.Fatalf("Send error = %v; want nil", err)
 	}
 
-	if got := bus.Round9AbsorbFiredProxyMediated(); got != 1 {
-		t.Errorf("Round9AbsorbFiredProxyMediated() = %d; want 1 (per-entry, not per-byte)", got)
+	if got := bus.Round9AbsorbEntered(); got != 1 {
+		t.Errorf("Round9AbsorbEntered() = %d; want 1 (per-entry, not per-byte)", got)
 	}
 	// Per-byte counter should report 2 — the predicate fires once on
 	// entry, but two AUTO-SYN bytes are drained.
@@ -141,12 +187,12 @@ func TestRound9AbsorbFiredProxyMediated_PerEntryNotPerByte(t *testing.T) {
 	}
 }
 
-// TestRound9AbsorbFiredProxyMediated_StaysZeroOnCleanEcho asserts the
+// TestRound9AbsorbEntered_StaysZeroOnCleanEcho asserts the
 // expected steady-state under the v8 enforce contract: when the proxy
 // correctly filters wire AUTO-SYNs (no round-9 entry is needed), the
 // counter stays at zero and the HelianthusRound9FiredUnderProxy alert
 // remains silent.
-func TestRound9AbsorbFiredProxyMediated_StaysZeroOnCleanEcho(t *testing.T) {
+func TestRound9AbsorbEntered_StaysZeroOnCleanEcho(t *testing.T) {
 	t.Parallel()
 
 	tr := &echoF23TestTransport{unescaped: true}
@@ -188,21 +234,21 @@ func TestRound9AbsorbFiredProxyMediated_StaysZeroOnCleanEcho(t *testing.T) {
 		t.Fatalf("Send error = %v; want nil", err)
 	}
 
-	if got := bus.Round9AbsorbFiredProxyMediated(); got != 0 {
-		t.Errorf("Round9AbsorbFiredProxyMediated() = %d; want 0 (no round-9 entry under clean echo)", got)
+	if got := bus.Round9AbsorbEntered(); got != 0 {
+		t.Errorf("Round9AbsorbEntered() = %d; want 0 (no round-9 entry under clean echo)", got)
 	}
 	if got := bus.PayloadAaAutoSynAbsorbed(); got != 0 {
 		t.Errorf("PayloadAaAutoSynAbsorbed() = %d; want 0", got)
 	}
 }
 
-// TestRound9AbsorbFiredProxyMediated_CapExhaustedStillCounts asserts
+// TestRound9AbsorbEntered_CapExhaustedStillCounts asserts
 // that even when the absorb loop reaches its cap without recovery
 // (drainExhausted path), the counter still increments — the predicate
 // fires regardless of the absorb outcome. This is critical for the
 // alert: a failing round-9 entry is still a v8 invariant violation
 // under proxy-mediated mode.
-func TestRound9AbsorbFiredProxyMediated_CapExhaustedStillCounts(t *testing.T) {
+func TestRound9AbsorbEntered_CapExhaustedStillCounts(t *testing.T) {
 	t.Parallel()
 
 	tr := &echoF23TestTransport{unescaped: true}
@@ -245,18 +291,18 @@ func TestRound9AbsorbFiredProxyMediated_CapExhaustedStillCounts(t *testing.T) {
 
 	// Counter must increment EVEN when the absorb attempt fails — the
 	// fire happened, the alert should observe it.
-	if got := bus.Round9AbsorbFiredProxyMediated(); got != 1 {
-		t.Errorf("Round9AbsorbFiredProxyMediated() = %d; want 1 (predicate fired even on exhaustion)", got)
+	if got := bus.Round9AbsorbEntered(); got != 1 {
+		t.Errorf("Round9AbsorbEntered() = %d; want 1 (predicate fired even on exhaustion)", got)
 	}
 	if got := bus.PayloadAaAutoSynDrainExhausted(); got != 1 {
 		t.Errorf("PayloadAaAutoSynDrainExhausted() = %d; want 1", got)
 	}
 }
 
-// TestRound9AbsorbFiredProxyMediated_AccumulatesAcrossSends asserts
+// TestRound9AbsorbEntered_AccumulatesAcrossSends asserts
 // monotonic accumulation across multiple Send() calls — each round-9
 // entry adds 1, and the counter never decrements.
-func TestRound9AbsorbFiredProxyMediated_AccumulatesAcrossSends(t *testing.T) {
+func TestRound9AbsorbEntered_AccumulatesAcrossSends(t *testing.T) {
 	t.Parallel()
 
 	tr := &echoF23TestTransport{unescaped: true}
@@ -303,16 +349,16 @@ func TestRound9AbsorbFiredProxyMediated_AccumulatesAcrossSends(t *testing.T) {
 		}
 	}
 
-	if got := bus.Round9AbsorbFiredProxyMediated(); got != 3 {
-		t.Errorf("Round9AbsorbFiredProxyMediated() = %d; want 3 (one fire per Send)", got)
+	if got := bus.Round9AbsorbEntered(); got != 3 {
+		t.Errorf("Round9AbsorbEntered() = %d; want 3 (one fire per Send)", got)
 	}
 }
 
-// TestRound9AbsorbFiredProxyMediated_ConcurrentSendsRaceFree exercises
+// TestRound9AbsorbEntered_ConcurrentSendsRaceFree exercises
 // the atomic counter under concurrent senders. We don't claim
 // strict ordering — only that the final count equals the number of
 // expected round-9 entries with no torn reads/writes.
-func TestRound9AbsorbFiredProxyMediated_ConcurrentSendsRaceFree(t *testing.T) {
+func TestRound9AbsorbEntered_ConcurrentSendsRaceFree(t *testing.T) {
 	t.Parallel()
 
 	tr := &echoF23TestTransport{unescaped: true}
@@ -365,7 +411,64 @@ func TestRound9AbsorbFiredProxyMediated_ConcurrentSendsRaceFree(t *testing.T) {
 	}
 	wg.Wait()
 
-	if got := bus.Round9AbsorbFiredProxyMediated(); got != n {
-		t.Errorf("Round9AbsorbFiredProxyMediated() = %d; want %d (concurrent monotonic)", got, n)
+	if got := bus.Round9AbsorbEntered(); got != n {
+		t.Errorf("Round9AbsorbEntered() = %d; want %d (concurrent monotonic)", got, n)
+	}
+}
+
+// TestRound9AbsorbEntered_WriteErrorLeavesCounterAtZero asserts the
+// write-phase error boundary: when transport.Write fails before
+// sendRawWithEcho enters the active-echo-wait phase, the counter MUST
+// NOT increment and the activeEchoWaits predicate MUST NOT be stuck
+// at >0. The latter is asserted indirectly via a SUBSEQUENT Send call:
+// if the predicate were leaked, the next round-9 fire would either
+// double-count or never re-enter (depending on the leak shape). We
+// use two failed sends in a row plus a count assertion to give the
+// leak a chance to surface.
+func TestRound9AbsorbEntered_WriteErrorLeavesCounterAtZero(t *testing.T) {
+	t.Parallel()
+
+	// Fail on the FIRST Write — sendRawWithEcho returns immediately
+	// without ever incrementing activeEchoWaits or reaching the
+	// round-9 absorb block.
+	tr := &writeFailTransport{failOnWrite: 1}
+
+	bus := protocol.NewBus(tr, protocol.DefaultBusConfig(), 8)
+	runCtx, runCancel := context.WithCancel(context.Background())
+	defer runCancel()
+	bus.Run(runCtx)
+
+	// Bounded context so the Bus does not retry on transport-error
+	// classifications that route through the retry policy.
+	sendCtx, sendCancel := context.WithCancel(context.Background())
+	defer sendCancel()
+
+	for i := 0; i < 2; i++ {
+		frame := protocol.Frame{
+			Source:    0x10,
+			Target:    protocol.AddressBroadcast,
+			Primary:   0xB5,
+			Secondary: 0x16,
+			Data:      []byte{0x01},
+		}
+		_, err := bus.Send(sendCtx, frame)
+		if err == nil {
+			t.Fatalf("Send #%d returned nil; want error (transport.Write must fail)", i)
+		}
+	}
+
+	if got := bus.Round9AbsorbEntered(); got != 0 {
+		t.Errorf("Round9AbsorbEntered() = %d; want 0 (Write error must not enter absorb block)", got)
+	}
+	// PayloadAaAutoSynAbsorbed/Recovered/DrainExhausted must also be
+	// 0 — Write error is a transport-layer fault, not an absorb event.
+	if got := bus.PayloadAaAutoSynAbsorbed(); got != 0 {
+		t.Errorf("PayloadAaAutoSynAbsorbed() = %d; want 0", got)
+	}
+	if got := bus.PayloadAaAutoSynRecovered(); got != 0 {
+		t.Errorf("PayloadAaAutoSynRecovered() = %d; want 0", got)
+	}
+	if got := bus.PayloadAaAutoSynDrainExhausted(); got != 0 {
+		t.Errorf("PayloadAaAutoSynDrainExhausted() = %d; want 0", got)
 	}
 }

--- a/protocol/bus_round9_proxy_mediated_counter_test.go
+++ b/protocol/bus_round9_proxy_mediated_counter_test.go
@@ -76,7 +76,7 @@ func (t *writeFailTransport) ArbitrationSendsSource() bool  { return true }
 
 // TestRound9AbsorbEntered_SingleEntry asserts that one
 // round-9 absorb entry (regardless of how many bytes are drained
-// inside the loop) increments the proxy-mediated counter exactly once.
+// inside the loop) increments the round9AbsorbEntered counter exactly once.
 func TestRound9AbsorbEntered_SingleEntry(t *testing.T) {
 	t.Parallel()
 
@@ -129,7 +129,7 @@ func TestRound9AbsorbEntered_SingleEntry(t *testing.T) {
 
 // TestRound9AbsorbEntered_PerEntryNotPerByte asserts that
 // when the absorb loop drains multiple bytes within a single entry,
-// the proxy-mediated counter still increments by ONE (per-fire
+// the round9AbsorbEntered counter still increments by ONE (per-fire
 // semantics, not per-byte). This distinguishes it from
 // PayloadAaAutoSynAbsorbed which counts per drained byte.
 func TestRound9AbsorbEntered_PerEntryNotPerByte(t *testing.T) {
@@ -247,7 +247,7 @@ func TestRound9AbsorbEntered_StaysZeroOnCleanEcho(t *testing.T) {
 // (drainExhausted path), the counter still increments — the predicate
 // fires regardless of the absorb outcome. This is critical for the
 // alert: a failing round-9 entry is still a v8 invariant violation
-// under proxy-mediated mode.
+// when the alert that gates on classifier_mode == enforce fires.
 func TestRound9AbsorbEntered_CapExhaustedStillCounts(t *testing.T) {
 	t.Parallel()
 
@@ -418,13 +418,17 @@ func TestRound9AbsorbEntered_ConcurrentSendsRaceFree(t *testing.T) {
 
 // TestRound9AbsorbEntered_WriteErrorLeavesCounterAtZero asserts the
 // write-phase error boundary: when transport.Write fails before
-// sendRawWithEcho enters the active-echo-wait phase, the counter MUST
-// NOT increment and the activeEchoWaits predicate MUST NOT be stuck
-// at >0. The latter is asserted indirectly via a SUBSEQUENT Send call:
-// if the predicate were leaked, the next round-9 fire would either
-// double-count or never re-enter (depending on the leak shape). We
-// use two failed sends in a row plus a count assertion to give the
-// leak a chance to surface.
+// sendRawWithEcho enters the active-echo-wait phase, the
+// Round9AbsorbEntered and PayloadAaAutoSyn* counters MUST NOT
+// increment. This is the boundary the test actually proves — with
+// failOnWrite=1 the function returns before activeEchoWaits.Add(1),
+// so by construction the predicate is never bumped. A "predicate
+// leak" test would need a separate scenario where Write succeeds,
+// the increment-and-defer registers, and the function returns
+// abnormally (panic, runtime.Goexit, etc.); this test is not that
+// scenario. Two sequential failed sends are used purely to confirm
+// the counters stay at zero across multiple attempts (no monotonic
+// surprise).
 func TestRound9AbsorbEntered_WriteErrorLeavesCounterAtZero(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

Phase 1 Step B4 of the frame-atomic-visibility v8 rollout — adds the
proxy-mediated alert counter for the round-9 AUTO-SYN absorb path in
`sendRawWithEcho`, gated on the new `inSendRawWithEchoActiveEchoWait()`
runtime predicate.

Per [frame-atomic-visibility-v8 §1.8 / I8](https://github.com/Project-Helianthus/helianthus-docs-ebus/blob/frame-atomic-visibility/architecture/adaptermux/frame-atomic-visibility-v8.md):

- Round-9 absorb code itself is **RETAINED** as the legacy fallback for
  direct-adapter mode (no proxy mediating wire AUTO-SYNs).
- New counter `Round9AbsorbFiredProxyMediated` (Prometheus name
  `helianthus_round9_absorb_fired_proxy_mediated_total`) exposes round-9
  fires so the operator-side alert
  `HelianthusRound9FiredUnderProxy` (v8 §1.12) can observe the v8
  invariant violation: round-9 firing under adaptermux classifier
  `enforce` mode means the proxy is NOT correctly filtering wire
  AUTO-SYNs before they reach the gateway's echo position.
- The Go code does NOT consult the classifier mode. Gating against
  `classifier_mode == enforce` lives in the Prometheus alert rule (see
  companion docs PR).

## Changes

- `Bus.activeEchoWaits atomic.Int32` — incremented on
  `sendRawWithEcho` post-Write phase entry; decremented via `defer`.
- `Bus.round9AbsorbFiredProxyMediated atomic.Uint64` — incremented at
  round-9 absorb predicate-true entry, gated on
  `inSendRawWithEchoActiveEchoWait()`.
- `Bus.inSendRawWithEchoActiveEchoWait() bool` — runtime predicate.
- `Bus.Round9AbsorbFiredProxyMediated() uint64` — accessor.

## Tests (6 new, all green under `-race`)

| Test | Asserts |
|---|---|
| `SingleEntry` | 1 round-9 fire → counter = 1 |
| `PerEntryNotPerByte` | 2 bytes drained, 1 entry → counter = 1 |
| `StaysZeroOnCleanEcho` | no absorb fire → counter = 0 |
| `CapExhaustedStillCounts` | absorb cap-exhausted → counter still increments (the fire IS the alert event, regardless of recovery outcome) |
| `AccumulatesAcrossSends` | 3 sequential entries → counter = 3 |
| `ConcurrentSendsRaceFree` | 5 concurrent senders → counter = 5 |

## Test plan

- [x] `go test ./protocol/ -run 'Round9AbsorbFiredProxyMediated' -count=1 -race` — all 6 new tests pass
- [x] `go test ./... -count=1 -race` — full suite green, no regressions
- [x] `go vet ./...` — clean
- [x] `go build ./...` — clean
- [x] Terminology gate (GH Actions exclusion list) — clean
- [x] Public symbol gate — clean

## References

- frame-atomic-visibility-v8 §1.8 — predicate gating rationale
- frame-atomic-visibility-v8 §1.12 — alert deployment ownership
- frame-atomic-visibility-v8 I8 — round-9 retained as legacy fallback
- Companion docs PR (helianthus-docs-ebus): Prometheus alert rule definition

🤖 Generated with [Claude Code](https://claude.com/claude-code)