### PR TITLE
Phase 1 Step B1 (corrected): v8 AA-aware escape decoder in ebusgo transport

### DIFF
--- a/transport/apply_escape_admin_event_test.go
+++ b/transport/apply_escape_admin_event_test.go
@@ -1,0 +1,187 @@
+package transport
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// Phase 1 Step B1 (frame-atomic-visibility v8 §1.3 / §5, invariant
+// I4): deterministic unit tests for applyEscapeAdminEvent — the
+// admin-event-to-counter routing extracted from
+// feedEscapeDecoderLocked per Codex round-3 review on PR #165.
+//
+// The integration tests in enh_transport_v8_counters_test.go cover
+// the wiring for Recovery, BudgetExhausted, and AaAbsorbed via the
+// end-to-end ENH stream path. The wall-clock timeout case cannot be
+// integration-tested deterministically (see the NOTE in that file
+// + Codex round-2 finding) because net.Pipe.Write returning does
+// not prove the decoder has been fed yet. These pure-function tests
+// close that gap: they feed each AdminEvent kind into
+// applyEscapeAdminEvent directly and assert the counter side-effects
+// PLUS the dropEmission return value, without depending on
+// scheduler timing or net.Pipe semantics.
+
+// pinPendingTimeout asserts that AdminEventEscapePendingTimeout
+// increments ONLY the pending-timeout counter and returns
+// dropEmission=false (data-preserving recovery).
+func TestApplyEscapeAdminEvent_PendingTimeout(t *testing.T) {
+	t.Parallel()
+
+	var pendingTimeout, recovery, budgetExhausted, decodeFault atomic.Uint64
+
+	admin := AdminEvent{
+		Kind:     AdminEventEscapePendingTimeout,
+		Duration: 33 * time.Millisecond,
+		Absorbed: 0,
+	}
+	drop := applyEscapeAdminEvent(admin, &pendingTimeout, &recovery, &budgetExhausted, &decodeFault)
+
+	if drop {
+		t.Error("dropEmission=true for PendingTimeout; want false (data-preserving)")
+	}
+	if got := pendingTimeout.Load(); got != 1 {
+		t.Errorf("pendingTimeout=%d; want 1", got)
+	}
+	if got := recovery.Load(); got != 0 {
+		t.Errorf("recovery=%d; want 0 (only pendingTimeout should increment)", got)
+	}
+	if got := budgetExhausted.Load(); got != 0 {
+		t.Errorf("budgetExhausted=%d; want 0", got)
+	}
+	if got := decodeFault.Load(); got != 0 {
+		t.Errorf("decodeFault=%d; want 0 (timeout is NOT a fault — data-preserving)", got)
+	}
+}
+
+func TestApplyEscapeAdminEvent_Recovery(t *testing.T) {
+	t.Parallel()
+
+	var pendingTimeout, recovery, budgetExhausted, decodeFault atomic.Uint64
+
+	admin := AdminEvent{Kind: AdminEventEscapeRecovery, Absorbed: 0}
+	drop := applyEscapeAdminEvent(admin, &pendingTimeout, &recovery, &budgetExhausted, &decodeFault)
+
+	if !drop {
+		t.Error("dropEmission=false for Recovery; want true (fault — drop the byte)")
+	}
+	if got := recovery.Load(); got != 1 {
+		t.Errorf("recovery=%d; want 1", got)
+	}
+	if got := decodeFault.Load(); got != 1 {
+		t.Errorf("decodeFault=%d; want 1 (Recovery is a fault)", got)
+	}
+	if got := pendingTimeout.Load(); got != 0 {
+		t.Errorf("pendingTimeout=%d; want 0", got)
+	}
+	if got := budgetExhausted.Load(); got != 0 {
+		t.Errorf("budgetExhausted=%d; want 0", got)
+	}
+}
+
+func TestApplyEscapeAdminEvent_BudgetExhausted(t *testing.T) {
+	t.Parallel()
+
+	var pendingTimeout, recovery, budgetExhausted, decodeFault atomic.Uint64
+
+	admin := AdminEvent{Kind: AdminEventEscapeBudgetExhausted, Absorbed: MaxAaAbsorptionsPerEscapePair}
+	drop := applyEscapeAdminEvent(admin, &pendingTimeout, &recovery, &budgetExhausted, &decodeFault)
+
+	if !drop {
+		t.Error("dropEmission=false for BudgetExhausted; want true (fault — drop)")
+	}
+	if got := budgetExhausted.Load(); got != 1 {
+		t.Errorf("budgetExhausted=%d; want 1", got)
+	}
+	if got := decodeFault.Load(); got != 1 {
+		t.Errorf("decodeFault=%d; want 1 (BudgetExhausted is a fault)", got)
+	}
+	if got := pendingTimeout.Load(); got != 0 {
+		t.Errorf("pendingTimeout=%d; want 0", got)
+	}
+	if got := recovery.Load(); got != 0 {
+		t.Errorf("recovery=%d; want 0", got)
+	}
+}
+
+func TestApplyEscapeAdminEvent_None(t *testing.T) {
+	t.Parallel()
+
+	var pendingTimeout, recovery, budgetExhausted, decodeFault atomic.Uint64
+
+	admin := AdminEvent{Kind: AdminEventNone}
+	drop := applyEscapeAdminEvent(admin, &pendingTimeout, &recovery, &budgetExhausted, &decodeFault)
+
+	if drop {
+		t.Error("dropEmission=true for None; want false (no event, emission proceeds)")
+	}
+	if got := pendingTimeout.Load(); got != 0 {
+		t.Errorf("pendingTimeout=%d; want 0", got)
+	}
+	if got := recovery.Load(); got != 0 {
+		t.Errorf("recovery=%d; want 0", got)
+	}
+	if got := budgetExhausted.Load(); got != 0 {
+		t.Errorf("budgetExhausted=%d; want 0", got)
+	}
+	if got := decodeFault.Load(); got != 0 {
+		t.Errorf("decodeFault=%d; want 0", got)
+	}
+}
+
+// TestApplyEscapeAdminEvent_TimeoutDoesNotIncrementDecodeFault is a
+// targeted regression guard against the most likely refactor mistake:
+// someone treating PendingTimeout as a "fault" and adding it to
+// DecodeFaultTotal. Per v8 §1.3 the timeout path is data-preserving
+// (the current byte is re-emitted), so it MUST NOT be a fault.
+func TestApplyEscapeAdminEvent_TimeoutDoesNotIncrementDecodeFault(t *testing.T) {
+	t.Parallel()
+
+	var pendingTimeout, recovery, budgetExhausted, decodeFault atomic.Uint64
+
+	// Fire the timeout admin event many times — none should
+	// increment decodeFault.
+	for i := 0; i < 100; i++ {
+		_ = applyEscapeAdminEvent(
+			AdminEvent{Kind: AdminEventEscapePendingTimeout},
+			&pendingTimeout, &recovery, &budgetExhausted, &decodeFault,
+		)
+	}
+
+	if got := pendingTimeout.Load(); got != 100 {
+		t.Errorf("pendingTimeout=%d; want 100", got)
+	}
+	if got := decodeFault.Load(); got != 0 {
+		t.Errorf("decodeFault=%d; want 0 (timeout MUST NOT count toward fault — v8 §1.3 data-preserving invariant)", got)
+	}
+}
+
+// TestApplyEscapeAdminEvent_FaultsBothIncrementDecodeFault is the
+// dual regression guard: Recovery and BudgetExhausted MUST both
+// increment decodeFault (the legacy fault counter operators are
+// already watching). If a refactor decouples them, this test fires.
+func TestApplyEscapeAdminEvent_FaultsBothIncrementDecodeFault(t *testing.T) {
+	t.Parallel()
+
+	var pendingTimeout, recovery, budgetExhausted, decodeFault atomic.Uint64
+
+	_ = applyEscapeAdminEvent(
+		AdminEvent{Kind: AdminEventEscapeRecovery},
+		&pendingTimeout, &recovery, &budgetExhausted, &decodeFault,
+	)
+	_ = applyEscapeAdminEvent(
+		AdminEvent{Kind: AdminEventEscapeBudgetExhausted},
+		&pendingTimeout, &recovery, &budgetExhausted, &decodeFault,
+	)
+
+	if got := recovery.Load(); got != 1 {
+		t.Errorf("recovery=%d; want 1", got)
+	}
+	if got := budgetExhausted.Load(); got != 1 {
+		t.Errorf("budgetExhausted=%d; want 1", got)
+	}
+	// DecodeFault should be 2 (Recovery + BudgetExhausted).
+	if got := decodeFault.Load(); got != 2 {
+		t.Errorf("decodeFault=%d; want 2 (both faults must increment the legacy counter)", got)
+	}
+}

--- a/transport/ebus_escape.go
+++ b/transport/ebus_escape.go
@@ -1,6 +1,9 @@
 package transport
 
-import "fmt"
+import (
+	"fmt"
+	"time"
+)
 
 // EbusEscapeDecoder unescapes eBUS byte-stuffing as documented in
 // john30/ebusd/docs/enhanced_proto.md:
@@ -9,11 +12,39 @@ import "fmt"
 //	wire 0xA9 0x01 → logical 0xAA (data byte equal to SYN value)
 //	any other byte → passes through unchanged
 //
-// The decoder is stateful — the `escape` flag carries across calls so a
-// pair split between Read() boundaries decodes correctly on the next
-// byte. The decoder does NOT own the byte stream: callers invoke Push
-// once per wire byte, and Reset() clears in-flight state at transport
-// lifecycle boundaries (reconnect, RESETTED frame, surface reset).
+// Phase 1 Step B1 (frame-atomic-visibility v8 §1.3, §5, invariant I4)
+// extends the decoder with AA-injection absorption and a wall-clock
+// cap on the pending state. The two motivating defects:
+//
+//   - **AA-injection mid-escape-pair.** When a 0xA9 lead is followed
+//     by spurious 0xAA bytes (the adapter buffer leaking AUTO-SYN
+//     mid-escape-pair, per the round-9 motivating bug), the decoder
+//     silently absorbs up to MaxAaAbsorptionsPerEscapePair (8) of them
+//     and continues waiting for the real second byte. Without this,
+//     every AA-injection mid-escape would corrupt the decoded byte
+//     stream and surface as a phantom PROTOCOL_FAULT downstream.
+//
+//   - **Hard 32 ms wall-clock cap on ESCAPE_PENDING.** Per v8 §1.3:
+//     "Beyond 32 ms, the wire is genuinely broken; better to abandon
+//     and let downstream FSM detect protocol fault." When the cap is
+//     reached, the decoder drops the orphaned 0xA9 plus any absorbed
+//     AAs and re-processes the current byte in NORMAL state to
+//     preserve data for next-byte resync.
+//
+// Per v8 §1.3, a 0xA9 followed by anything OTHER than 0x00 / 0x01 /
+// 0xAA-within-budget is treated as protocol corruption. The decoder
+// emits NOTHING for the failed escape pair (drops both the 0xA9 and
+// the offending byte) and returns to NORMAL state. v6's earlier
+// emit-0xA9-as-raw recovery was rejected because the 0xA9 may have
+// been pure injection noise; emitting it would invent a byte the
+// wire never carried.
+//
+// The decoder is stateful — fields carry across calls so an escape
+// pair split across Read() boundaries decodes correctly. The decoder
+// does NOT own the byte stream: callers invoke Feed (or the legacy
+// Push) once per wire byte, and Reset() clears in-flight state at
+// transport lifecycle boundaries (reconnect, RESETTED frame, surface
+// reset).
 //
 // Concurrency: the decoder is NOT safe for concurrent use. The ENH
 // transport invokes it under readMu, which already serializes byte
@@ -29,68 +60,291 @@ import "fmt"
 // buffers and produced false unexpected_symbol abandons whenever a
 // legitimate frame contained a logical 0xA9 or 0xAA byte (Patterns A
 // and B in batch-19's verification report). This decoder makes the
-// BytesAreUnescaped() contract honest.
+// BytesAreUnescaped() contract honest. The v8 additions (AA absorption
+// + wall-clock cap) layer on top of that without changing the
+// underlying contract.
 type EbusEscapeDecoder struct {
-	escape bool
+	escape         bool
+	leadObservedAt time.Time
+	absorbedCount  int
 }
 
-// Push consumes one wire byte and returns the decoded result.
+// MaxAaAbsorptionsPerEscapePair is the maximum number of consecutive
+// 0xAA bytes the decoder will absorb between the 0xA9 lead and the
+// completion byte (0x00 or 0x01). Per frame-atomic-visibility v8 §5
+// and invariant I4. Beyond this count the decoder declares escape
+// failure (AdminEventEscapeBudgetExhausted).
+//
+// This constant MUST match
+// `protocol.FrameAtomicV8MaxAaAbsorptionsPerEscapePair` in
+// `protocol/frame_atomic_v8_timeouts.go`. The transport package
+// cannot import the protocol package (circular dependency), so the
+// constant is mirrored here with an explicit cross-reference comment.
+const MaxAaAbsorptionsPerEscapePair = 8
+
+// EscapePendingTimeout is the wall-clock cap on the decoder's
+// pending state. Beyond this, the decoder declares ESCAPE_PENDING
+// timeout (AdminEventEscapePendingTimeout). Per v8 §1.3.
+//
+// This constant MUST match `protocol.FrameAtomicV8EscapePendingTimeout`
+// in `protocol/frame_atomic_v8_timeouts.go`. Same mirroring rationale
+// as MaxAaAbsorptionsPerEscapePair.
+const EscapePendingTimeout = 32 * time.Millisecond
+
+// AdminEventKind classifies admin-channel events the decoder emits
+// when it detects fault or recovery conditions per v8 §1.3 / §5.
+// These events live strictly on the proxy admin channel; per v8
+// invariant I1 they are NEVER injected into client byte streams.
+type AdminEventKind int
+
+const (
+	// AdminEventNone means the Feed call produced no admin event.
+	AdminEventNone AdminEventKind = iota
+
+	// AdminEventEscapePendingTimeout means the decoder spent more
+	// than EscapePendingTimeout in pending state without resolving.
+	// The orphaned 0xA9 and any absorbed AAs are dropped; the
+	// current byte is re-processed in NORMAL state. Per v8 §1.3.
+	AdminEventEscapePendingTimeout
+
+	// AdminEventEscapeRecovery means the decoder saw a byte in
+	// pending state that is neither a valid completion byte
+	// (0x00 / 0x01) nor an absorbable 0xAA-within-budget. The
+	// orphaned 0xA9 and any absorbed AAs are dropped; the current
+	// byte is also dropped (treated as continuation of the
+	// corruption). Per v8 §5.
+	AdminEventEscapeRecovery
+
+	// AdminEventEscapeBudgetExhausted means the decoder saw the
+	// (MaxAaAbsorptionsPerEscapePair + 1)-th 0xAA in pending state,
+	// exhausting the count-bounded absorption budget. The orphaned
+	// 0xA9, the 8 absorbed AAs, AND the over-budget 0xAA are ALL
+	// dropped — emit nothing. Per v8 §5 / I4: only the timeout path
+	// re-processes the current byte; the count-bounded path drops
+	// everything so a raw AUTO-SYN cannot leak into the downstream
+	// classifier after declared escape failure.
+	AdminEventEscapeBudgetExhausted
+)
+
+// String returns a human-readable label for the admin event kind.
+// Used in admin-channel logs.
+func (k AdminEventKind) String() string {
+	switch k {
+	case AdminEventNone:
+		return "none"
+	case AdminEventEscapePendingTimeout:
+		return "escape_pending_timeout"
+	case AdminEventEscapeRecovery:
+		return "escape_decoder_recovery"
+	case AdminEventEscapeBudgetExhausted:
+		return "escape_budget_exhausted"
+	default:
+		return "unknown"
+	}
+}
+
+// AdminEvent captures the per-Feed diagnostic that the decoder
+// wishes to surface to the admin channel. Empty (Kind ==
+// AdminEventNone) means no event.
+type AdminEvent struct {
+	Kind     AdminEventKind
+	Duration time.Duration // wall-clock duration in pending state, if relevant
+	Absorbed int           // number of AAs absorbed before the event, if relevant
+}
+
+// Feed consumes one wire byte and returns:
+//   - decoded: the decoded logical byte (valid only when ok=true).
+//   - ok: true if a logical byte is ready; false while accumulating
+//     an escape pair, absorbing an AA-injection, or dropping a
+//     fault.
+//   - wasEscaped: true if `decoded` came from a wire escape pair
+//     (0xA9 0x00 → 0xA9 or 0xA9 0x01 → 0xAA); false for a raw
+//     passthrough byte.
+//   - admin: a diagnostic event for the admin channel, or
+//     AdminEventNone.
+//
+// Callers MUST pass `now` as the monotonic-clock observation time
+// for `raw` (per v8 invariant I0). Tests pass synthetic times. The
+// `now` value is used ONLY for the EscapePendingTimeout wall-clock
+// cap; any caller that doesn't care about admin-channel observability
+// may use the legacy Push method instead.
+//
+// Feed is allocation-free on the hot path.
+func (d *EbusEscapeDecoder) Feed(raw byte, now time.Time) (decoded byte, ok bool, wasEscaped bool, admin AdminEvent) {
+	if d.escape {
+		return d.feedPending(raw, now)
+	}
+	return d.feedNormal(raw, now)
+}
+
+func (d *EbusEscapeDecoder) feedNormal(raw byte, now time.Time) (byte, bool, bool, AdminEvent) {
+	if raw == 0xA9 {
+		// Escape lead — enter pending state, remember when the lead
+		// arrived for the wall-clock cap. Do not emit yet.
+		d.escape = true
+		d.leadObservedAt = now
+		d.absorbedCount = 0
+		return 0, false, false, AdminEvent{}
+	}
+	// Plain wire byte. WasEscaped=false because no escape pair was
+	// used. A wire AUTO-SYN (0xAA) flows through here as
+	// (0xAA, wasEscaped=false) — the classifier in v8 §4 uses this
+	// provenance to distinguish wire AUTO-SYN from escape-decoded
+	// payload 0xAA.
+	return raw, true, false, AdminEvent{}
+}
+
+func (d *EbusEscapeDecoder) feedPending(raw byte, now time.Time) (byte, bool, bool, AdminEvent) {
+	// Wall-clock cap fires before the byte-value branches. Per v8
+	// §1.3: "Beyond 32 ms, the wire is genuinely broken; better to
+	// abandon and let downstream FSM detect protocol fault." Only
+	// honor the cap when `leadObservedAt` is non-zero — a zero time
+	// is a legacy signal from the Push wrapper meaning "no clock
+	// available, skip wall-clock cap" (preserves Push's
+	// no-time-dependence behavior).
+	if !d.leadObservedAt.IsZero() {
+		elapsed := now.Sub(d.leadObservedAt)
+		if elapsed > EscapePendingTimeout {
+			absorbed := d.absorbedCount
+			d.escape = false
+			d.leadObservedAt = time.Time{}
+			d.absorbedCount = 0
+			// Re-process the current byte in NORMAL state to preserve
+			// it for next-byte resync (v8 §1.3 polish commit).
+			decoded, ok, wasEscaped, _ := d.feedNormal(raw, now)
+			return decoded, ok, wasEscaped, AdminEvent{
+				Kind:     AdminEventEscapePendingTimeout,
+				Duration: elapsed,
+				Absorbed: absorbed,
+			}
+		}
+	}
+
+	switch raw {
+	case 0x01:
+		// 0xA9 0x01 → logical 0xAA, wasEscaped=true.
+		d.escape = false
+		d.leadObservedAt = time.Time{}
+		d.absorbedCount = 0
+		return 0xAA, true, true, AdminEvent{}
+
+	case 0x00:
+		// 0xA9 0x00 → logical 0xA9, wasEscaped=true.
+		d.escape = false
+		d.leadObservedAt = time.Time{}
+		d.absorbedCount = 0
+		return 0xA9, true, true, AdminEvent{}
+
+	case 0xAA:
+		// AA-injection mid-escape-pair. Absorb if budget allows.
+		if d.absorbedCount < MaxAaAbsorptionsPerEscapePair {
+			d.absorbedCount++
+			return 0, false, false, AdminEvent{}
+		}
+		// Budget exhausted. Per v8 §5 / I4: drop the 0xA9, all
+		// absorbed AAs, AND this over-budget AA. Emit NOTHING. Only
+		// the timeout path (wall-clock cap above) re-processes the
+		// current byte; the count-exhausted path drops everything so
+		// an over-budget raw AUTO-SYN cannot leak into the
+		// downstream classifier after declared escape failure.
+		absorbed := d.absorbedCount
+		elapsed := time.Duration(0)
+		if !d.leadObservedAt.IsZero() {
+			elapsed = now.Sub(d.leadObservedAt)
+		}
+		d.escape = false
+		d.leadObservedAt = time.Time{}
+		d.absorbedCount = 0
+		return 0, false, false, AdminEvent{
+			Kind:     AdminEventEscapeBudgetExhausted,
+			Duration: elapsed,
+			Absorbed: absorbed,
+		}
+
+	default:
+		// Malformed escape: byte is neither a valid completion
+		// (0x00 / 0x01) nor an absorbable 0xAA-within-budget. Drop
+		// the 0xA9 plus absorbed AAs AND drop this byte (treat as
+		// continuation of corruption). Emit admin event.
+		absorbed := d.absorbedCount
+		elapsed := time.Duration(0)
+		if !d.leadObservedAt.IsZero() {
+			elapsed = now.Sub(d.leadObservedAt)
+		}
+		d.escape = false
+		d.leadObservedAt = time.Time{}
+		d.absorbedCount = 0
+		return 0, false, false, AdminEvent{
+			Kind:     AdminEventEscapeRecovery,
+			Duration: elapsed,
+			Absorbed: absorbed,
+		}
+	}
+}
+
+// Push consumes one wire byte and returns the decoded result. This
+// is the legacy entry point — it forwards to Feed with a zero time,
+// which suppresses the wall-clock cap (the AA absorption budget
+// still applies). Use Feed directly when you need the wall-clock cap
+// and admin-channel observability.
 //
 // Return values:
 //
 //	decoded     — the logical byte to emit (valid only when ok=true)
 //	ok          — true if a logical byte is ready; false while still
-//	              accumulating (the escape lead 0xA9 was just consumed)
+//	              accumulating (the escape lead 0xA9 was just
+//	              consumed, an AA-injection was absorbed, or a fault
+//	              dropped the current byte)
 //	wasEscaped  — true if `decoded` came from a wire escape pair
 //	              (0xA9 0x00 → 0xA9 or 0xA9 0x01 → 0xAA); false for a
 //	              raw passthrough byte
-//	err         — non-nil iff a 0xA9 lead was followed by an invalid
-//	              second byte (anything other than 0x00 or 0x01); the
-//	              decoder clears its `escape` state before returning so
-//	              the next call resumes cleanly on the next wire byte
+//	err         — non-nil iff Feed emitted AdminEventEscapeRecovery
+//	              or AdminEventEscapeBudgetExhausted (mapped to err
+//	              for legacy callers that expect the pre-v8 fault
+//	              contract). The decoder clears its escape state
+//	              before returning, so the next call resumes cleanly.
 //
 // On err != nil the caller should count the fault and continue;
-// emission of the offending pair is suppressed (ok=false, decoded
-// undefined). The next Push resumes clean decoding.
+// emission of the offending pair/byte is suppressed (ok=false,
+// decoded undefined). The next Push resumes clean decoding.
 func (d *EbusEscapeDecoder) Push(raw byte) (decoded byte, ok bool, wasEscaped bool, err error) {
-	if d.escape {
-		// We previously consumed a 0xA9 lead; `raw` is the second byte
-		// of the escape pair. Clear the flag first so a malformed pair
-		// (returning an error) does not strand us mid-pair on the next
-		// call — see error-resume note in the func docstring.
-		d.escape = false
-		switch raw {
-		case 0x00:
-			return 0xA9, true, true, nil
-		case 0x01:
-			return 0xAA, true, true, nil
-		default:
-			return 0, false, false, fmt.Errorf("ebus escape: 0xA9 0x%02X is not a valid pair (expected 0x00 or 0x01)", raw)
-		}
+	// Pass time.Time{} (zero time) to disable the wall-clock cap.
+	// Push has no clock injection point so it cannot enforce the cap
+	// honestly — Feed is the v8 entry point that does.
+	decoded, ok, wasEscaped, admin := d.Feed(raw, time.Time{})
+	switch admin.Kind {
+	case AdminEventEscapeRecovery:
+		return 0, false, false, fmt.Errorf("ebus escape: 0xA9 0x%02X is not a valid pair (expected 0x00 or 0x01)", raw)
+	case AdminEventEscapeBudgetExhausted:
+		return 0, false, false, fmt.Errorf("ebus escape: AA-injection budget (%d) exhausted in pending state", MaxAaAbsorptionsPerEscapePair)
 	}
-	if raw == 0xA9 {
-		// Escape lead. Buffer the state; do not emit yet.
-		d.escape = true
-		return 0, false, false, nil
-	}
-	return raw, true, false, nil
+	return decoded, ok, wasEscaped, nil
 }
 
 // Reset clears any in-flight escape state. Call at every transport
 // lifecycle boundary that invalidates an in-progress wire pair:
 // reconnect, adapter-surfaced RESETTED frame, or any other state
-// discard. Do NOT call on read timeout — a 0xA9 lead may have arrived
-// just before the timeout and its pair may legitimately arrive on the
-// next read.
+// discard. Do NOT call on read timeout — a 0xA9 lead may have
+// arrived just before the timeout and its pair may legitimately
+// arrive on the next read.
 func (d *EbusEscapeDecoder) Reset() {
 	d.escape = false
+	d.leadObservedAt = time.Time{}
+	d.absorbedCount = 0
 }
 
 // HasPendingEscape reports whether the decoder is mid-pair (a 0xA9
-// lead has been consumed and we are awaiting the second byte). Useful
-// for diagnostics and for callers that want to flag mid-frame
-// interruption when a transport-level boundary fires while the
-// decoder is mid-pair.
+// lead has been consumed and we are awaiting the second byte or
+// absorbing AA-injection). Useful for diagnostics and for callers
+// that want to flag mid-frame interruption when a transport-level
+// boundary fires while the decoder is mid-pair.
 func (d *EbusEscapeDecoder) HasPendingEscape() bool {
 	return d.escape
+}
+
+// AbsorbedCount returns the number of 0xAA bytes absorbed in the
+// current pending sequence. Returns 0 when not pending. Exposed for
+// testing and admin-channel observability.
+func (d *EbusEscapeDecoder) AbsorbedCount() int {
+	return d.absorbedCount
 }

--- a/transport/ebus_escape.go
+++ b/transport/ebus_escape.go
@@ -288,6 +288,40 @@ func (d *EbusEscapeDecoder) feedPending(raw byte, now time.Time) (byte, bool, bo
 // still applies). Use Feed directly when you need the wall-clock cap
 // and admin-channel observability.
 //
+// DEPRECATED RECOMMENDATION: new callers should use Feed(b, now)
+// instead of Push. Feed is the v8 entry point — it accepts an
+// explicit monotonic-clock observation time (per v8 invariant I0),
+// enforces the 32 ms wall-clock cap on the pending state, and
+// surfaces AdminEvent diagnostics that the transport layer routes
+// to dedicated counters (EscapePendingTimeoutTotal,
+// EscapeRecoveryTotal, EscapeBudgetExhaustedTotal,
+// EscapeAaAbsorbedTotal). Push exists ONLY to preserve binary
+// compatibility for legacy callers (the existing F-23 contract +
+// the existing transport-level integration tests) and DOES NOT
+// emit the wall-clock cap signal even when a real stale-pair
+// scenario occurs.
+//
+// V8 BEHAVIOR CHANGES vs the pre-v8 Push:
+//
+//   - 0xA9 followed by 0xAA — pre-v8: returned err (invalid pair).
+//     Post-v8: 0xAA is silently absorbed as the first AA-injection
+//     byte; the decoder remains in pending state, ok=false, err=nil.
+//     Up to MaxAaAbsorptionsPerEscapePair absorptions are tolerated
+//     before a real completion (0x00/0x01) or budget-exhaustion.
+//   - 0xA9 followed by ≥9 consecutive 0xAA — pre-v8 had no concept
+//     of this; the first 0xAA after the lead errored.
+//     Post-v8: the 9th 0xAA exhausts the budget; Push returns err
+//     (budget-exhausted) and the decoder drops everything.
+//   - 0xA9 followed by any other invalid byte (e.g. 0xFF) — pre-v8
+//     and post-v8 both return err and drop the pair.
+//
+// External callers that depended on "0xA9 0xAA → err" as a
+// dropped-byte signal must migrate to Feed and inspect the admin
+// channel directly. There are no production callers of Push left
+// in helianthus-ebusgo after this PR (ENHTransport now uses Feed);
+// the method survives for legacy tests + any future external
+// linkage that might pin Push's signature.
+//
 // Return values:
 //
 //	decoded     — the logical byte to emit (valid only when ok=true)

--- a/transport/ebus_escape_v8_test.go
+++ b/transport/ebus_escape_v8_test.go
@@ -1,0 +1,447 @@
+package transport
+
+import (
+	"testing"
+	"time"
+)
+
+// Phase 1 Step B1 (frame-atomic-visibility v8 §1.3 / §5, invariant
+// I4): unit tests for the v8 AA-aware escape decoder. The legacy
+// Push tests in ebus_escape_test.go continue to pin the un-clocked
+// (legacy) contract; this file pins the v8 Feed contract — AA
+// absorption, wall-clock cap, admin events, data-preserving
+// recovery on timeout.
+
+// TestFeed_PlainPassthrough pins the no-escape path under Feed:
+// every non-0xA9 wire byte emits unchanged with WasEscaped=false on
+// the first call. No admin event.
+func TestFeed_PlainPassthrough(t *testing.T) {
+	t.Parallel()
+
+	d := &EbusEscapeDecoder{}
+	t0 := time.Unix(0, 0)
+	for _, raw := range []byte{0x00, 0x01, 0x08, 0x55, 0x7F, 0x80, 0xA8, 0xAA, 0xFE, 0xFF} {
+		got, ok, wasEscaped, admin := d.Feed(raw, t0)
+		if !ok {
+			t.Fatalf("Feed(0x%02X): ok=false; want true (plain passthrough)", raw)
+		}
+		if got != raw {
+			t.Fatalf("Feed(0x%02X): decoded=0x%02X; want passthrough", raw, got)
+		}
+		if wasEscaped {
+			t.Fatalf("Feed(0x%02X): wasEscaped=true; want false for raw byte", raw)
+		}
+		if admin.Kind != AdminEventNone {
+			t.Fatalf("Feed(0x%02X): admin.Kind=%v; want AdminEventNone", raw, admin.Kind)
+		}
+	}
+}
+
+// TestFeed_A9_01_DecodesToAA pins the canonical
+// `wire 0xA9 0x01 → logical 0xAA, wasEscaped=true` rule under Feed.
+// No admin event on the happy path.
+func TestFeed_A9_01_DecodesToAA(t *testing.T) {
+	t.Parallel()
+
+	d := &EbusEscapeDecoder{}
+	t0 := time.Unix(0, 0)
+
+	_, ok, _, admin := d.Feed(0xA9, t0)
+	if ok {
+		t.Fatal("Feed(0xA9): ok=true on lead; want false")
+	}
+	if admin.Kind != AdminEventNone {
+		t.Fatalf("Feed(0xA9): admin.Kind=%v; want AdminEventNone", admin.Kind)
+	}
+	if !d.HasPendingEscape() {
+		t.Fatal("HasPendingEscape() = false after lead; want true")
+	}
+
+	got, ok, wasEscaped, admin := d.Feed(0x01, t0.Add(1*time.Millisecond))
+	if !ok || got != 0xAA || !wasEscaped {
+		t.Fatalf("Feed(0x01): got=(0x%02X, ok=%v, wasEscaped=%v); want (0xAA, true, true)", got, ok, wasEscaped)
+	}
+	if admin.Kind != AdminEventNone {
+		t.Fatalf("Feed(0x01) completion: admin.Kind=%v; want AdminEventNone", admin.Kind)
+	}
+	if d.HasPendingEscape() {
+		t.Fatal("HasPendingEscape() = true after completion; want false")
+	}
+}
+
+// TestFeed_A9_00_DecodesToA9 pins the
+// `wire 0xA9 0x00 → logical 0xA9, wasEscaped=true` rule under Feed.
+func TestFeed_A9_00_DecodesToA9(t *testing.T) {
+	t.Parallel()
+
+	d := &EbusEscapeDecoder{}
+	t0 := time.Unix(0, 0)
+
+	if _, ok, _, _ := d.Feed(0xA9, t0); ok {
+		t.Fatal("Feed(0xA9): ok=true on lead; want false")
+	}
+	got, ok, wasEscaped, admin := d.Feed(0x00, t0.Add(1*time.Millisecond))
+	if !ok || got != 0xA9 || !wasEscaped {
+		t.Fatalf("Feed(0x00): got=(0x%02X, ok=%v, wasEscaped=%v); want (0xA9, true, true)", got, ok, wasEscaped)
+	}
+	if admin.Kind != AdminEventNone {
+		t.Fatalf("admin.Kind=%v; want AdminEventNone", admin.Kind)
+	}
+}
+
+// TestFeed_A9_AA_Absorbed_Then_01 pins the core v8 AA-absorption
+// path: a 0xA9 lead followed by one 0xAA injection then 0x01 must
+// (a) absorb the 0xAA without emission, (b) accept the 0x01 as the
+// real completion and emit 0xAA wasEscaped=true.
+func TestFeed_A9_AA_Absorbed_Then_01(t *testing.T) {
+	t.Parallel()
+
+	d := &EbusEscapeDecoder{}
+	t0 := time.Unix(0, 0)
+
+	if _, ok, _, _ := d.Feed(0xA9, t0); ok {
+		t.Fatal("Feed(0xA9): ok=true; want false")
+	}
+	// AA-injection within budget.
+	_, ok, _, admin := d.Feed(0xAA, t0.Add(1*time.Millisecond))
+	if ok {
+		t.Fatal("Feed(0xAA) after lead: ok=true; want false (absorbed)")
+	}
+	if admin.Kind != AdminEventNone {
+		t.Fatalf("absorption admin.Kind=%v; want AdminEventNone", admin.Kind)
+	}
+	if d.AbsorbedCount() != 1 {
+		t.Fatalf("AbsorbedCount=%d after 1 AA; want 1", d.AbsorbedCount())
+	}
+
+	// Now the real completion.
+	got, ok, wasEscaped, admin := d.Feed(0x01, t0.Add(2*time.Millisecond))
+	if !ok || got != 0xAA || !wasEscaped {
+		t.Fatalf("Feed(0x01) post-absorb: got=(0x%02X, ok=%v, wasEscaped=%v); want (0xAA, true, true)", got, ok, wasEscaped)
+	}
+	if admin.Kind != AdminEventNone {
+		t.Fatalf("completion admin.Kind=%v; want AdminEventNone", admin.Kind)
+	}
+	if d.AbsorbedCount() != 0 {
+		t.Fatalf("AbsorbedCount=%d after completion; want 0 (reset)", d.AbsorbedCount())
+	}
+}
+
+// TestFeed_A9_MaxAA_Then_01 exercises the upper edge of the
+// absorption budget: 8 AAs absorbed, then 0x01 must still complete
+// cleanly. Verifies MaxAaAbsorptionsPerEscapePair == 8 is the
+// "inclusive ceiling" — absorb 8, then complete on the 9th call.
+func TestFeed_A9_MaxAA_Then_01(t *testing.T) {
+	t.Parallel()
+
+	d := &EbusEscapeDecoder{}
+	t0 := time.Unix(0, 0)
+
+	if _, ok, _, _ := d.Feed(0xA9, t0); ok {
+		t.Fatal("Feed(0xA9): ok=true; want false")
+	}
+	for i := 0; i < MaxAaAbsorptionsPerEscapePair; i++ {
+		_, ok, _, admin := d.Feed(0xAA, t0.Add(time.Duration(i+1)*time.Millisecond))
+		if ok {
+			t.Fatalf("Feed(0xAA) iter %d: ok=true; want false (absorbed)", i)
+		}
+		if admin.Kind != AdminEventNone {
+			t.Fatalf("Feed(0xAA) iter %d: admin.Kind=%v; want None", i, admin.Kind)
+		}
+	}
+	if d.AbsorbedCount() != MaxAaAbsorptionsPerEscapePair {
+		t.Fatalf("AbsorbedCount=%d after %d AAs; want %d",
+			d.AbsorbedCount(), MaxAaAbsorptionsPerEscapePair, MaxAaAbsorptionsPerEscapePair)
+	}
+
+	// 9th byte is the real completion.
+	got, ok, wasEscaped, admin := d.Feed(0x01, t0.Add(20*time.Millisecond))
+	if !ok || got != 0xAA || !wasEscaped {
+		t.Fatalf("Feed(0x01) post-max-absorb: got=(0x%02X, ok=%v, wasEscaped=%v); want (0xAA, true, true)", got, ok, wasEscaped)
+	}
+	if admin.Kind != AdminEventNone {
+		t.Fatalf("completion admin.Kind=%v; want None", admin.Kind)
+	}
+}
+
+// TestFeed_BudgetExhausted_AA_Over9 pins the count-bound failure:
+// 9 consecutive AAs (one over the budget) yields
+// AdminEventEscapeBudgetExhausted; the 9th AA AND all 8 absorbed
+// AAs AND the 0xA9 are ALL dropped — emit nothing.
+func TestFeed_BudgetExhausted_AA_Over9(t *testing.T) {
+	t.Parallel()
+
+	d := &EbusEscapeDecoder{}
+	t0 := time.Unix(0, 0)
+
+	if _, ok, _, _ := d.Feed(0xA9, t0); ok {
+		t.Fatal("Feed(0xA9): ok=true; want false")
+	}
+	for i := 0; i < MaxAaAbsorptionsPerEscapePair; i++ {
+		_, _, _, admin := d.Feed(0xAA, t0.Add(time.Duration(i+1)*time.Millisecond))
+		if admin.Kind != AdminEventNone {
+			t.Fatalf("Feed(0xAA) iter %d: premature admin event %v", i, admin.Kind)
+		}
+	}
+
+	// 9th AA — exceeds budget.
+	got, ok, wasEscaped, admin := d.Feed(0xAA, t0.Add(20*time.Millisecond))
+	if ok {
+		t.Fatalf("Feed(over-budget 0xAA): ok=true; want false (drop, emit nothing)")
+	}
+	if got != 0 {
+		t.Errorf("decoded=0x%02X; want 0 (sentinel) on drop", got)
+	}
+	if wasEscaped {
+		t.Error("wasEscaped=true; want false on drop")
+	}
+	if admin.Kind != AdminEventEscapeBudgetExhausted {
+		t.Fatalf("admin.Kind=%v; want AdminEventEscapeBudgetExhausted", admin.Kind)
+	}
+	if admin.Absorbed != MaxAaAbsorptionsPerEscapePair {
+		t.Errorf("admin.Absorbed=%d; want %d", admin.Absorbed, MaxAaAbsorptionsPerEscapePair)
+	}
+	if d.HasPendingEscape() {
+		t.Error("decoder still pending after exhaustion; want cleared")
+	}
+	if d.AbsorbedCount() != 0 {
+		t.Errorf("AbsorbedCount=%d; want 0 after exhaustion", d.AbsorbedCount())
+	}
+
+	// Resume: next byte decodes cleanly.
+	got, ok, _, admin = d.Feed(0x55, t0.Add(30*time.Millisecond))
+	if !ok || got != 0x55 || admin.Kind != AdminEventNone {
+		t.Errorf("resume Feed(0x55): got=(0x%02X, ok=%v, admin.Kind=%v); want (0x55, true, None)",
+			got, ok, admin.Kind)
+	}
+}
+
+// TestFeed_InvalidSecondByte pins the malformed-pair drop path: a
+// 0xA9 followed by 0xFF (not 0x00/0x01/0xAA) yields
+// AdminEventEscapeRecovery; both bytes are dropped.
+func TestFeed_InvalidSecondByte(t *testing.T) {
+	t.Parallel()
+
+	d := &EbusEscapeDecoder{}
+	t0 := time.Unix(0, 0)
+
+	if _, ok, _, _ := d.Feed(0xA9, t0); ok {
+		t.Fatal("Feed(0xA9): ok=true; want false")
+	}
+	got, ok, wasEscaped, admin := d.Feed(0xFF, t0.Add(1*time.Millisecond))
+	if ok {
+		t.Fatal("Feed(0xFF) after lead: ok=true; want false (drop)")
+	}
+	if got != 0 || wasEscaped {
+		t.Errorf("got=(0x%02X, wasEscaped=%v); want (0, false)", got, wasEscaped)
+	}
+	if admin.Kind != AdminEventEscapeRecovery {
+		t.Fatalf("admin.Kind=%v; want AdminEventEscapeRecovery", admin.Kind)
+	}
+	if d.HasPendingEscape() {
+		t.Error("decoder still pending after recovery; want cleared")
+	}
+
+	// Resume.
+	got, ok, _, admin = d.Feed(0x55, t0.Add(2*time.Millisecond))
+	if !ok || got != 0x55 || admin.Kind != AdminEventNone {
+		t.Errorf("resume Feed(0x55): got=(0x%02X, ok=%v, admin.Kind=%v); want (0x55, true, None)",
+			got, ok, admin.Kind)
+	}
+}
+
+// TestFeed_WallClockCap_BeyondTimeout pins the 32 ms timeout
+// behavior: a 0xA9 followed by a byte > EscapePendingTimeout later
+// yields AdminEventEscapePendingTimeout; the current byte is
+// re-processed in NORMAL state (data-preserving recovery).
+func TestFeed_WallClockCap_BeyondTimeout(t *testing.T) {
+	t.Parallel()
+
+	d := &EbusEscapeDecoder{}
+	t0 := time.Unix(0, 0)
+
+	if _, ok, _, _ := d.Feed(0xA9, t0); ok {
+		t.Fatal("Feed(0xA9): ok=true; want false")
+	}
+	// Advance past the cap by 1 ms.
+	tLate := t0.Add(EscapePendingTimeout + 1*time.Millisecond)
+
+	got, ok, wasEscaped, admin := d.Feed(0x55, tLate)
+	if !ok {
+		t.Fatal("Feed(0x55) post-timeout: ok=false; want true (re-processed in NORMAL)")
+	}
+	if got != 0x55 {
+		t.Errorf("decoded=0x%02X; want 0x55 (re-processed plain byte)", got)
+	}
+	if wasEscaped {
+		t.Error("wasEscaped=true; want false on plain re-processed byte")
+	}
+	if admin.Kind != AdminEventEscapePendingTimeout {
+		t.Fatalf("admin.Kind=%v; want AdminEventEscapePendingTimeout", admin.Kind)
+	}
+	if admin.Duration <= EscapePendingTimeout {
+		t.Errorf("admin.Duration=%v; want > %v", admin.Duration, EscapePendingTimeout)
+	}
+	if d.HasPendingEscape() {
+		t.Error("decoder still pending after timeout; want cleared")
+	}
+}
+
+// TestFeed_WallClockCap_BoundaryExact pins the strict-greater-than
+// semantics: exactly EscapePendingTimeout elapsed does NOT trigger
+// the cap (only `> EscapePendingTimeout` does). Documents the
+// boundary behavior.
+func TestFeed_WallClockCap_BoundaryExact(t *testing.T) {
+	t.Parallel()
+
+	d := &EbusEscapeDecoder{}
+	t0 := time.Unix(0, 0)
+
+	if _, ok, _, _ := d.Feed(0xA9, t0); ok {
+		t.Fatal("Feed(0xA9): ok=true; want false")
+	}
+	// Advance to EXACTLY the cap.
+	tBoundary := t0.Add(EscapePendingTimeout)
+	got, ok, wasEscaped, admin := d.Feed(0x01, tBoundary)
+	if !ok || got != 0xAA || !wasEscaped {
+		t.Fatalf("Feed(0x01) at boundary: got=(0x%02X, ok=%v, wasEscaped=%v); want clean completion", got, ok, wasEscaped)
+	}
+	if admin.Kind != AdminEventNone {
+		t.Fatalf("admin.Kind=%v; want AdminEventNone at boundary", admin.Kind)
+	}
+}
+
+// TestFeed_WallClockCap_TimeoutBytePreservedAsEscape exercises a
+// subtle case: the timeout fires, the current byte is re-processed
+// in NORMAL state, and the current byte happens to BE a new 0xA9.
+// The byte must start a new pending state (not get dropped).
+func TestFeed_WallClockCap_TimeoutBytePreservedAsEscape(t *testing.T) {
+	t.Parallel()
+
+	d := &EbusEscapeDecoder{}
+	t0 := time.Unix(0, 0)
+
+	if _, ok, _, _ := d.Feed(0xA9, t0); ok {
+		t.Fatal("Feed(0xA9): ok=true; want false")
+	}
+	tLate := t0.Add(EscapePendingTimeout + 1*time.Millisecond)
+	got, ok, wasEscaped, admin := d.Feed(0xA9, tLate)
+	if ok {
+		t.Fatal("Feed(0xA9) post-timeout: ok=true; want false (new lead, accumulating)")
+	}
+	if got != 0 || wasEscaped {
+		t.Errorf("got=(0x%02X, wasEscaped=%v); want (0, false) on new lead", got, wasEscaped)
+	}
+	if admin.Kind != AdminEventEscapePendingTimeout {
+		t.Fatalf("admin.Kind=%v; want AdminEventEscapePendingTimeout", admin.Kind)
+	}
+	if !d.HasPendingEscape() {
+		t.Error("HasPendingEscape=false after re-entering on new 0xA9; want true")
+	}
+
+	// Now complete the NEW pair cleanly.
+	got, ok, wasEscaped, admin = d.Feed(0x01, tLate.Add(1*time.Millisecond))
+	if !ok || got != 0xAA || !wasEscaped {
+		t.Fatalf("new pair completion: got=(0x%02X, ok=%v, wasEscaped=%v); want (0xAA, true, true)", got, ok, wasEscaped)
+	}
+	if admin.Kind != AdminEventNone {
+		t.Errorf("admin.Kind=%v; want None on completion", admin.Kind)
+	}
+}
+
+// TestFeed_Reset_ClearsAbsorbedAndLeadTime pins that Reset() wipes
+// the v8 fields (absorbedCount, leadObservedAt) in addition to the
+// legacy `escape` flag.
+func TestFeed_Reset_ClearsAbsorbedAndLeadTime(t *testing.T) {
+	t.Parallel()
+
+	d := &EbusEscapeDecoder{}
+	t0 := time.Unix(0, 0)
+
+	_, _, _, _ = d.Feed(0xA9, t0)
+	_, _, _, _ = d.Feed(0xAA, t0.Add(1*time.Millisecond))
+	if !d.HasPendingEscape() || d.AbsorbedCount() != 1 {
+		t.Fatalf("precondition: pending=%v absorbed=%d; want true, 1",
+			d.HasPendingEscape(), d.AbsorbedCount())
+	}
+
+	d.Reset()
+	if d.HasPendingEscape() {
+		t.Error("HasPendingEscape() = true after Reset(); want false")
+	}
+	if d.AbsorbedCount() != 0 {
+		t.Errorf("AbsorbedCount=%d after Reset(); want 0", d.AbsorbedCount())
+	}
+
+	// Verify the reset cleared the wall-clock anchor: a fresh lead
+	// followed by an immediate AAa across what WOULD have been a
+	// timeout from the OLD anchor must NOT trigger the cap.
+	_, ok, _, _ := d.Feed(0xA9, t0.Add(100*time.Millisecond))
+	if ok {
+		t.Fatal("fresh lead post-reset: ok=true; want false")
+	}
+	got, ok, wasEscaped, admin := d.Feed(0x01, t0.Add(101*time.Millisecond))
+	if !ok || got != 0xAA || !wasEscaped {
+		t.Fatalf("completion post-reset: got=(0x%02X, ok=%v, wasEscaped=%v); want (0xAA, true, true)", got, ok, wasEscaped)
+	}
+	if admin.Kind != AdminEventNone {
+		t.Errorf("admin.Kind=%v; want None (reset cleared the timeout anchor)", admin.Kind)
+	}
+}
+
+// TestFeed_Push_LegacyContract_WithAbsorption pins the Push wrapper:
+// Push silently absorbs AAs (it does NOT report admin events) and
+// completes cleanly when a valid 0x00/0x01 follows. This is a v8
+// BEHAVIOR CHANGE relative to pre-v8 Push, which would have
+// returned an err on Push(0xA9)+Push(0xAA). Documented intentional
+// change — the AA absorption is now a SUCCESS path.
+func TestFeed_Push_LegacyContract_WithAbsorption(t *testing.T) {
+	t.Parallel()
+
+	d := &EbusEscapeDecoder{}
+
+	if _, ok, _, err := d.Push(0xA9); err != nil || ok {
+		t.Fatalf("Push(0xA9): err=%v ok=%v; want nil false", err, ok)
+	}
+	// First AA — absorbed silently. Pre-v8 this would have errored.
+	_, ok, _, err := d.Push(0xAA)
+	if err != nil {
+		t.Errorf("Push(0xAA) after lead: err=%v; want nil (v8 absorbs)", err)
+	}
+	if ok {
+		t.Error("Push(0xAA) after lead: ok=true; want false (absorbed)")
+	}
+	// Then real completion.
+	got, ok, wasEscaped, err := d.Push(0x01)
+	if err != nil || !ok || got != 0xAA || !wasEscaped {
+		t.Fatalf("Push(0x01) completion: got=(0x%02X, ok=%v, wasEscaped=%v, err=%v); want (0xAA, true, true, nil)",
+			got, ok, wasEscaped, err)
+	}
+}
+
+// TestFeed_Push_BudgetExhausted_StillReturnsErr pins that the
+// legacy Push wrapper still maps budget-exhaustion to err for
+// callers that depend on the err signal.
+func TestFeed_Push_BudgetExhausted_StillReturnsErr(t *testing.T) {
+	t.Parallel()
+
+	d := &EbusEscapeDecoder{}
+
+	_, _, _, _ = d.Push(0xA9)
+	for i := 0; i < MaxAaAbsorptionsPerEscapePair; i++ {
+		if _, _, _, err := d.Push(0xAA); err != nil {
+			t.Fatalf("Push(0xAA) iter %d: err=%v; want nil", i, err)
+		}
+	}
+	// Over-budget.
+	_, ok, _, err := d.Push(0xAA)
+	if err == nil {
+		t.Fatal("Push(over-budget 0xAA): err=nil; want non-nil")
+	}
+	if ok {
+		t.Error("Push(over-budget 0xAA): ok=true; want false")
+	}
+	if d.HasPendingEscape() {
+		t.Error("decoder still pending after exhaustion via Push; want cleared")
+	}
+}

--- a/transport/enh_transport.go
+++ b/transport/enh_transport.go
@@ -1432,29 +1432,73 @@ func (t *ENHTransport) feedEscapeDecoderLocked(raw byte) (decoded byte, ok bool,
 		t.escapeAaAbsorbedTotal.Add(uint64(delta))
 	}
 
-	switch admin.Kind {
-	case AdminEventEscapePendingTimeout:
-		// 32 ms cap hit. Orphaned 0xA9 + absorbed AAs dropped; the
-		// current byte was re-processed in NORMAL state and may have
-		// produced a decoded byte (`decoded`, `ok`, `wasEscaped` are
-		// the result of that re-processing). Surface the timeout but
-		// preserve the data-preserving recovery emission.
-		t.escapePendingTimeoutTotal.Add(1)
-	case AdminEventEscapeRecovery:
-		// Invalid escape pair: increment both fault counters and
-		// drop. The decoder cleared its in-flight state before
-		// returning.
-		t.escapeRecoveryTotal.Add(1)
-		t.decodeFaultTotal.Add(1)
-		return 0, false, false
-	case AdminEventEscapeBudgetExhausted:
-		// AA-injection budget exhausted: increment both fault
-		// counters and drop.
-		t.escapeBudgetExhaustedTotal.Add(1)
-		t.decodeFaultTotal.Add(1)
+	if applyEscapeAdminEvent(
+		admin,
+		&t.escapePendingTimeoutTotal,
+		&t.escapeRecoveryTotal,
+		&t.escapeBudgetExhaustedTotal,
+		&t.decodeFaultTotal,
+	) {
+		// Drop-everything fault path (Recovery or BudgetExhausted) —
+		// emission suppressed regardless of what the decoder returned
+		// for this byte. The decoder cleared its in-flight state
+		// before returning, so subsequent bytes resume cleanly.
 		return 0, false, false
 	}
+	// AdminEventNone or AdminEventEscapePendingTimeout:
+	// data-preserving paths. For Timeout, the current byte was
+	// re-processed in NORMAL state by the decoder and may have
+	// produced a decoded byte (`decoded`, `ok`, `wasEscaped` reflect
+	// that re-processing); the counter was already bumped inside
+	// applyEscapeAdminEvent.
 	return decoded, ok, wasEscaped
+}
+
+// applyEscapeAdminEvent routes a v8 escape-decoder admin event to
+// the four transport-level counters and reports whether the caller
+// must drop the current byte's emission. Extracted from
+// feedEscapeDecoderLocked so the routing logic is directly unit-
+// testable without standing up a full ENHTransport (per Codex
+// round-3 review on PR #165 — "visually parallel wiring is not
+// executable coverage").
+//
+// Returns dropEmission=true when admin.Kind indicates a drop-
+// everything fault (AdminEventEscapeRecovery or
+// AdminEventEscapeBudgetExhausted). Returns false for AdminEventNone
+// (no event) and AdminEventEscapePendingTimeout (data-preserving —
+// the current byte was re-processed in NORMAL state by the decoder
+// and the caller should emit whatever the decoder returned).
+//
+// The function is allocation-free and operates only on the four
+// atomic counter pointers passed in; it does not depend on any
+// ENHTransport state, making it pure-function testable.
+func applyEscapeAdminEvent(
+	admin AdminEvent,
+	pendingTimeoutCtr, recoveryCtr, budgetExhaustedCtr, decodeFaultCtr *atomic.Uint64,
+) (dropEmission bool) {
+	switch admin.Kind {
+	case AdminEventEscapePendingTimeout:
+		// 32 ms cap hit. The decoder already re-processed the
+		// current byte in NORMAL state; the caller emits whatever
+		// the decoder returned. Surface the timeout via its own
+		// counter — NOT a fault (decodeFaultCtr stays put).
+		pendingTimeoutCtr.Add(1)
+		return false
+	case AdminEventEscapeRecovery:
+		// Invalid second byte. Drop the 0xA9, any absorbed AAs, AND
+		// the offending byte. Fault.
+		recoveryCtr.Add(1)
+		decodeFaultCtr.Add(1)
+		return true
+	case AdminEventEscapeBudgetExhausted:
+		// AA-injection budget exhausted. Drop the 0xA9, the 8
+		// absorbed AAs, AND the over-budget AA. Fault.
+		budgetExhaustedCtr.Add(1)
+		decodeFaultCtr.Add(1)
+		return true
+	}
+	// AdminEventNone — no admin event, nothing to do.
+	return false
 }
 
 // appendDecodedByteLocked emits a fully-decoded logical byte to

--- a/transport/enh_transport.go
+++ b/transport/enh_transport.go
@@ -193,7 +193,54 @@ type ENHTransport struct {
 	// byte. Exposed via DecodeFaultTotal() for transport-level
 	// observability. Atomic because external readers (gateway metrics
 	// snapshot) read it without holding readMu.
+	//
+	// Phase 1 Step B1 (frame-atomic-visibility v8 §1.3 / §5,
+	// invariant I4) — the counter is now incremented by BOTH legacy
+	// "0xA9 + invalid second byte" faults (AdminEventEscapeRecovery)
+	// AND v8 AA-injection budget exhaustion
+	// (AdminEventEscapeBudgetExhausted). The latter is a new fault
+	// mode introduced by v8's bounded AA absorption; semantically
+	// both indicate "the escape decoder gave up on a pending pair",
+	// so they share this single fault counter. The decomposed
+	// counters below (escapeBudgetExhaustedTotal,
+	// escapeRecoveryTotal) give granular visibility for operators
+	// who want to attribute decodeFaultTotal to a specific cause.
 	decodeFaultTotal atomic.Uint64
+
+	// escapePendingTimeoutTotal counts wire 0xA9 leads that spent
+	// more than EscapePendingTimeout (32 ms) in pending state without
+	// resolution, per v8 §1.3. Non-fatal: the decoder drops the
+	// orphaned 0xA9 plus any absorbed AAs and re-processes the
+	// current byte in NORMAL state to preserve data for next-byte
+	// resync. Distinct from decodeFaultTotal because timeout is a
+	// different failure mode (wire/adapter pathologically slow vs.
+	// malformed escape pair). Exposed via EscapePendingTimeoutTotal()
+	// for transport-level observability.
+	escapePendingTimeoutTotal atomic.Uint64
+
+	// escapeRecoveryTotal counts AdminEventEscapeRecovery emissions —
+	// a wire 0xA9 followed by a byte that is neither a valid
+	// completion (0x00 / 0x01) nor an absorbable 0xAA-within-budget.
+	// The decoder drops the 0xA9, absorbed AAs, AND the offending
+	// byte. Subset of decodeFaultTotal; exposed for granular
+	// operator visibility.
+	escapeRecoveryTotal atomic.Uint64
+
+	// escapeBudgetExhaustedTotal counts AdminEventEscapeBudgetExhausted
+	// emissions — a wire 0xA9 followed by more than
+	// MaxAaAbsorptionsPerEscapePair (8) consecutive 0xAA bytes. The
+	// decoder drops the 0xA9, all 8 absorbed AAs, and the
+	// over-budget AA. Subset of decodeFaultTotal; exposed for
+	// granular operator visibility.
+	escapeBudgetExhaustedTotal atomic.Uint64
+
+	// escapeAaAbsorbedTotal counts the cumulative number of 0xAA
+	// bytes the decoder absorbed mid-escape-pair across all
+	// transactions. Each absorption is a successful in-budget event
+	// (NOT a fault). Tracks the AA-injection load the v8 absorber is
+	// catching. Note: this is per-byte, not per-pair — a single pair
+	// that absorbed 3 AAs increments this counter by 3.
+	escapeAaAbsorbedTotal atomic.Uint64
 }
 
 // NewENHTransport creates a new ENH transport with read/write timeouts.
@@ -1331,13 +1378,12 @@ func (t *ENHTransport) resetPendingEscapeBeforeEmissionLocked() {
 	}
 }
 
-// feedEscapeDecoderLocked advances the F-23 eBUS escape decoder by one
+// feedEscapeDecoderLocked advances the eBUS escape decoder by one
 // wire byte WITHOUT making an emission decision. Returns the decoded
-// logical byte and its WasEscaped flag when a logical symbol is ready
-// (ok=true), or ok=false while accumulating an escape pair / on
-// invalid-pair fault. Invalid pairs increment decodeFaultTotal and
-// clear the decoder's internal state so subsequent calls resume
-// cleanly. Caller must hold readMu.
+// logical byte and its WasEscaped flag when a logical symbol is
+// ready (ok=true), or ok=false while accumulating an escape pair,
+// absorbing AA-injection mid-pair, or dropping a fault. Caller must
+// hold readMu.
 //
 // This primitive MUST be called on every wire byte the transport
 // observes, including bytes that are dropped by application-layer
@@ -1346,13 +1392,65 @@ func (t *ENHTransport) resetPendingEscapeBeforeEmissionLocked() {
 // 0xA9 lead stranded, and the next non-dropped byte would falsely
 // complete the stale pair (Codex bot P2 on PR-1: discarded-byte
 // discontinuity preserving pending escape).
+//
+// Phase 1 Step B1 (frame-atomic-visibility v8 §1.3 / §5, invariant
+// I4): the underlying decoder is now the v8 AA-aware version with
+// bounded AA-injection absorption (up to
+// MaxAaAbsorptionsPerEscapePair) and a wall-clock cap on the pending
+// state (EscapePendingTimeout). The StreamEvent contract is
+// preserved — callers see exactly the same `(decoded, ok,
+// wasEscaped)` triple. The v8 additions are surfaced via
+// transport-level admin counters:
+//
+//   - escapeAaAbsorbedTotal — every absorbed mid-pair 0xAA
+//     increments this (per-byte).
+//   - escapePendingTimeoutTotal — every 32 ms wall-clock cap hit.
+//     The orphaned 0xA9 is dropped; the current byte is
+//     re-processed in NORMAL state and emitted if it produces a
+//     decoded byte (data-preserving recovery).
+//   - escapeRecoveryTotal — 0xA9 followed by a byte that is neither
+//     0x00/0x01 nor an absorbable 0xAA. The 0xA9, absorbed AAs,
+//     AND the offending byte are all dropped. Increments
+//     decodeFaultTotal too (subset).
+//   - escapeBudgetExhaustedTotal — over-budget AA after 8
+//     absorptions. The 0xA9, 8 absorbed AAs, AND the over-budget
+//     AA are all dropped. Increments decodeFaultTotal too (subset).
 func (t *ENHTransport) feedEscapeDecoderLocked(raw byte) (decoded byte, ok bool, wasEscaped bool) {
-	var err error
-	decoded, ok, wasEscaped, err = t.escDecoder.Push(raw)
-	if err != nil {
-		// Invalid escape pair: increment the fault counter and drop.
-		// The decoder cleared its in-flight state before returning, so
-		// subsequent bytes resume cleanly.
+	// Snapshot the in-budget AA count BEFORE Feed so we can
+	// distinguish "AA absorbed this call" from "AA absorbed earlier".
+	absorbedBefore := t.escDecoder.AbsorbedCount()
+
+	var admin AdminEvent
+	decoded, ok, wasEscaped, admin = t.escDecoder.Feed(raw, time.Now())
+
+	// Account for any AA absorbed by this specific Feed call. The
+	// absorber increments AbsorbedCount when a 0xAA arrives mid-pair
+	// within budget, and resets to 0 on any exit from pending. So
+	// the per-call delta is +1 if we absorbed; otherwise 0 or
+	// negative-on-exit (which we map to 0).
+	if delta := t.escDecoder.AbsorbedCount() - absorbedBefore; delta > 0 {
+		t.escapeAaAbsorbedTotal.Add(uint64(delta))
+	}
+
+	switch admin.Kind {
+	case AdminEventEscapePendingTimeout:
+		// 32 ms cap hit. Orphaned 0xA9 + absorbed AAs dropped; the
+		// current byte was re-processed in NORMAL state and may have
+		// produced a decoded byte (`decoded`, `ok`, `wasEscaped` are
+		// the result of that re-processing). Surface the timeout but
+		// preserve the data-preserving recovery emission.
+		t.escapePendingTimeoutTotal.Add(1)
+	case AdminEventEscapeRecovery:
+		// Invalid escape pair: increment both fault counters and
+		// drop. The decoder cleared its in-flight state before
+		// returning.
+		t.escapeRecoveryTotal.Add(1)
+		t.decodeFaultTotal.Add(1)
+		return 0, false, false
+	case AdminEventEscapeBudgetExhausted:
+		// AA-injection budget exhausted: increment both fault
+		// counters and drop.
+		t.escapeBudgetExhaustedTotal.Add(1)
 		t.decodeFaultTotal.Add(1)
 		return 0, false, false
 	}
@@ -1394,14 +1492,73 @@ func (t *ENHTransport) appendWireSynLocked() {
 	}
 }
 
-// DecodeFaultTotal returns the cumulative count of invalid eBUS escape
-// pairs observed on the wire (a 0xA9 lead followed by a byte other
-// than 0x00 or 0x01). Non-fatal — the decoder drops the offending
-// pair and resumes on the next byte. Exposed for transport-level
-// observability surfaces (gateway metrics snapshot, admin endpoints).
-// Safe to call without holding readMu.
+// DecodeFaultTotal returns the cumulative count of invalid eBUS
+// escape sequences observed on the wire. Non-fatal — the decoder
+// drops the offending pair (and any absorbed AAs) and resumes on
+// the next byte. Exposed for transport-level observability surfaces
+// (gateway metrics snapshot, admin endpoints). Safe to call without
+// holding readMu.
+//
+// Phase 1 Step B1 (frame-atomic-visibility v8) widened the
+// definition to include BOTH:
+//
+//   - "0xA9 + invalid second byte" (the legacy fault, now
+//     AdminEventEscapeRecovery) — see EscapeRecoveryTotal.
+//   - "0xA9 + 8 AAs + over-budget AA" (a new v8 fault,
+//     AdminEventEscapeBudgetExhausted) — see
+//     EscapeBudgetExhaustedTotal.
+//
+// The 32 ms wall-clock timeout (AdminEventEscapePendingTimeout) is
+// NOT counted here because it is a data-preserving recovery (the
+// current byte is re-processed in NORMAL state and may emit
+// normally). See EscapePendingTimeoutTotal for that counter.
 func (t *ENHTransport) DecodeFaultTotal() uint64 {
 	return t.decodeFaultTotal.Load()
+}
+
+// EscapePendingTimeoutTotal returns the cumulative count of v8 32 ms
+// wall-clock cap hits on the escape decoder's pending state. Per v8
+// §1.3: beyond 32 ms the wire is considered genuinely broken, so the
+// decoder drops the orphaned 0xA9 plus any absorbed AAs and
+// re-processes the current byte in NORMAL state to preserve data
+// for next-byte resync. Non-fatal, data-preserving — distinct from
+// DecodeFaultTotal which counts drop-everything faults. Safe to call
+// without holding readMu.
+func (t *ENHTransport) EscapePendingTimeoutTotal() uint64 {
+	return t.escapePendingTimeoutTotal.Load()
+}
+
+// EscapeRecoveryTotal returns the cumulative count of v8
+// AdminEventEscapeRecovery events: a 0xA9 lead followed by a byte
+// that is neither 0x00/0x01 nor an absorbable 0xAA-within-budget.
+// Subset of DecodeFaultTotal. Exposed for granular operator
+// visibility into the fault mix (legacy invalid-pair vs. v8
+// budget-exhausted). Safe to call without holding readMu.
+func (t *ENHTransport) EscapeRecoveryTotal() uint64 {
+	return t.escapeRecoveryTotal.Load()
+}
+
+// EscapeBudgetExhaustedTotal returns the cumulative count of v8
+// AdminEventEscapeBudgetExhausted events: a 0xA9 lead followed by
+// more than MaxAaAbsorptionsPerEscapePair (8) consecutive 0xAA
+// bytes. Subset of DecodeFaultTotal. Exposed for granular operator
+// visibility — a non-zero rate here suggests adapter buffer
+// pathology (sustained AA-injection mid-escape) and may correlate
+// with round-9 absorb fires. Safe to call without holding readMu.
+func (t *ENHTransport) EscapeBudgetExhaustedTotal() uint64 {
+	return t.escapeBudgetExhaustedTotal.Load()
+}
+
+// EscapeAaAbsorbedTotal returns the cumulative number of 0xAA bytes
+// absorbed mid-escape-pair across all transactions. Each absorption
+// is a successful in-budget event (NOT a fault). Per-byte, not
+// per-pair — a single pair that absorbed 3 AAs increments this
+// counter by 3. Useful for measuring the AA-injection load the v8
+// absorber is catching; pair with EscapeBudgetExhaustedTotal to
+// detect a budget that is too small. Safe to call without holding
+// readMu.
+func (t *ENHTransport) EscapeAaAbsorbedTotal() uint64 {
+	return t.escapeAaAbsorbedTotal.Load()
 }
 
 // PostGrantWindowExpiredCount returns the cumulative count of

--- a/transport/enh_transport_v8_counters_test.go
+++ b/transport/enh_transport_v8_counters_test.go
@@ -152,77 +152,41 @@ func TestENHCounters_BudgetExhausted(t *testing.T) {
 	}
 }
 
-// TestENHCounters_WallClockTimeout pins that
-// AdminEventEscapePendingTimeout (0xA9 followed by a byte
-// >EscapePendingTimeout later) increments
-// EscapePendingTimeoutTotal AND emits the current byte (data-
-// preserving recovery — re-processed in NORMAL state). The
-// DecodeFaultTotal counter MUST stay at zero (timeout is not a
-// drop-everything fault).
+// NOTE — wall-clock timeout NOT covered by an integration test.
 //
-// Test sync model: net.Pipe is synchronous (Write blocks until Read
-// consumes). The pacedWriteGoroutine uses this property to interleave
-// real wall-clock sleeps BETWEEN byte writes — when the goroutine's
-// first Write returns, we know the transport has already fed the
-// 0xA9 to the decoder (entering pending state); the sleep then
-// counts toward the 32 ms cap; the second Write feeds the 0x55,
-// which sees elapsed > EscapePendingTimeout and fires the cap.
-func TestENHCounters_WallClockTimeout(t *testing.T) {
-	t.Parallel()
-
-	// Read timeout MUST exceed the 32 ms cap + scheduling jitter so
-	// the transport's net.Conn.Read deadline doesn't fire while we
-	// are deliberately stalling the wire.
-	const readTimeout = 2 * time.Second
-
-	client, server := net.Pipe()
-	defer func() { _ = client.Close() }()
-	defer func() { _ = server.Close() }()
-
-	enh := transport.NewENHTransport(client, readTimeout, readTimeout)
-
-	// Encode each byte upfront.
-	leadFrame := encodeENHWireByte(0xA9)
-	tailFrame := encodeENHWireByte(0x55)
-
-	// Paced writer: write the lead, wait for the transport to read
-	// it (net.Pipe Write returns when the read completes), sleep
-	// past the cap, then write the trailing byte.
-	go func() {
-		_, _ = server.Write(leadFrame)
-		// Lead is now in the decoder's pending state. Sleep past
-		// EscapePendingTimeout (32 ms) + a small jitter margin.
-		time.Sleep(transport.EscapePendingTimeout + 10*time.Millisecond)
-		_, _ = server.Write(tailFrame)
-	}()
-
-	events := drainBytes(t, enh, 1)
-	if events[0].Byte != 0x55 || events[0].WasEscaped {
-		t.Fatalf("post-timeout event = {Byte=0x%02X WasEscaped=%v}; want {0x55 false} (data-preserving recovery)",
-			events[0].Byte, events[0].WasEscaped)
-	}
-
-	if got := enh.EscapePendingTimeoutTotal(); got != 1 {
-		t.Errorf("EscapePendingTimeoutTotal() = %d; want 1", got)
-	}
-	// Timeout is data-preserving, NOT a drop-everything fault.
-	if got := enh.DecodeFaultTotal(); got != 0 {
-		t.Errorf("DecodeFaultTotal() = %d; want 0 (timeout is data-preserving, not a fault)", got)
-	}
-	if got := enh.EscapeRecoveryTotal(); got != 0 {
-		t.Errorf("EscapeRecoveryTotal() = %d; want 0", got)
-	}
-	if got := enh.EscapeBudgetExhaustedTotal(); got != 0 {
-		t.Errorf("EscapeBudgetExhaustedTotal() = %d; want 0", got)
-	}
-}
-
-// encodeENHWireByte returns the 2-byte ENHResReceived encoding of
-// `wire`. Local helper for the paced-write test pattern.
-func encodeENHWireByte(wire byte) []byte {
-	seq := transport.EncodeENH(transport.ENHResReceived, wire)
-	return []byte{seq[0], seq[1]}
-}
+// Codex round-2 review on PR #165 correctly observed that any
+// integration test that relies on a wall-clock sleep between two
+// net.Pipe writes has an unavoidable race: net.Pipe.Write returns
+// when the matching Read consumes the bytes from the underlying
+// conn, but it does NOT prove the transport's read loop has yet
+// fed those bytes through the escape decoder (the decoder feed
+// happens AFTER the conn.Read returns, in the same goroutine but
+// after a Parse step). If the scheduler delays the reader, the
+// test's wall-clock sleep can elapse before the decoder records
+// the lead's `leadObservedAt`, and the timeout will not fire.
+//
+// We have three orthogonal layers of coverage that, together, pin
+// the wall-clock timeout contract without this race:
+//
+//   - `ebus_escape_v8_test.go::TestFeed_WallClockCap_*`: pins the
+//     decoder-level timeout semantics deterministically with
+//     synthetic times. Three tests cover beyond-cap, exact-boundary,
+//     and timeout-byte-is-a-new-0xA9.
+//   - `enh_transport_v8_counters_test.go` (this file): pins the
+//     ENHTransport plumbing for the OTHER three admin event kinds
+//     (Recovery, BudgetExhausted, AaAbsorbed); the timeout case's
+//     wiring is a one-line `t.escapePendingTimeoutTotal.Add(1)`
+//     visually parallel to the tested Recovery and BudgetExhausted
+//     branches.
+//   - `v8_constant_drift_test.go`: pins
+//     transport.EscapePendingTimeout == protocol.FrameAtomicV8EscapePendingTimeout
+//     so the constant cannot silently regress.
+//
+// If a future refactor moves the timeout wiring to a non-trivial
+// shape, this note should be revisited — either a clock-injection
+// hook on ENHTransport or a test-only "wait until decoder pending"
+// synchronization barrier would unlock a deterministic integration
+// test.
 
 // TestENHCounters_AccumulatesAcrossEvents pins that the counters
 // accumulate monotonically across multiple events of the same kind

--- a/transport/enh_transport_v8_counters_test.go
+++ b/transport/enh_transport_v8_counters_test.go
@@ -152,7 +152,8 @@ func TestENHCounters_BudgetExhausted(t *testing.T) {
 	}
 }
 
-// NOTE — wall-clock timeout NOT covered by an integration test.
+// NOTE — wall-clock timeout NOT covered by an end-to-end ENH
+// integration test in this file.
 //
 // Codex round-2 review on PR #165 correctly observed that any
 // integration test that relies on a wall-clock sleep between two
@@ -160,33 +161,46 @@ func TestENHCounters_BudgetExhausted(t *testing.T) {
 // when the matching Read consumes the bytes from the underlying
 // conn, but it does NOT prove the transport's read loop has yet
 // fed those bytes through the escape decoder (the decoder feed
-// happens AFTER the conn.Read returns, in the same goroutine but
+// happens AFTER conn.Read returns, in the same goroutine but
 // after a Parse step). If the scheduler delays the reader, the
 // test's wall-clock sleep can elapse before the decoder records
 // the lead's `leadObservedAt`, and the timeout will not fire.
 //
-// We have three orthogonal layers of coverage that, together, pin
-// the wall-clock timeout contract without this race:
+// Coverage of the wall-clock timeout contract is split across four
+// deterministic layers — collectively they pin every layer of the
+// pipeline without the scheduler race:
 //
-//   - `ebus_escape_v8_test.go::TestFeed_WallClockCap_*`: pins the
-//     decoder-level timeout semantics deterministically with
-//     synthetic times. Three tests cover beyond-cap, exact-boundary,
-//     and timeout-byte-is-a-new-0xA9.
-//   - `enh_transport_v8_counters_test.go` (this file): pins the
-//     ENHTransport plumbing for the OTHER three admin event kinds
-//     (Recovery, BudgetExhausted, AaAbsorbed); the timeout case's
-//     wiring is a one-line `t.escapePendingTimeoutTotal.Add(1)`
-//     visually parallel to the tested Recovery and BudgetExhausted
-//     branches.
-//   - `v8_constant_drift_test.go`: pins
-//     transport.EscapePendingTimeout == protocol.FrameAtomicV8EscapePendingTimeout
-//     so the constant cannot silently regress.
+//   1. **Decoder semantics** —
+//      `ebus_escape_v8_test.go::TestFeed_WallClockCap_*` uses
+//      synthetic times to assert the decoder emits
+//      AdminEventEscapePendingTimeout under the right elapsed
+//      condition (3 tests: beyond-cap, exact-boundary,
+//      timeout-byte-is-a-new-0xA9).
+//   2. **Constant alignment** — `v8_constant_drift_test.go` asserts
+//      `transport.EscapePendingTimeout ==
+//      protocol.FrameAtomicV8EscapePendingTimeout` so the 32 ms
+//      value cannot regress.
+//   3. **ENHTransport admin-event-to-counter routing** —
+//      `apply_escape_admin_event_test.go` directly unit-tests the
+//      `applyEscapeAdminEvent` free function (extracted from
+//      `feedEscapeDecoderLocked` per Codex round-3) with each
+//      AdminEvent kind as input. The PendingTimeout branch is
+//      executable-tested for: counter increment, NO decodeFault
+//      increment (data-preserving invariant), dropEmission=false.
+//   4. **ENHTransport plumbing for other admin event kinds** —
+//      this file pins Recovery, BudgetExhausted, and AaAbsorbed
+//      via the end-to-end ENH stream path (5 deterministic tests).
+//      The PendingTimeout integration path is the ONLY admin event
+//      kind without an end-to-end test; the deterministic unit
+//      test in #3 above covers the routing contract that the
+//      end-to-end test would otherwise exercise.
 //
-// If a future refactor moves the timeout wiring to a non-trivial
-// shape, this note should be revisited — either a clock-injection
-// hook on ENHTransport or a test-only "wait until decoder pending"
-// synchronization barrier would unlock a deterministic integration
-// test.
+// If a future refactor changes the routing shape (e.g. moves
+// counter increments back into a non-extractable inline switch),
+// the unit test in #3 would need to be re-derived; either a
+// clock-injection hook on ENHTransport or a test-only "wait until
+// decoder pending" synchronization barrier would unlock a true
+// end-to-end timeout integration test.
 
 // TestENHCounters_AccumulatesAcrossEvents pins that the counters
 // accumulate monotonically across multiple events of the same kind

--- a/transport/enh_transport_v8_counters_test.go
+++ b/transport/enh_transport_v8_counters_test.go
@@ -1,0 +1,278 @@
+package transport_test
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/Project-Helianthus/helianthus-ebusgo/transport"
+)
+
+// Phase 1 Step B1 (frame-atomic-visibility v8 §1.3 / §5, invariant
+// I4): integration tests at the ENHTransport boundary verifying
+// that the v8 admin events from the AA-aware escape decoder are
+// correctly routed to the public counter accessors. These tests are
+// the regression guard for Codex's round-1 MINOR finding — the
+// decoder-only tests in ebus_escape_v8_test.go prove the decoder
+// emits admin events; these tests prove the ENHTransport
+// feedEscapeDecoderLocked plumbing wires those events to the right
+// counters.
+
+// TestENHCounters_PlainBytes_AllZero pins the baseline — a stream
+// with no escape sequences must leave all v8 counters at zero.
+func TestENHCounters_PlainBytes_AllZero(t *testing.T) {
+	t.Parallel()
+
+	client, server := net.Pipe()
+	defer func() { _ = client.Close() }()
+	defer func() { _ = server.Close() }()
+
+	enh := transport.NewENHTransport(client, 500*time.Millisecond, 500*time.Millisecond)
+	feedENHReceivedBytes(t, server, []byte{0x00, 0x55, 0xFE, 0x7F})
+
+	_ = drainBytes(t, enh, 4)
+
+	assertCountersZero(t, enh)
+}
+
+// TestENHCounters_AaAbsorbed pins that an in-budget AA-injection
+// increments EscapeAaAbsorbedTotal per absorbed byte and leaves the
+// fault counters at zero (clean recovery).
+func TestENHCounters_AaAbsorbed(t *testing.T) {
+	t.Parallel()
+
+	client, server := net.Pipe()
+	defer func() { _ = client.Close() }()
+	defer func() { _ = server.Close() }()
+
+	enh := transport.NewENHTransport(client, 500*time.Millisecond, 500*time.Millisecond)
+	// 0xA9 (lead), 0xAA (absorbed), 0xAA (absorbed), 0x01 (real completion → emits 0xAA WasEscaped=true)
+	feedENHReceivedBytes(t, server, []byte{0xA9, 0xAA, 0xAA, 0x01})
+
+	events := drainBytes(t, enh, 1)
+	if events[0].Byte != 0xAA || !events[0].WasEscaped {
+		t.Fatalf("decoded event = {Byte=0x%02X WasEscaped=%v}; want {0xAA true}",
+			events[0].Byte, events[0].WasEscaped)
+	}
+
+	if got := enh.EscapeAaAbsorbedTotal(); got != 2 {
+		t.Errorf("EscapeAaAbsorbedTotal() = %d; want 2 (one per absorbed AA)", got)
+	}
+	if got := enh.EscapeRecoveryTotal(); got != 0 {
+		t.Errorf("EscapeRecoveryTotal() = %d; want 0 (clean recovery)", got)
+	}
+	if got := enh.EscapeBudgetExhaustedTotal(); got != 0 {
+		t.Errorf("EscapeBudgetExhaustedTotal() = %d; want 0", got)
+	}
+	if got := enh.EscapePendingTimeoutTotal(); got != 0 {
+		t.Errorf("EscapePendingTimeoutTotal() = %d; want 0", got)
+	}
+	if got := enh.DecodeFaultTotal(); got != 0 {
+		t.Errorf("DecodeFaultTotal() = %d; want 0 (absorption is not a fault)", got)
+	}
+}
+
+// TestENHCounters_InvalidSecondByte_Recovery pins that
+// AdminEventEscapeRecovery (0xA9 followed by a byte that's not
+// 0x00/0x01/0xAA) increments both EscapeRecoveryTotal and
+// DecodeFaultTotal, drops the offending bytes, and leaves the
+// stream consistent for subsequent bytes.
+func TestENHCounters_InvalidSecondByte_Recovery(t *testing.T) {
+	t.Parallel()
+
+	client, server := net.Pipe()
+	defer func() { _ = client.Close() }()
+	defer func() { _ = server.Close() }()
+
+	enh := transport.NewENHTransport(client, 500*time.Millisecond, 500*time.Millisecond)
+	// 0xA9 (lead), 0xFF (invalid → recovery, drop both), 0x55 (plain byte, emitted)
+	feedENHReceivedBytes(t, server, []byte{0xA9, 0xFF, 0x55})
+
+	events := drainBytes(t, enh, 1)
+	if events[0].Byte != 0x55 || events[0].WasEscaped {
+		t.Fatalf("decoded event = {Byte=0x%02X WasEscaped=%v}; want {0x55 false}",
+			events[0].Byte, events[0].WasEscaped)
+	}
+
+	if got := enh.EscapeRecoveryTotal(); got != 1 {
+		t.Errorf("EscapeRecoveryTotal() = %d; want 1", got)
+	}
+	if got := enh.DecodeFaultTotal(); got != 1 {
+		t.Errorf("DecodeFaultTotal() = %d; want 1 (recovery is a fault)", got)
+	}
+	if got := enh.EscapeBudgetExhaustedTotal(); got != 0 {
+		t.Errorf("EscapeBudgetExhaustedTotal() = %d; want 0", got)
+	}
+	if got := enh.EscapeAaAbsorbedTotal(); got != 0 {
+		t.Errorf("EscapeAaAbsorbedTotal() = %d; want 0 (no AA absorbed before recovery)", got)
+	}
+}
+
+// TestENHCounters_BudgetExhausted pins that
+// AdminEventEscapeBudgetExhausted (0xA9 + 9 consecutive AAs)
+// increments both EscapeBudgetExhaustedTotal and DecodeFaultTotal,
+// AND increments EscapeAaAbsorbedTotal by exactly
+// MaxAaAbsorptionsPerEscapePair (the 8 absorbed AAs, NOT the
+// over-budget 9th).
+func TestENHCounters_BudgetExhausted(t *testing.T) {
+	t.Parallel()
+
+	client, server := net.Pipe()
+	defer func() { _ = client.Close() }()
+	defer func() { _ = server.Close() }()
+
+	enh := transport.NewENHTransport(client, 500*time.Millisecond, 500*time.Millisecond)
+	// 0xA9 + 9 consecutive AAs (1 over budget).
+	stream := []byte{0xA9}
+	for i := 0; i < transport.MaxAaAbsorptionsPerEscapePair+1; i++ {
+		stream = append(stream, 0xAA)
+	}
+	// Trailing plain byte to confirm clean resume.
+	stream = append(stream, 0x77)
+	feedENHReceivedBytes(t, server, stream)
+
+	events := drainBytes(t, enh, 1)
+	if events[0].Byte != 0x77 || events[0].WasEscaped {
+		t.Fatalf("post-exhaust event = {Byte=0x%02X WasEscaped=%v}; want {0x77 false}",
+			events[0].Byte, events[0].WasEscaped)
+	}
+
+	if got := enh.EscapeBudgetExhaustedTotal(); got != 1 {
+		t.Errorf("EscapeBudgetExhaustedTotal() = %d; want 1", got)
+	}
+	if got := enh.DecodeFaultTotal(); got != 1 {
+		t.Errorf("DecodeFaultTotal() = %d; want 1", got)
+	}
+	if got := enh.EscapeAaAbsorbedTotal(); got != uint64(transport.MaxAaAbsorptionsPerEscapePair) {
+		t.Errorf("EscapeAaAbsorbedTotal() = %d; want %d (only the in-budget AAs count)",
+			got, transport.MaxAaAbsorptionsPerEscapePair)
+	}
+	if got := enh.EscapeRecoveryTotal(); got != 0 {
+		t.Errorf("EscapeRecoveryTotal() = %d; want 0", got)
+	}
+}
+
+// TestENHCounters_WallClockTimeout pins that
+// AdminEventEscapePendingTimeout (0xA9 followed by a byte
+// >EscapePendingTimeout later) increments
+// EscapePendingTimeoutTotal AND emits the current byte (data-
+// preserving recovery — re-processed in NORMAL state). The
+// DecodeFaultTotal counter MUST stay at zero (timeout is not a
+// drop-everything fault).
+//
+// Test sync model: net.Pipe is synchronous (Write blocks until Read
+// consumes). The pacedWriteGoroutine uses this property to interleave
+// real wall-clock sleeps BETWEEN byte writes — when the goroutine's
+// first Write returns, we know the transport has already fed the
+// 0xA9 to the decoder (entering pending state); the sleep then
+// counts toward the 32 ms cap; the second Write feeds the 0x55,
+// which sees elapsed > EscapePendingTimeout and fires the cap.
+func TestENHCounters_WallClockTimeout(t *testing.T) {
+	t.Parallel()
+
+	// Read timeout MUST exceed the 32 ms cap + scheduling jitter so
+	// the transport's net.Conn.Read deadline doesn't fire while we
+	// are deliberately stalling the wire.
+	const readTimeout = 2 * time.Second
+
+	client, server := net.Pipe()
+	defer func() { _ = client.Close() }()
+	defer func() { _ = server.Close() }()
+
+	enh := transport.NewENHTransport(client, readTimeout, readTimeout)
+
+	// Encode each byte upfront.
+	leadFrame := encodeENHWireByte(0xA9)
+	tailFrame := encodeENHWireByte(0x55)
+
+	// Paced writer: write the lead, wait for the transport to read
+	// it (net.Pipe Write returns when the read completes), sleep
+	// past the cap, then write the trailing byte.
+	go func() {
+		_, _ = server.Write(leadFrame)
+		// Lead is now in the decoder's pending state. Sleep past
+		// EscapePendingTimeout (32 ms) + a small jitter margin.
+		time.Sleep(transport.EscapePendingTimeout + 10*time.Millisecond)
+		_, _ = server.Write(tailFrame)
+	}()
+
+	events := drainBytes(t, enh, 1)
+	if events[0].Byte != 0x55 || events[0].WasEscaped {
+		t.Fatalf("post-timeout event = {Byte=0x%02X WasEscaped=%v}; want {0x55 false} (data-preserving recovery)",
+			events[0].Byte, events[0].WasEscaped)
+	}
+
+	if got := enh.EscapePendingTimeoutTotal(); got != 1 {
+		t.Errorf("EscapePendingTimeoutTotal() = %d; want 1", got)
+	}
+	// Timeout is data-preserving, NOT a drop-everything fault.
+	if got := enh.DecodeFaultTotal(); got != 0 {
+		t.Errorf("DecodeFaultTotal() = %d; want 0 (timeout is data-preserving, not a fault)", got)
+	}
+	if got := enh.EscapeRecoveryTotal(); got != 0 {
+		t.Errorf("EscapeRecoveryTotal() = %d; want 0", got)
+	}
+	if got := enh.EscapeBudgetExhaustedTotal(); got != 0 {
+		t.Errorf("EscapeBudgetExhaustedTotal() = %d; want 0", got)
+	}
+}
+
+// encodeENHWireByte returns the 2-byte ENHResReceived encoding of
+// `wire`. Local helper for the paced-write test pattern.
+func encodeENHWireByte(wire byte) []byte {
+	seq := transport.EncodeENH(transport.ENHResReceived, wire)
+	return []byte{seq[0], seq[1]}
+}
+
+// TestENHCounters_AccumulatesAcrossEvents pins that the counters
+// accumulate monotonically across multiple events of the same kind
+// in a single ENHTransport instance.
+func TestENHCounters_AccumulatesAcrossEvents(t *testing.T) {
+	t.Parallel()
+
+	client, server := net.Pipe()
+	defer func() { _ = client.Close() }()
+	defer func() { _ = server.Close() }()
+
+	enh := transport.NewENHTransport(client, 500*time.Millisecond, 500*time.Millisecond)
+	// Two consecutive recovery faults, then plain byte to confirm
+	// the decoder is still healthy.
+	feedENHReceivedBytes(t, server, []byte{
+		0xA9, 0xFF, // recovery #1
+		0xA9, 0xFE, // recovery #2
+		0x33, // plain byte (emitted)
+	})
+
+	events := drainBytes(t, enh, 1)
+	if events[0].Byte != 0x33 || events[0].WasEscaped {
+		t.Fatalf("final event = {Byte=0x%02X WasEscaped=%v}; want {0x33 false}",
+			events[0].Byte, events[0].WasEscaped)
+	}
+
+	if got := enh.EscapeRecoveryTotal(); got != 2 {
+		t.Errorf("EscapeRecoveryTotal() = %d; want 2 (monotonic accumulation)", got)
+	}
+	if got := enh.DecodeFaultTotal(); got != 2 {
+		t.Errorf("DecodeFaultTotal() = %d; want 2", got)
+	}
+}
+
+// assertCountersZero is a helper used by the baseline test.
+func assertCountersZero(t *testing.T, enh *transport.ENHTransport) {
+	t.Helper()
+	if got := enh.EscapeAaAbsorbedTotal(); got != 0 {
+		t.Errorf("EscapeAaAbsorbedTotal() = %d; want 0", got)
+	}
+	if got := enh.EscapePendingTimeoutTotal(); got != 0 {
+		t.Errorf("EscapePendingTimeoutTotal() = %d; want 0", got)
+	}
+	if got := enh.EscapeRecoveryTotal(); got != 0 {
+		t.Errorf("EscapeRecoveryTotal() = %d; want 0", got)
+	}
+	if got := enh.EscapeBudgetExhaustedTotal(); got != 0 {
+		t.Errorf("EscapeBudgetExhaustedTotal() = %d; want 0", got)
+	}
+	if got := enh.DecodeFaultTotal(); got != 0 {
+		t.Errorf("DecodeFaultTotal() = %d; want 0", got)
+	}
+}

--- a/transport/v8_constant_drift_test.go
+++ b/transport/v8_constant_drift_test.go
@@ -1,0 +1,49 @@
+package transport_test
+
+import (
+	"testing"
+
+	"github.com/Project-Helianthus/helianthus-ebusgo/protocol"
+	"github.com/Project-Helianthus/helianthus-ebusgo/transport"
+)
+
+// Phase 1 Step B1 (frame-atomic-visibility v8 §1.3 / §5, invariant
+// I4): the transport package mirrors two v8 constants from the
+// protocol package because production-code in transport cannot
+// import protocol (circular dependency). External test code is the
+// ONLY layer that can hold both packages and prove the mirror has
+// not drifted.
+//
+// These tests are the drift guard. If they fail, either:
+//   - protocol/frame_atomic_v8_timeouts.go changed and transport
+//     was not updated, or
+//   - transport/ebus_escape.go changed the mirror to a different
+//     literal without updating the protocol source of truth.
+//
+// Either way, the mismatch is a bug: protocol is the source of
+// truth (v8 design constants live there) and transport must
+// faithfully mirror.
+
+// TestV8DriftGuard_MaxAaAbsorptionsPerEscapePair asserts the
+// AA-injection absorption budget matches across packages.
+func TestV8DriftGuard_MaxAaAbsorptionsPerEscapePair(t *testing.T) {
+	t.Parallel()
+
+	if transport.MaxAaAbsorptionsPerEscapePair != protocol.FrameAtomicV8MaxAaAbsorptionsPerEscapePair {
+		t.Fatalf("v8 constant drift: transport.MaxAaAbsorptionsPerEscapePair=%d, protocol.FrameAtomicV8MaxAaAbsorptionsPerEscapePair=%d; both must match (v8 §5 / I4)",
+			transport.MaxAaAbsorptionsPerEscapePair,
+			protocol.FrameAtomicV8MaxAaAbsorptionsPerEscapePair)
+	}
+}
+
+// TestV8DriftGuard_EscapePendingTimeout asserts the 32 ms
+// wall-clock cap matches across packages.
+func TestV8DriftGuard_EscapePendingTimeout(t *testing.T) {
+	t.Parallel()
+
+	if transport.EscapePendingTimeout != protocol.FrameAtomicV8EscapePendingTimeout {
+		t.Fatalf("v8 constant drift: transport.EscapePendingTimeout=%v, protocol.FrameAtomicV8EscapePendingTimeout=%v; both must match (v8 §1.3)",
+			transport.EscapePendingTimeout,
+			protocol.FrameAtomicV8EscapePendingTimeout)
+	}
+}


### PR DESCRIPTION
## Summary

Replaces the legacy F-23 escape-pair decoder with the
frame-atomic-visibility v8 §1.3 / §5 / I4 semantics in `ebusgo/transport/`.
Previous Step B1 (PR #105 in `helianthus-ebus-adapter-proxy`) landed
the same logic in the standalone proxy as a bonus side-deliverable;
this PR brings it to the **primary** target — the gateway's
adapter-facing read path uses `ebusgo`'s `ENHTransport`.

Preserves the `StreamEvent{Byte, WasEscaped}` contract — every caller
of `feedEscapeDecoderLocked` sees the same return triple. The v8
additions are surfaced via NEW transport counters, NOT via byte-stream
content changes (per v8 invariant I1: admin events never inject into
client byte streams).

## v8 semantics added

| Feature | Constant | Failure mode (admin event) |
|---|---|---|
| AA-injection absorption | `MaxAaAbsorptionsPerEscapePair = 8` | `AdminEventEscapeBudgetExhausted` |
| Wall-clock cap on pending state | `EscapePendingTimeout = 32 ms` | `AdminEventEscapePendingTimeout` (data-preserving — current byte re-processed in NORMAL state) |
| Invalid second byte | (same as before) | `AdminEventEscapeRecovery` |

Constants mirror `protocol/frame_atomic_v8_timeouts.go` (transport
cannot import protocol due to circular dep; mirror is annotated).

## New transport counters

- `EscapePendingTimeoutTotal()` — 32 ms cap hits (NEW; data-preserving recovery)
- `EscapeRecoveryTotal()` — invalid second byte (subset of `DecodeFaultTotal`)
- `EscapeBudgetExhaustedTotal()` — AA-injection budget exhausted (subset of `DecodeFaultTotal`)
- `EscapeAaAbsorbedTotal()` — per-byte count of absorbed mid-pair AAs

`DecodeFaultTotal` still increments for Recovery + BudgetExhausted so
operators see no monotonicity break. Timeout is NOT counted there
(data-preserving).

## API surface

- `Feed(raw byte, now time.Time)` — new v8 entry point with admin event.
- `Push(raw byte)` — preserved for legacy callers; delegates to `Feed`
  with zero time (suppresses wall-clock cap), maps Recovery/BudgetExhausted to err.

## Tests (13 new, all green under `-race`)

| Test | Asserts |
|---|---|
| `TestFeed_PlainPassthrough` | non-0xA9 bytes pass through, no admin |
| `TestFeed_A9_01_DecodesToAA` | canonical pair, wasEscaped=true |
| `TestFeed_A9_00_DecodesToA9` | canonical pair, wasEscaped=true |
| `TestFeed_A9_AA_Absorbed_Then_01` | 1 AA absorbed, then real completion |
| `TestFeed_A9_MaxAA_Then_01` | 8 AAs absorbed at upper edge, then completion |
| `TestFeed_BudgetExhausted_AA_Over9` | 9 AAs → drop all, resume cleanly |
| `TestFeed_InvalidSecondByte` | 0xA9+0xFF → drop, AdminEventEscapeRecovery |
| `TestFeed_WallClockCap_BeyondTimeout` | 32 ms+1 → timeout, re-process current byte |
| `TestFeed_WallClockCap_BoundaryExact` | exactly 32 ms NOT past cap (strict >) |
| `TestFeed_WallClockCap_TimeoutBytePreservedAsEscape` | timeout + current byte is new 0xA9 → start new pending |
| `TestFeed_Reset_ClearsAbsorbedAndLeadTime` | Reset() wipes v8 fields too |
| `TestFeed_Push_LegacyContract_WithAbsorption` | DOCUMENTS intentional Push behavior change |
| `TestFeed_Push_BudgetExhausted_StillReturnsErr` | Push wrapper still surfaces err on budget exhaust |

## Behavior change in Push (documented)

Pre-v8: `Push(0xA9), Push(0xAA)` → err.
Post-v8: `Push(0xA9), Push(0xAA)` → absorbed (success path).

Search of the repo confirmed no callers exercise this specific
sequence — `feedEscapeDecoderLocked` already routed err to the same
drop-and-count path that v8 now does via admin events.

## Test plan

- [x] `go test ./transport/ -run TestFeed -count=1 -race` — 13 new tests green
- [x] `go test ./... -count=1 -race` — full suite green, no regressions
- [x] `go vet ./...` clean
- [x] `gofmt -l` clean
- [x] Terminology gate (GH Actions exclusion list) clean
- [x] Public symbol gate clean

## References

- frame-atomic-visibility-v8 §1.3 — escape decoder spec
- frame-atomic-visibility-v8 §5 — telegram FSM integration
- frame-atomic-visibility-v8 I4 — 8-AA OR 32-ms bound (whichever first)
- [helianthus-ebus-adapter-proxy PR #105](https://github.com/Project-Helianthus/helianthus-ebus-adapter-proxy/pull/105) — standalone-proxy reference impl

🤖 Generated with [Claude Code](https://claude.com/claude-code)