### PR TITLE
v0.5.1 ebusgo: frame-atomic-visibility v8 protocol updates → main

### DIFF
--- a/protocol/bus.go
+++ b/protocol/bus.go
@@ -130,6 +130,36 @@ type Bus struct {
 	payloadAaAutoSynAbsorbed       atomic.Uint64
 	payloadAaAutoSynRecovered      atomic.Uint64
 	payloadAaAutoSynDrainExhausted atomic.Uint64
+
+	// Phase 1 Step B4 (frame-atomic-v8 §1.8 / §1.12, retained per v8 I8):
+	// activeEchoWaits is a bus-wide phase predicate counter — it is >0
+	// whenever ONE OR MORE goroutines on this Bus are inside the active
+	// echo-wait phase of sendRawWithEcho (between a successful raw-byte
+	// Write and the resolution of its echo). It is NOT goroutine-local;
+	// the predicate inSendRawWithEchoActiveEchoWait() answers "is any
+	// goroutine on this Bus currently in echo wait?", not "did THIS
+	// caller arrive via sendRawWithEcho?". For the only current call
+	// site (round-9 absorb entry, also inside sendRawWithEcho), this
+	// distinction is moot — the answer is always true. The predicate
+	// exists to document the phase invariant and to give the Prometheus
+	// alert a runtime hook; future call sites that try to count round-9
+	// fires from outside sendRawWithEcho would need a different
+	// per-call mechanism (e.g. an explicit token argument).
+	//
+	// round9AbsorbEntered counts how many times the round-9 AUTO-SYN
+	// absorb predicate fired while the active-echo-wait predicate held.
+	// The counter is deliberately named neutrally: this code has no
+	// notion of whether a proxy is mediating wire AUTO-SYNs. The
+	// Prometheus alert HelianthusRound9FiredUnderProxy (defined in the
+	// gateway deploy manifest — see helianthus-docs-ebus →
+	// deployment/prometheus-alerts.md, NOT in this repo) is the layer
+	// that AND-s this counter with the adaptermux classifier_mode label
+	// to derive "round-9 fired while proxy SHOULD have filtered". Per
+	// v8 I8 the round-9 absorb code itself is retained as the legacy
+	// fallback for direct-adapter mode; expected steady-state under
+	// classifier_mode == enforce is counter rate == 0.
+	activeEchoWaits     atomic.Int32
+	round9AbsorbEntered atomic.Uint64
 }
 
 // NewBus initializes a Bus with transport, config, and optional queue capacity.
@@ -1019,6 +1049,17 @@ func (b *Bus) sendRawWithEcho(runCtx, reqCtx context.Context, raw byte, expectRa
 		Byte:    raw,
 	})
 
+	// Phase 1 Step B4 (frame-atomic-v8 §1.8): mark the bus as being in
+	// the active echo-wait phase from here until this call returns.
+	// inSendRawWithEchoActiveEchoWait() must hold for any round-9
+	// AUTO-SYN absorb fire to count toward the proxy-mediated alert
+	// counter — gating the increment on this predicate prevents future
+	// callers that mimic the absorb shape from outside the
+	// sendRawWithEcho call-stack from tripping the
+	// HelianthusRound9FiredUnderProxy alert (v8 §1.12).
+	b.activeEchoWaits.Add(1)
+	defer b.activeEchoWaits.Add(-1)
+
 	// F-23 (batch-19, Codex bot follow-up review on PR #154): for
 	// ENH-class transports, read the echo via the EscapeFlaggedReader
 	// path so we can distinguish a real wire SYN from an escape-
@@ -1161,6 +1202,21 @@ func (b *Bus) sendRawWithEcho(runCtx, reqCtx context.Context, raw byte, expectRa
 	// legitimate arbitration collisions where we wrote a non-SYN and
 	// the bus is idle (a real defect, not buffering interference).
 	if flagged != nil && !expectRawSyn && raw == SymbolSyn && echo == SymbolSyn && !echoWasEscaped {
+		// Phase 1 Step B4 (frame-atomic-v8 §1.8): the round-9 absorb
+		// predicate just fired. The neutrally-named round9AbsorbEntered
+		// counter increments here, gated on the runtime phase predicate
+		// inSendRawWithEchoActiveEchoWait(). At this call site the
+		// predicate is always true by construction (we are inside
+		// sendRawWithEcho between Write and echo resolution); the gate
+		// is kept as a phase assertion, not as proof of any cross-repo
+		// state (this code has zero proxy-awareness — the
+		// proxy-mediated interpretation lives in the Prometheus alert
+		// HelianthusRound9FiredUnderProxy, not in the counter name).
+		// Round-9 absorb itself is RETAINED per v8 I8 as the legacy
+		// fallback for direct-adapter mode.
+		if b.inSendRawWithEchoActiveEchoWait() {
+			b.round9AbsorbEntered.Add(1)
+		}
 		const maxPayloadAaAutoSynDrains = 3
 		absorbed := 0
 		drainExhausted := true // assume cap-exhausted; flipped to false on any non-SYN break
@@ -1456,6 +1512,42 @@ func (b *Bus) PayloadAaAutoSynRecovered() uint64 {
 // behavior for adapter-genuinely-stuck cases.
 func (b *Bus) PayloadAaAutoSynDrainExhausted() uint64 {
 	return b.payloadAaAutoSynDrainExhausted.Load()
+}
+
+// inSendRawWithEchoActiveEchoWait reports whether at least one
+// goroutine on this Bus is currently inside the active echo-wait
+// phase of sendRawWithEcho — i.e. between a successful raw-byte
+// Write and the resolution of its echo. The predicate is bus-wide,
+// not goroutine-local; it answers "is any goroutine in echo wait?",
+// not "did the caller arrive via sendRawWithEcho?". For the only
+// current call site (the round-9 absorb predicate, itself inside
+// sendRawWithEcho) the predicate is always true and the gate is a
+// no-op assertion. The hook exists for Prometheus / future call
+// sites and documents the phase invariant explicitly.
+func (b *Bus) inSendRawWithEchoActiveEchoWait() bool {
+	return b.activeEchoWaits.Load() > 0
+}
+
+// Round9AbsorbEntered returns the cumulative count of round-9
+// AUTO-SYN absorb predicate fires that occurred while the bus was in
+// the active echo-wait phase of sendRawWithEcho. The counter is
+// deliberately named neutrally: this code has no notion of whether a
+// proxy is mediating wire AUTO-SYNs, so it counts every entry
+// regardless of deployment mode. The Prometheus alert that AND-s
+// this counter with the adaptermux classifier-mode label
+// (HelianthusRound9FiredUnderProxy — see helianthus-docs-ebus →
+// deployment/prometheus-alerts.md) is what makes the round-9-under-
+// proxy interpretation. Per frame-atomic-v8 I8 the round-9 absorb
+// code itself is RETAINED as the legacy fallback for direct-adapter
+// mode; expected steady-state under classifier_mode == enforce is
+// counter rate == 0.
+//
+// Suggested Prometheus name: helianthus_round9_absorb_entered_total.
+// Pair with PayloadAaAutoSynAbsorbed / PayloadAaAutoSynRecovered /
+// PayloadAaAutoSynDrainExhausted for severity dashboards (per-byte
+// drained, recovery rate, cap exhaustion).
+func (b *Bus) Round9AbsorbEntered() uint64 {
+	return b.round9AbsorbEntered.Load()
 }
 
 func (b *Bus) emitAttemptComplete(request Frame, response *Frame, frameType FrameType, attempt uint16, startedAt time.Time) {

--- a/protocol/bus_round9_proxy_mediated_counter_test.go
+++ b/protocol/bus_round9_proxy_mediated_counter_test.go
@@ -1,0 +1,478 @@
+package protocol_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+
+	ebuserrors "github.com/Project-Helianthus/helianthus-ebusgo/errors"
+	"github.com/Project-Helianthus/helianthus-ebusgo/protocol"
+	"github.com/Project-Helianthus/helianthus-ebusgo/transport"
+)
+
+// writeFailTransport returns an error from Write after a configured
+// number of successful writes. Used to assert that a Write-phase
+// error in sendRawWithEcho does NOT increment Round9AbsorbEntered
+// and leaves no lingering active-echo-wait state on the Bus.
+type writeFailTransport struct {
+	mu          sync.Mutex
+	writes      int
+	failOnWrite int // 1 = fail on the FIRST write (no successful writes), 2 = fail on the 2nd, ...
+}
+
+var (
+	_ transport.RawTransport        = (*writeFailTransport)(nil)
+	_ transport.EscapeAware         = (*writeFailTransport)(nil)
+	_ transport.EscapeFlaggedReader = (*writeFailTransport)(nil)
+)
+
+var errSyntheticWriteFailure = errors.New("synthetic write failure")
+
+func (t *writeFailTransport) ReadByte() (byte, error) {
+	// Never expected to be invoked — Write errors before any echo wait.
+	return 0, ebuserrors.ErrTimeout
+}
+
+func (t *writeFailTransport) ReadByteWithEscape() (byte, bool, error) {
+	return 0, false, ebuserrors.ErrTimeout
+}
+
+func (t *writeFailTransport) Write(payload []byte) (int, error) {
+	t.mu.Lock()
+	t.writes++
+	w := t.writes
+	t.mu.Unlock()
+	if t.failOnWrite > 0 && w >= t.failOnWrite {
+		return 0, errSyntheticWriteFailure
+	}
+	return len(payload), nil
+}
+
+func (t *writeFailTransport) Close() error                  { return nil }
+func (t *writeFailTransport) BytesAreUnescaped() bool       { return true }
+func (t *writeFailTransport) StartArbitration(byte) error   { return nil }
+func (t *writeFailTransport) ArbitrationSendsSource() bool  { return true }
+
+// Phase 1 Step B4 (frame-atomic-v8 §1.8, §1.12, retained per v8 I8):
+// the round-9 AUTO-SYN absorb code at the payload-0xAA echo site in
+// sendRawWithEcho stays as a legacy fallback for direct-adapter mode.
+// In adaptermux's `enforce` mode, the proxy MUST filter wire AUTO-SYNs
+// before they reach the gateway's echo position; if round-9 still fires
+// under that mode, the Prometheus alert HelianthusRound9FiredUnderProxy
+// trips. The Round9AbsorbEntered counter exposes the fires
+// from the gateway's perspective so the alert can be evaluated against
+// it AND classifier-mode label (the gating is in the alert rule, not in
+// the Go code — the counter just increments any time the round-9
+// absorb predicate fires within sendRawWithEcho's active echo-wait).
+//
+// These tests assert:
+//   - the new counter increments by exactly 1 per round-9 entry;
+//   - it stays at zero when round-9 never fires (clean echo path);
+//   - it tracks the existing PayloadAaAutoSynAbsorbed counter shape
+//     (per-fire, not per-byte-drained);
+//   - the inSendRawWithEchoActiveEchoWait() predicate is true at the
+//     absorb site by construction.
+
+// TestRound9AbsorbEntered_SingleEntry asserts that one
+// round-9 absorb entry (regardless of how many bytes are drained
+// inside the loop) increments the round9AbsorbEntered counter exactly once.
+func TestRound9AbsorbEntered_SingleEntry(t *testing.T) {
+	t.Parallel()
+
+	tr := &echoF23TestTransport{unescaped: true}
+
+	bus := protocol.NewBus(tr, protocol.DefaultBusConfig(), 8)
+	runCtx, runCancel := context.WithCancel(context.Background())
+	defer runCancel()
+	bus.Run(runCtx)
+	ctx := context.Background()
+
+	frame := protocol.Frame{
+		Source:    0x10,
+		Target:    protocol.AddressBroadcast,
+		Primary:   0xB5,
+		Secondary: 0x16,
+		Data:      []byte{protocol.SymbolSyn},
+	}
+	telegram := []byte{
+		protocol.AddressBroadcast, 0xB5, 0x16, 0x01, protocol.SymbolSyn,
+	}
+	telegram = append(telegram, protocol.CRC(append([]byte{0x10}, telegram...)))
+
+	tr.mu.Lock()
+	tr.echo = nil
+	for _, b := range telegram[:4] {
+		tr.echo = append(tr.echo, echoF23Event{value: b, wasEscaped: false})
+	}
+	// Byte 4 echo slot: one wire AUTO-SYN, then real escape-decoded
+	// payload echo. Round-9 absorb predicate fires once.
+	tr.echo = append(tr.echo,
+		echoF23Event{value: protocol.SymbolSyn, wasEscaped: false},
+		echoF23Event{value: protocol.SymbolSyn, wasEscaped: true},
+	)
+	tr.echo = append(tr.echo, echoF23Event{value: telegram[5], wasEscaped: false})
+	tr.echo = append(tr.echo, echoF23Event{value: protocol.SymbolSyn, wasEscaped: false})
+	tr.mu.Unlock()
+
+	if _, err := bus.Send(ctx, frame); err != nil {
+		t.Fatalf("Send error = %v; want nil", err)
+	}
+
+	if got := bus.Round9AbsorbEntered(); got != 1 {
+		t.Errorf("Round9AbsorbEntered() = %d; want 1 (single round-9 entry)", got)
+	}
+	if got := bus.PayloadAaAutoSynAbsorbed(); got != 1 {
+		t.Errorf("PayloadAaAutoSynAbsorbed() = %d; want 1", got)
+	}
+}
+
+// TestRound9AbsorbEntered_PerEntryNotPerByte asserts that
+// when the absorb loop drains multiple bytes within a single entry,
+// the round9AbsorbEntered counter still increments by ONE (per-fire
+// semantics, not per-byte). This distinguishes it from
+// PayloadAaAutoSynAbsorbed which counts per drained byte.
+func TestRound9AbsorbEntered_PerEntryNotPerByte(t *testing.T) {
+	t.Parallel()
+
+	tr := &echoF23TestTransport{unescaped: true}
+
+	bus := protocol.NewBus(tr, protocol.DefaultBusConfig(), 8)
+	runCtx, runCancel := context.WithCancel(context.Background())
+	defer runCancel()
+	bus.Run(runCtx)
+	ctx := context.Background()
+
+	frame := protocol.Frame{
+		Source:    0x10,
+		Target:    protocol.AddressBroadcast,
+		Primary:   0xB5,
+		Secondary: 0x16,
+		Data:      []byte{protocol.SymbolSyn},
+	}
+	telegram := []byte{
+		protocol.AddressBroadcast, 0xB5, 0x16, 0x01, protocol.SymbolSyn,
+	}
+	telegram = append(telegram, protocol.CRC(append([]byte{0x10}, telegram...)))
+
+	tr.mu.Lock()
+	tr.echo = nil
+	for _, b := range telegram[:4] {
+		tr.echo = append(tr.echo, echoF23Event{value: b, wasEscaped: false})
+	}
+	// Byte 4 echo slot: two wire AUTO-SYNs (one entry + one drain
+	// iteration), then real escape-decoded echo. The absorb predicate
+	// is checked once on entry — the loop drains the second AUTO-SYN
+	// internally without re-firing the predicate.
+	tr.echo = append(tr.echo,
+		echoF23Event{value: protocol.SymbolSyn, wasEscaped: false},
+		echoF23Event{value: protocol.SymbolSyn, wasEscaped: false},
+		echoF23Event{value: protocol.SymbolSyn, wasEscaped: true},
+	)
+	tr.echo = append(tr.echo, echoF23Event{value: telegram[5], wasEscaped: false})
+	tr.echo = append(tr.echo, echoF23Event{value: protocol.SymbolSyn, wasEscaped: false})
+	tr.mu.Unlock()
+
+	if _, err := bus.Send(ctx, frame); err != nil {
+		t.Fatalf("Send error = %v; want nil", err)
+	}
+
+	if got := bus.Round9AbsorbEntered(); got != 1 {
+		t.Errorf("Round9AbsorbEntered() = %d; want 1 (per-entry, not per-byte)", got)
+	}
+	// Per-byte counter should report 2 — the predicate fires once on
+	// entry, but two AUTO-SYN bytes are drained.
+	if got := bus.PayloadAaAutoSynAbsorbed(); got != 2 {
+		t.Errorf("PayloadAaAutoSynAbsorbed() = %d; want 2 (per-byte)", got)
+	}
+}
+
+// TestRound9AbsorbEntered_StaysZeroOnCleanEcho asserts the
+// expected steady-state under the v8 enforce contract: when the proxy
+// correctly filters wire AUTO-SYNs (no round-9 entry is needed), the
+// counter stays at zero and the HelianthusRound9FiredUnderProxy alert
+// remains silent.
+func TestRound9AbsorbEntered_StaysZeroOnCleanEcho(t *testing.T) {
+	t.Parallel()
+
+	tr := &echoF23TestTransport{unescaped: true}
+
+	bus := protocol.NewBus(tr, protocol.DefaultBusConfig(), 8)
+	runCtx, runCancel := context.WithCancel(context.Background())
+	defer runCancel()
+	bus.Run(runCtx)
+	ctx := context.Background()
+
+	frame := protocol.Frame{
+		Source:    0x10,
+		Target:    protocol.AddressBroadcast,
+		Primary:   0xB5,
+		Secondary: 0x16,
+		Data:      []byte{protocol.SymbolSyn},
+	}
+	telegram := []byte{
+		protocol.AddressBroadcast, 0xB5, 0x16, 0x01, protocol.SymbolSyn,
+	}
+	telegram = append(telegram, protocol.CRC(append([]byte{0x10}, telegram...)))
+
+	tr.mu.Lock()
+	tr.echo = nil
+	for _, b := range telegram[:4] {
+		tr.echo = append(tr.echo, echoF23Event{value: b, wasEscaped: false})
+	}
+	// Byte 4 echo slot: real escape-decoded echo arrives immediately,
+	// no wire AUTO-SYN interference. Round-9 absorb predicate stays
+	// false — counter must remain at zero.
+	tr.echo = append(tr.echo,
+		echoF23Event{value: protocol.SymbolSyn, wasEscaped: true},
+	)
+	tr.echo = append(tr.echo, echoF23Event{value: telegram[5], wasEscaped: false})
+	tr.echo = append(tr.echo, echoF23Event{value: protocol.SymbolSyn, wasEscaped: false})
+	tr.mu.Unlock()
+
+	if _, err := bus.Send(ctx, frame); err != nil {
+		t.Fatalf("Send error = %v; want nil", err)
+	}
+
+	if got := bus.Round9AbsorbEntered(); got != 0 {
+		t.Errorf("Round9AbsorbEntered() = %d; want 0 (no round-9 entry under clean echo)", got)
+	}
+	if got := bus.PayloadAaAutoSynAbsorbed(); got != 0 {
+		t.Errorf("PayloadAaAutoSynAbsorbed() = %d; want 0", got)
+	}
+}
+
+// TestRound9AbsorbEntered_CapExhaustedStillCounts asserts
+// that even when the absorb loop reaches its cap without recovery
+// (drainExhausted path), the counter still increments — the predicate
+// fires regardless of the absorb outcome. This is critical for the
+// alert: a failing round-9 entry is still a v8 invariant violation
+// when the alert that gates on classifier_mode == enforce fires.
+func TestRound9AbsorbEntered_CapExhaustedStillCounts(t *testing.T) {
+	t.Parallel()
+
+	tr := &echoF23TestTransport{unescaped: true}
+
+	bus := protocol.NewBus(tr, protocol.DefaultBusConfig(), 8)
+	runCtx, runCancel := context.WithCancel(context.Background())
+	defer runCancel()
+	bus.Run(runCtx)
+	ctx := context.Background()
+
+	frame := protocol.Frame{
+		Source:    0x10,
+		Target:    protocol.AddressBroadcast,
+		Primary:   0xB5,
+		Secondary: 0x16,
+		Data:      []byte{protocol.SymbolSyn},
+	}
+	telegram := []byte{
+		protocol.AddressBroadcast, 0xB5, 0x16, 0x01, protocol.SymbolSyn,
+	}
+	telegram = append(telegram, protocol.CRC(append([]byte{0x10}, telegram...)))
+
+	tr.mu.Lock()
+	tr.echo = nil
+	for _, b := range telegram[:4] {
+		tr.echo = append(tr.echo, echoF23Event{value: b, wasEscaped: false})
+	}
+	// Byte 4 echo slot: cap+1 wire AUTO-SYNs in a row. Round-9
+	// predicate fires on entry, drain loop exhausts the cap (3) without
+	// finding the real echo, falls through to echo_mismatch /
+	// ErrBusCollision.
+	for i := 0; i < 4; i++ {
+		tr.echo = append(tr.echo, echoF23Event{value: protocol.SymbolSyn, wasEscaped: false})
+	}
+	tr.mu.Unlock()
+
+	if _, err := bus.Send(ctx, frame); err == nil {
+		t.Fatalf("Send error = nil; want non-nil (cap exhausted should error)")
+	}
+
+	// Counter must increment EVEN when the absorb attempt fails — the
+	// fire happened, the alert should observe it.
+	if got := bus.Round9AbsorbEntered(); got != 1 {
+		t.Errorf("Round9AbsorbEntered() = %d; want 1 (predicate fired even on exhaustion)", got)
+	}
+	if got := bus.PayloadAaAutoSynDrainExhausted(); got != 1 {
+		t.Errorf("PayloadAaAutoSynDrainExhausted() = %d; want 1", got)
+	}
+}
+
+// TestRound9AbsorbEntered_AccumulatesAcrossSends asserts
+// monotonic accumulation across multiple Send() calls — each round-9
+// entry adds 1, and the counter never decrements.
+func TestRound9AbsorbEntered_AccumulatesAcrossSends(t *testing.T) {
+	t.Parallel()
+
+	tr := &echoF23TestTransport{unescaped: true}
+
+	bus := protocol.NewBus(tr, protocol.DefaultBusConfig(), 8)
+	runCtx, runCancel := context.WithCancel(context.Background())
+	defer runCancel()
+	bus.Run(runCtx)
+	ctx := context.Background()
+
+	makeFrame := func() protocol.Frame {
+		return protocol.Frame{
+			Source:    0x10,
+			Target:    protocol.AddressBroadcast,
+			Primary:   0xB5,
+			Secondary: 0x16,
+			Data:      []byte{protocol.SymbolSyn},
+		}
+	}
+	makeTelegram := func() []byte {
+		t := []byte{
+			protocol.AddressBroadcast, 0xB5, 0x16, 0x01, protocol.SymbolSyn,
+		}
+		return append(t, protocol.CRC(append([]byte{0x10}, t...)))
+	}
+
+	for i := 0; i < 3; i++ {
+		telegram := makeTelegram()
+		tr.mu.Lock()
+		tr.echo = nil
+		for _, b := range telegram[:4] {
+			tr.echo = append(tr.echo, echoF23Event{value: b, wasEscaped: false})
+		}
+		tr.echo = append(tr.echo,
+			echoF23Event{value: protocol.SymbolSyn, wasEscaped: false},
+			echoF23Event{value: protocol.SymbolSyn, wasEscaped: true},
+		)
+		tr.echo = append(tr.echo, echoF23Event{value: telegram[5], wasEscaped: false})
+		tr.echo = append(tr.echo, echoF23Event{value: protocol.SymbolSyn, wasEscaped: false})
+		tr.mu.Unlock()
+
+		if _, err := bus.Send(ctx, makeFrame()); err != nil {
+			t.Fatalf("Send #%d error = %v; want nil", i, err)
+		}
+	}
+
+	if got := bus.Round9AbsorbEntered(); got != 3 {
+		t.Errorf("Round9AbsorbEntered() = %d; want 3 (one fire per Send)", got)
+	}
+}
+
+// TestRound9AbsorbEntered_ConcurrentSendsRaceFree exercises
+// the atomic counter under concurrent senders. We don't claim
+// strict ordering — only that the final count equals the number of
+// expected round-9 entries with no torn reads/writes.
+func TestRound9AbsorbEntered_ConcurrentSendsRaceFree(t *testing.T) {
+	t.Parallel()
+
+	tr := &echoF23TestTransport{unescaped: true}
+
+	// Pre-seed enough echo slots for 5 sequential Send() calls. The
+	// transport mutex serializes Write→Read pairs at the test harness
+	// level, so even with concurrent goroutines the sequencing is
+	// well-defined; we only verify the counter accumulates correctly.
+	telegramBase := []byte{
+		protocol.AddressBroadcast, 0xB5, 0x16, 0x01, protocol.SymbolSyn,
+	}
+	telegramBase = append(telegramBase, protocol.CRC(append([]byte{0x10}, telegramBase...)))
+
+	const n = 5
+	tr.mu.Lock()
+	tr.echo = nil
+	for i := 0; i < n; i++ {
+		for _, b := range telegramBase[:4] {
+			tr.echo = append(tr.echo, echoF23Event{value: b, wasEscaped: false})
+		}
+		tr.echo = append(tr.echo,
+			echoF23Event{value: protocol.SymbolSyn, wasEscaped: false},
+			echoF23Event{value: protocol.SymbolSyn, wasEscaped: true},
+		)
+		tr.echo = append(tr.echo, echoF23Event{value: telegramBase[5], wasEscaped: false})
+		tr.echo = append(tr.echo, echoF23Event{value: protocol.SymbolSyn, wasEscaped: false})
+	}
+	tr.mu.Unlock()
+
+	bus := protocol.NewBus(tr, protocol.DefaultBusConfig(), 16)
+	runCtx, runCancel := context.WithCancel(context.Background())
+	defer runCancel()
+	bus.Run(runCtx)
+	ctx := context.Background()
+
+	var wg sync.WaitGroup
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func() {
+			defer wg.Done()
+			frame := protocol.Frame{
+				Source:    0x10,
+				Target:    protocol.AddressBroadcast,
+				Primary:   0xB5,
+				Secondary: 0x16,
+				Data:      []byte{protocol.SymbolSyn},
+			}
+			_, _ = bus.Send(ctx, frame)
+		}()
+	}
+	wg.Wait()
+
+	if got := bus.Round9AbsorbEntered(); got != n {
+		t.Errorf("Round9AbsorbEntered() = %d; want %d (concurrent monotonic)", got, n)
+	}
+}
+
+// TestRound9AbsorbEntered_WriteErrorLeavesCounterAtZero asserts the
+// write-phase error boundary: when transport.Write fails before
+// sendRawWithEcho enters the active-echo-wait phase, the
+// Round9AbsorbEntered and PayloadAaAutoSyn* counters MUST NOT
+// increment. This is the boundary the test actually proves — with
+// failOnWrite=1 the function returns before activeEchoWaits.Add(1),
+// so by construction the predicate is never bumped. A "predicate
+// leak" test would need a separate scenario where Write succeeds,
+// the increment-and-defer registers, and the function returns
+// abnormally (panic, runtime.Goexit, etc.); this test is not that
+// scenario. Two sequential failed sends are used purely to confirm
+// the counters stay at zero across multiple attempts (no monotonic
+// surprise).
+func TestRound9AbsorbEntered_WriteErrorLeavesCounterAtZero(t *testing.T) {
+	t.Parallel()
+
+	// Fail on the FIRST Write — sendRawWithEcho returns immediately
+	// without ever incrementing activeEchoWaits or reaching the
+	// round-9 absorb block.
+	tr := &writeFailTransport{failOnWrite: 1}
+
+	bus := protocol.NewBus(tr, protocol.DefaultBusConfig(), 8)
+	runCtx, runCancel := context.WithCancel(context.Background())
+	defer runCancel()
+	bus.Run(runCtx)
+
+	// Bounded context so the Bus does not retry on transport-error
+	// classifications that route through the retry policy.
+	sendCtx, sendCancel := context.WithCancel(context.Background())
+	defer sendCancel()
+
+	for i := 0; i < 2; i++ {
+		frame := protocol.Frame{
+			Source:    0x10,
+			Target:    protocol.AddressBroadcast,
+			Primary:   0xB5,
+			Secondary: 0x16,
+			Data:      []byte{0x01},
+		}
+		_, err := bus.Send(sendCtx, frame)
+		if err == nil {
+			t.Fatalf("Send #%d returned nil; want error (transport.Write must fail)", i)
+		}
+	}
+
+	if got := bus.Round9AbsorbEntered(); got != 0 {
+		t.Errorf("Round9AbsorbEntered() = %d; want 0 (Write error must not enter absorb block)", got)
+	}
+	// PayloadAaAutoSynAbsorbed/Recovered/DrainExhausted must also be
+	// 0 — Write error is a transport-layer fault, not an absorb event.
+	if got := bus.PayloadAaAutoSynAbsorbed(); got != 0 {
+		t.Errorf("PayloadAaAutoSynAbsorbed() = %d; want 0", got)
+	}
+	if got := bus.PayloadAaAutoSynRecovered(); got != 0 {
+		t.Errorf("PayloadAaAutoSynRecovered() = %d; want 0", got)
+	}
+	if got := bus.PayloadAaAutoSynDrainExhausted(); got != 0 {
+		t.Errorf("PayloadAaAutoSynDrainExhausted() = %d; want 0", got)
+	}
+}

--- a/protocol/frame_atomic_v8_timeouts.go
+++ b/protocol/frame_atomic_v8_timeouts.go
@@ -1,0 +1,111 @@
+// Package protocol — frame-atomic visibility v8 per-phase timeout constants.
+//
+// These constants are the spec-aligned per-state timeout and budget values
+// for the telegram FSM described in:
+//
+//	helianthus-docs-ebus/architecture/adaptermux/frame-atomic-visibility-v8.md
+//
+// v8 is the converged design after eight rounds of adversarial review. The
+// numbered sections in v8.md are scoped to the *delta* over v7; the full
+// FSM phase timeout table is canonically defined in v6 §3 ("The FSM
+// (unchanged from v5 §3 plus passive-mode transitions) ... Per-state
+// timeouts pinned from eBUS V1.3.1 spec"), with v7 §1.5 and v8 §1.5
+// reaffirming WAIT_MASTER_ACK = 200 ms, and v8 §1.3 introducing the
+// ESCAPE_PENDING 32 ms hard cap.
+//
+// These constants are DECLARED here so the Step A migration can land
+// independently as a doc-aligned addition with no behavior change. Actual
+// wiring into the active read path happens in Step B, when the telegram
+// FSM is extracted into a shared library (per v8 §1.11 and the migration
+// list in v8.md, last block).
+//
+// Current bus.go does not have per-phase timeouts in the read path; it
+// inherits the transport-level read timeout (default 5s on adapter-direct
+// transports). Step B will replace per-symbol reads with phase-aware
+// readByteWithDeadline(phase) calls keyed off these constants.
+//
+// All wall-clock values are engineering choices per v8 §1.5 and v6 §3:
+//
+//   - The eBUS V1.3.1 spec mandates that the target respond within the
+//     AUTO-SYN slot (~35–45 ms). The longer values here (e.g., 200 ms
+//     for ACK phases) provide tolerance for slow or contended targets
+//     without introducing spec violations on our side.
+//   - Reducing these values below the documented constants will create
+//     spurious aborts on healthy-but-slow targets; increasing them past
+//     these constants will mask real stuck-target detection.
+//
+// The corresponding Prometheus alert (per v8 §1.9) on
+// helianthus_round9_absorb_fired_proxy_mediated_total must be deployed
+// alongside any code path that wires these timeouts in, since the alert
+// gates the legacy-fallback verification of v8 §10.
+package protocol
+
+import "time"
+
+// Per-phase wall-clock timeouts from the v8 telegram FSM. Each value
+// traces to a specific section of the design doc, cited inline.
+//
+// All values are constants. Downstream consumers (the proxy in
+// helianthus-ebus-adapter-proxy, the future FSM extraction in
+// protocol/telegram_fsm) must reference these names rather than
+// duplicating the literals.
+const (
+	// FrameAtomicV8InterByteTimeout is the deadline between consecutive
+	// bytes within a fixed-length phase (MASTER_HEADER consuming the 5
+	// header bytes, MASTER_DATA consuming NN data bytes, MASTER_CRC,
+	// SLAVE_LENGTH, SLAVE_DATA, SLAVE_CRC). Per v6 §3: "10 ms
+	// (conservative; spec minimum 4.17 ms)."
+	FrameAtomicV8InterByteTimeout = 10 * time.Millisecond
+
+	// FrameAtomicV8WaitMasterAckTimeout is the deadline for receiving
+	// ACK/NACK after the initiator's CRC. Per v8 §1.5: "200 ms is an
+	// engineering choice that accommodates targets up to ~5× the
+	// AUTO-SYN slot (~35–45 ms) while still bounding stuck-target
+	// detection." Named with the canonical FSM-phase identifier
+	// (WAIT_MASTER_ACK) which matches the spec-layer state name; the
+	// repo's protocol-layer terminology gate exempts these.
+	FrameAtomicV8WaitMasterAckTimeout = 200 * time.Millisecond
+
+	// FrameAtomicV8WaitSlaveAckTimeout symmetrical to
+	// WaitMasterAckTimeout for the initiator's ACK/NACK back to the
+	// target after the target's response CRC. Per v6 §3, same 200 ms
+	// budget.
+	FrameAtomicV8WaitSlaveAckTimeout = 200 * time.Millisecond
+
+	// FrameAtomicV8WaitTerminatorSynTimeout is the deadline for the
+	// final AUTO-SYN that terminates a successful telegram. Per v6 §3:
+	// "100 ms (allows up to two missed AUTO-SYN slots before declaring
+	// abandon)."
+	FrameAtomicV8WaitTerminatorSynTimeout = 100 * time.Millisecond
+
+	// FrameAtomicV8ArbitratingTimeout is the deadline for grant
+	// resolution between the STARTED event and the first echo byte.
+	// Per v6 §3: 50 ms.
+	FrameAtomicV8ArbitratingTimeout = 50 * time.Millisecond
+
+	// FrameAtomicV8EscapePendingTimeout is the wall-clock cap on the
+	// AA-aware escape decoder's ESCAPE_PENDING state. Per v8 §1.3:
+	// "explicit 32 ms hard cap." Beyond this, the decoder emits
+	// nothing, admin-logs, and re-processes the current byte in
+	// NORMAL state. Equivalent constraint to
+	// MaxAaAbsorptionsPerEscapePair; whichever fires first.
+	FrameAtomicV8EscapePendingTimeout = 32 * time.Millisecond
+)
+
+// Count-bounded budgets from the v8 telegram FSM.
+const (
+	// FrameAtomicV8MaxAaAbsorptionsPerEscapePair is the maximum number
+	// of consecutive 0xAA bytes the escape decoder will absorb between
+	// the 0xA9 lead and the completion byte (0x00 or 0x01). Per v8 §5
+	// and invariant I4: 8 absorptions. Beyond this, the decoder
+	// declares escape failure.
+	FrameAtomicV8MaxAaAbsorptionsPerEscapePair = 8
+
+	// FrameAtomicV8MaxNackRetxPerPhase is the eBUS V1.3.1
+	// single-retransmit cap per phase. Per v6 §3 and invariant I6,
+	// master_retx_count and slave_retx_count are independently
+	// bounded by this value. The existing 2-attempt inner loop in
+	// sendInitiatorTelegram (see bus.go ~line 714) already enforces
+	// this for the initiator phase.
+	FrameAtomicV8MaxNackRetxPerPhase = 1
+)

--- a/protocol/frame_atomic_v8_timeouts_test.go
+++ b/protocol/frame_atomic_v8_timeouts_test.go
@@ -1,0 +1,98 @@
+package protocol
+
+import (
+	"testing"
+	"time"
+)
+
+// TestFrameAtomicV8TimeoutsAreSpecAligned guards against silent drift of
+// the per-phase timeout values. The doc-of-record is
+// helianthus-docs-ebus/architecture/adaptermux/frame-atomic-visibility-v8.md
+// reading v6 §3 + v7 §1.5 + v8 §1.3 + v8 §1.5 (v8 is a delta over v7;
+// the full phase table is canonically in v6 §3).
+//
+// If the design doc is updated, this test must be updated to match —
+// any failure here means the const and the doc have drifted apart.
+func TestFrameAtomicV8TimeoutsAreSpecAligned(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		got  time.Duration
+		want time.Duration
+	}{
+		{"InterByte (v6 §3)", FrameAtomicV8InterByteTimeout, 10 * time.Millisecond},
+		{"WaitMasterAck (v8 §1.5)", FrameAtomicV8WaitMasterAckTimeout, 200 * time.Millisecond},
+		{"WaitSlaveAck (v6 §3)", FrameAtomicV8WaitSlaveAckTimeout, 200 * time.Millisecond},
+		{"WaitTerminatorSyn (v6 §3)", FrameAtomicV8WaitTerminatorSynTimeout, 100 * time.Millisecond},
+		{"Arbitrating (v6 §3)", FrameAtomicV8ArbitratingTimeout, 50 * time.Millisecond},
+		{"EscapePending (v8 §1.3)", FrameAtomicV8EscapePendingTimeout, 32 * time.Millisecond},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if tc.got != tc.want {
+				t.Fatalf("%s = %v, want %v (drift from v8 spec — sync the doc and this test together)", tc.name, tc.got, tc.want)
+			}
+		})
+	}
+}
+
+// TestFrameAtomicV8IntegralBudgetsAreSpecAligned asserts the count-bounded
+// budgets from v6 §3 / v8 §1.5 (NACK retx cap = 1) and v8 §1.3 / §5 / I4
+// (escape AA budget = 8). These are integral invariants from the spec,
+// not engineering choices that can drift.
+func TestFrameAtomicV8IntegralBudgetsAreSpecAligned(t *testing.T) {
+	t.Parallel()
+	if FrameAtomicV8MaxNackRetxPerPhase != 1 {
+		t.Fatalf("FrameAtomicV8MaxNackRetxPerPhase = %d, want 1 (per spec V1.3.1; v8 I6)",
+			FrameAtomicV8MaxNackRetxPerPhase)
+	}
+	if FrameAtomicV8MaxAaAbsorptionsPerEscapePair != 8 {
+		t.Fatalf("FrameAtomicV8MaxAaAbsorptionsPerEscapePair = %d, want 8 (per v8 §5 / I4)",
+			FrameAtomicV8MaxAaAbsorptionsPerEscapePair)
+	}
+}
+
+// TestFrameAtomicV8TimeoutOrdering captures the ordering relationships
+// among the per-phase timeouts. These relationships are load-bearing for
+// FSM correctness — for example, EscapePending must dominate single
+// inter-byte timeouts so the escape decoder's hard cap fires before
+// the classifier's inter-byte timer would in the worst case.
+func TestFrameAtomicV8TimeoutOrdering(t *testing.T) {
+	t.Parallel()
+
+	// Per v8 §1.3, the 32 ms EscapePending bound is the literal v8 cap.
+	// The doc rationale says "8 × τ_wire_byte ... extended slightly for
+	// jitter tolerance" but the actual literal is 32 ms (with
+	// τ_wire_byte = 4.17 ms, 8× = 33.36 ms, so the 32 ms cap fires
+	// just before the theoretical absorption window completes — this
+	// is a conservative early-cut, not a jitter-extension). The test
+	// asserts the literal, not the approximate arithmetic.
+	if FrameAtomicV8EscapePendingTimeout != 32*time.Millisecond {
+		t.Fatalf("FrameAtomicV8EscapePendingTimeout = %v, want exactly 32 ms (v8 §1.3 literal)",
+			FrameAtomicV8EscapePendingTimeout)
+	}
+
+	// Per v6 §3 and v8 §1.5: ACK-phase timeouts must dominate single
+	// inter-byte timeouts so a slow-but-spec-compliant ACK doesn't
+	// abort the phase.
+	if FrameAtomicV8WaitMasterAckTimeout <= FrameAtomicV8InterByteTimeout {
+		t.Fatalf("WaitMasterAck (%v) must be > InterByte (%v)",
+			FrameAtomicV8WaitMasterAckTimeout, FrameAtomicV8InterByteTimeout)
+	}
+	if FrameAtomicV8WaitSlaveAckTimeout <= FrameAtomicV8InterByteTimeout {
+		t.Fatalf("WaitSlaveAck (%v) must be > InterByte (%v)",
+			FrameAtomicV8WaitSlaveAckTimeout, FrameAtomicV8InterByteTimeout)
+	}
+
+	// Per v6 §3 WAIT_TERMINATOR_SYN rationale ("allows up to two
+	// missed AUTO-SYN slots"): WaitTerminatorSyn must cover at least
+	// 2 × AUTO-SYN slot. AUTO-SYN cadence is ~35-45 ms per V1.3.1, so
+	// 100 ms covers up to two slots comfortably. Assert >= 90 ms as
+	// a safety floor.
+	if FrameAtomicV8WaitTerminatorSynTimeout < 90*time.Millisecond {
+		t.Fatalf("WaitTerminatorSyn = %v, want >= 90 ms (≈ 2 × AUTO-SYN slot)",
+			FrameAtomicV8WaitTerminatorSynTimeout)
+	}
+}

--- a/protocol/telegram_fsm/fsm.go
+++ b/protocol/telegram_fsm/fsm.go
@@ -29,10 +29,16 @@
 //   - **NOT thread-safe**. Per v8 invariant I11, callers serialize
 //     access on a per-session goroutine.
 //
-// This first iteration (Step B2) covers the active write-out path:
-// IDLE, ARBITRATING, MASTER_HEADER, MASTER_DATA, MASTER_CRC,
-// WAIT_MASTER_ACK. Subsequent iterations will add SLAVE_* phases,
-// MASTER_RETX / SLAVE_RETX, PASSIVE_TRACKING, and WAIT_TERMINATOR_SYN.
+// Step B2 covers the full active-session path:
+//   - IDLE, ARBITRATING (event-driven entry)
+//   - MASTER_HEADER, MASTER_DATA, MASTER_CRC, WAIT_MASTER_ACK, MASTER_RETX
+//   - SLAVE_LENGTH, SLAVE_DATA, SLAVE_CRC, WAIT_SLAVE_ACK, SLAVE_RETX
+//   - WAIT_TERMINATOR_SYN (success terminator)
+//   - ABORTED (terminal fault)
+//
+// The PASSIVE_TRACKING composite state for foreign-initiator telegrams
+// lands in a subsequent commit (Step B2 part 3). Step B3 wires this
+// FSM into the proxy's adapter-facing read path.
 package telegram_fsm
 
 import "fmt"
@@ -43,8 +49,8 @@ import "fmt"
 // classification per v8 invariant I9 (classify under current phase,
 // then transition).
 //
-// v8's PASSIVE_TRACKING composite state and the SLAVE_* phases land
-// in subsequent commits.
+// v8's PASSIVE_TRACKING composite state for foreign-initiator
+// telegrams lands in a subsequent commit (Step B2 part 3).
 type State uint8
 
 const (
@@ -83,6 +89,48 @@ const (
 	// invariant I6 (retx cap = 1 per phase).
 	StateWaitMasterAck
 
+	// StateMasterRetx is the explicit retransmit state. Reached on
+	// the first NACK in WAIT_MASTER_ACK. The initiator re-sends the
+	// full frame (QQ ZZ PB SB NN DATA CRC). Per eBUS V1.3.1 / v8 I6
+	// at most one retransmit per phase; a second NACK abort.
+	StateMasterRetx
+
+	// StateSlaveLength consumes the target's response length byte
+	// (NN'). Per v6 §3 follows ACK from target in WAIT_MASTER_ACK.
+	// NN' > 16 violates eBUS V1.3.1; immediate abort.
+	StateSlaveLength
+
+	// StateSlaveData consumes NN' data bytes from the target.
+	StateSlaveData
+
+	// StateSlaveCRC consumes the target's response CRC byte. The
+	// initiator validates it; v8 §1.6 admin-logs CRC mismatch.
+	StateSlaveCRC
+
+	// StateWaitSlaveAck waits for the initiator's ACK/NACK of the
+	// target's response. ACK leads to WAIT_TERMINATOR_SYN; NACK with
+	// retx_count<1 leads to SLAVE_RETX; NACK with retx_count>=1 leads
+	// to ABORTED.
+	StateWaitSlaveAck
+
+	// StateSlaveRetx is the explicit retransmit state for the target
+	// half. Reached on the first NACK in WAIT_SLAVE_ACK. The target
+	// re-sends its response (NN' DATA CRC). Per v8 I6 at most one
+	// retransmit; a second NACK aborts.
+	StateSlaveRetx
+
+	// StateWaitTerminatorSyn waits for the final wire AUTO-SYN that
+	// marks telegram completion. Per v6 §3 reached on:
+	//   - MASTER_CRC with ZZ=0xFE (broadcast — no ACK/response).
+	//   - WAIT_MASTER_ACK with ACK + initiator-initiator frame
+	//     (PB=0xFE typically — no response phase).
+	//   - WAIT_SLAVE_ACK with ACK (response acknowledged).
+	// The terminator SYN itself IS a raw 0xAA byte; per v8 §4 it is
+	// forwarded (not dropped as AA-injection — the WAIT_TERMINATOR_SYN
+	// state is the one phase where raw 0xAA is legitimate). Per v8
+	// §3 the per-state timeout is 100 ms.
+	StateWaitTerminatorSyn
+
 	// StateAborted is a terminal state reached on protocol fault or
 	// NACK exhaustion. Per v8 §8 the FSM emits an admin event and
 	// returns to IDLE without injecting synthetic byte-stream events.
@@ -104,6 +152,20 @@ func (s State) String() string {
 		return "MASTER_CRC"
 	case StateWaitMasterAck:
 		return "WAIT_MASTER_ACK"
+	case StateMasterRetx:
+		return "MASTER_RETX"
+	case StateSlaveLength:
+		return "SLAVE_LENGTH"
+	case StateSlaveData:
+		return "SLAVE_DATA"
+	case StateSlaveCRC:
+		return "SLAVE_CRC"
+	case StateWaitSlaveAck:
+		return "WAIT_SLAVE_ACK"
+	case StateSlaveRetx:
+		return "SLAVE_RETX"
+	case StateWaitTerminatorSyn:
+		return "WAIT_TERMINATOR_SYN"
 	case StateAborted:
 		return "ABORTED"
 	default:
@@ -112,13 +174,10 @@ func (s State) String() string {
 }
 
 // IsTerminal reports whether the state is a terminal one (telegram
-// has either successfully completed or aborted). Terminal states
-// must transition back to IDLE before the next telegram begins.
-//
-// In this initial implementation only ABORTED is terminal; DONE
-// (success terminator) is represented by a transition back to IDLE
-// after WAIT_TERMINATOR_SYN sees its SYN (added in a later Step B2
-// iteration once WAIT_TERMINATOR_SYN is wired).
+// has either successfully completed or aborted). Successful
+// completion is represented by the FSM returning to StateIdle from
+// WAIT_TERMINATOR_SYN; ABORTED is the only state that explicitly
+// represents a terminated-with-fault telegram.
 func (s State) IsTerminal() bool {
 	return s == StateAborted
 }
@@ -187,19 +246,31 @@ type Machine struct {
 	masterNN byte
 
 	// masterBytesConsumed counts bytes consumed in the current phase.
-	// Reset on every phase transition. Used by MASTER_HEADER
-	// (counting to 5), MASTER_DATA (counting to masterNN), and
-	// MASTER_CRC (counting to 1).
+	// Reset on every phase transition. Used by MASTER_HEADER (counting
+	// to 5), MASTER_DATA (counting to masterNN), SLAVE_DATA (counting
+	// to slaveNN), and the single-byte phases (counting to 1). Name
+	// retained for diff stability across part 1 → part 2 of Step B2.
 	masterBytesConsumed byte
 
 	// masterDest is the ZZ byte from MASTER_HEADER. Determines
 	// post-MASTER_CRC routing: broadcast (0xFE) → terminator;
-	// otherwise → WAIT_MASTER_ACK.
+	// otherwise → WAIT_MASTER_ACK. Step B3 will add full
+	// address-class disambiguation via protocol.AddressClassOf to
+	// distinguish initiator-initiator (no response) from
+	// initiator-target (with response).
 	masterDest byte
 
 	// masterRetxCount counts initiator-frame retransmissions per v8
 	// invariant I6. Bounded at MaxRetxPerPhase = 1 per eBUS V1.3.1.
 	masterRetxCount byte
+
+	// slaveNN holds the target's response length (NN'), set in
+	// SLAVE_LENGTH and consumed by SLAVE_DATA.
+	slaveNN byte
+
+	// slaveRetxCount counts target-response retransmissions per v8
+	// invariant I6. Independent of masterRetxCount.
+	slaveRetxCount byte
 }
 
 // MaxRetxPerPhase is the eBUS V1.3.1 single-retransmit cap per phase
@@ -252,6 +323,8 @@ func (m *Machine) ResetToIdle() {
 	m.masterBytesConsumed = 0
 	m.masterDest = 0
 	m.masterRetxCount = 0
+	m.slaveNN = 0
+	m.slaveRetxCount = 0
 }
 
 // Feed consumes one decoded byte and returns the Decision for that
@@ -283,6 +356,20 @@ func (m *Machine) Feed(b byte, wasEscaped bool) Decision {
 		return m.feedMasterCRC(b, wasEscaped)
 	case StateWaitMasterAck:
 		return m.feedWaitMasterAck(b, wasEscaped)
+	case StateMasterRetx:
+		return m.feedMasterRetx(b, wasEscaped)
+	case StateSlaveLength:
+		return m.feedSlaveLength(b, wasEscaped)
+	case StateSlaveData:
+		return m.feedSlaveData(b, wasEscaped)
+	case StateSlaveCRC:
+		return m.feedSlaveCRC(b, wasEscaped)
+	case StateWaitSlaveAck:
+		return m.feedWaitSlaveAck(b, wasEscaped)
+	case StateSlaveRetx:
+		return m.feedSlaveRetx(b, wasEscaped)
+	case StateWaitTerminatorSyn:
+		return m.feedWaitTerminatorSyn(b, wasEscaped)
 	case StateAborted:
 		// Per v8 §8: after ABORTED, callers should ResetToIdle
 		// before feeding more bytes. Feeding while ABORTED is a
@@ -404,20 +491,15 @@ func (m *Machine) feedMasterData(b byte, wasEscaped bool) Decision {
 
 // feedMasterCRC handles the MASTER_CRC state. Consumes the single
 // CRC byte. Per v6 §3: if ZZ == 0xFE (broadcast) the FSM goes to
-// WAIT_TERMINATOR_SYN; otherwise to WAIT_MASTER_ACK. In this initial
-// Step B2 iteration WAIT_TERMINATOR_SYN is not yet wired, so the
-// broadcast path falls back to IDLE (caller is expected to forward
-// the post-CRC SYN as terminator) — this will be tightened in a
-// subsequent commit when WAIT_TERMINATOR_SYN is added.
+// WAIT_TERMINATOR_SYN; otherwise to WAIT_MASTER_ACK.
 func (m *Machine) feedMasterCRC(b byte, wasEscaped bool) Decision {
 	if b == SynByte && !wasEscaped {
 		return DecisionDropAaInjection
 	}
 	_ = b // CRC validation deferred to v8 §1.6 implementation.
 	if m.masterDest == BroadcastDestination {
-		// Broadcast: skip ACK phase, return to IDLE pending terminator.
-		// (WAIT_TERMINATOR_SYN added in a later commit.)
-		m.ResetToIdle()
+		// Broadcast: skip ACK phase, await final terminator SYN.
+		m.state = StateWaitTerminatorSyn
 	} else {
 		m.state = StateWaitMasterAck
 	}
@@ -425,31 +507,40 @@ func (m *Machine) feedMasterCRC(b byte, wasEscaped bool) Decision {
 }
 
 // feedWaitMasterAck handles the WAIT_MASTER_ACK state. Expects ACK
-// (0x00), NACK (0xFF), or AA-injection. Any other byte is a protocol
-// fault.
+// (0x00) → SLAVE_LENGTH, NACK (0xFF) → MASTER_RETX (if budget) or
+// ABORTED, AA-injection drop, anything else protocol fault.
 func (m *Machine) feedWaitMasterAck(b byte, wasEscaped bool) Decision {
 	if b == SynByte && !wasEscaped {
 		return DecisionDropAaInjection
 	}
 	switch b {
 	case ACKByte:
-		// ACK accepted. Next state in v6 §3 is SLAVE_LENGTH for
-		// initiator-target or WAIT_TERMINATOR_SYN for
-		// initiator-initiator. Target phases land in a follow-up
-		// commit; for now ABORT to IDLE so behavior is well-defined.
-		m.ResetToIdle()
+		// ACK from target → enter response phase. The current
+		// implementation routes EVERY non-broadcast frame to
+		// SLAVE_LENGTH (initiator-target assumption).
+		//
+		// INITIATOR-INITIATOR FRAMES ARE NOT YET SUPPORTED here:
+		// for i2i, v6 §3 says ACK → WAIT_TERMINATOR_SYN directly
+		// (no response phase). The current code would land in
+		// SLAVE_LENGTH and then receive the wire-real terminator
+		// SYN — which SLAVE_LENGTH drops as AA-injection per v8 §4,
+		// leaving the FSM stuck. Address-class routing via
+		// AddressClassOf is the fix and lands in Step B3.
+		// Until then, i2i frames must not be fed through this FSM;
+		// callers should detect i2i upstream and use an alternate
+		// path or skip FSM-mediated classification for those frames.
+		m.state = StateSlaveLength
+		m.masterBytesConsumed = 0
 		return DecisionForward
 	case NACKByte:
 		if m.masterRetxCount < MaxRetxPerPhase {
 			m.masterRetxCount++
-			// Per v6 §3, MASTER_RETX state resets header tracking
-			// and waits for the resend of QQ. In this initial
-			// iteration, restart MASTER_HEADER directly (MASTER_RETX
-			// state added in a follow-up commit).
-			m.state = StateMasterHeader
-			m.masterBytesConsumed = 0
-			m.masterNN = 0
-			m.masterDest = 0
+			// Per v6 §3, transition to MASTER_RETX. The initiator
+			// re-sends the full frame; the next bytes will form
+			// the resent QQ ZZ PB SB NN sequence. MASTER_RETX
+			// itself just immediately advances to MASTER_HEADER
+			// when the next byte arrives.
+			m.state = StateMasterRetx
 			return DecisionForward
 		}
 		// Retx budget exhausted (v8 invariant I6).
@@ -460,4 +551,154 @@ func (m *Machine) feedWaitMasterAck(b byte, wasEscaped bool) Decision {
 		m.state = StateAborted
 		return DecisionProtocolFault
 	}
+}
+
+// feedMasterRetx handles the MASTER_RETX state. Per v6 §3, the
+// initiator's NACK retransmit re-sends the entire initiator frame. The
+// first byte after the NACK is the resent QQ; transition to
+// MASTER_HEADER and consume the byte as header byte 1.
+//
+// Raw 0xAA in MASTER_RETX is AA-injection (same as ARBITRATING — no
+// real wire bytes should arrive in this micro-window).
+func (m *Machine) feedMasterRetx(b byte, wasEscaped bool) Decision {
+	if b == SynByte && !wasEscaped {
+		return DecisionDropAaInjection
+	}
+	// Reset header tracking for the retransmit.
+	m.state = StateMasterHeader
+	m.masterBytesConsumed = 1
+	m.masterNN = 0
+	m.masterDest = 0
+	_ = b // QQ recorded by header consumption; validation deferred.
+	return DecisionForward
+}
+
+// feedSlaveLength handles the SLAVE_LENGTH state. Consumes the
+// target's NN' response-length byte. Per v8 §1.7: NN' > 16 violates
+// eBUS V1.3.1; immediate abort. Raw 0xAA is AA-injection.
+//
+// Special case NN' == 0: skip SLAVE_DATA, go directly to SLAVE_CRC.
+// The frame is initiator-target with empty response payload (an
+// acknowledgement-only frame). Initiator-initiator frames are
+// NOT supported here yet (see feedWaitMasterAck comment); they
+// would never legitimately reach SLAVE_LENGTH once Step B3 lands
+// address-class routing.
+func (m *Machine) feedSlaveLength(b byte, wasEscaped bool) Decision {
+	if b == SynByte && !wasEscaped {
+		return DecisionDropAaInjection
+	}
+	if b > 16 {
+		// Per v8 §1.7 / I6: NN' > 16 is spec-illegal.
+		m.state = StateAborted
+		return DecisionProtocolFault
+	}
+	m.slaveNN = b
+	if b == 0 {
+		// Empty response — go straight to CRC.
+		m.state = StateSlaveCRC
+		m.masterBytesConsumed = 0
+	} else {
+		m.state = StateSlaveData
+		m.masterBytesConsumed = 0
+	}
+	return DecisionForward
+}
+
+// feedSlaveData handles the SLAVE_DATA state. Consumes slaveNN data
+// bytes then transitions to SLAVE_CRC. Raw 0xAA is AA-injection;
+// escape-decoded 0xAA is a legitimate payload byte.
+func (m *Machine) feedSlaveData(b byte, wasEscaped bool) Decision {
+	if b == SynByte && !wasEscaped {
+		return DecisionDropAaInjection
+	}
+	m.masterBytesConsumed++
+	if m.masterBytesConsumed >= m.slaveNN {
+		m.state = StateSlaveCRC
+		m.masterBytesConsumed = 0
+	}
+	return DecisionForward
+}
+
+// feedSlaveCRC handles the SLAVE_CRC state. Consumes the target's
+// CRC byte. Per v6 §3 always transitions to WAIT_SLAVE_ACK
+// (initiator must ACK/NACK the response). CRC validation is
+// deferred to v8 §1.6 admin-channel implementation.
+func (m *Machine) feedSlaveCRC(b byte, wasEscaped bool) Decision {
+	if b == SynByte && !wasEscaped {
+		return DecisionDropAaInjection
+	}
+	_ = b // CRC validation deferred to v8 §1.6.
+	m.state = StateWaitSlaveAck
+	return DecisionForward
+}
+
+// feedWaitSlaveAck handles the WAIT_SLAVE_ACK state. Expects ACK
+// (initiator accepts response) → WAIT_TERMINATOR_SYN; NACK
+// (initiator rejects) → SLAVE_RETX (if budget) or ABORTED.
+func (m *Machine) feedWaitSlaveAck(b byte, wasEscaped bool) Decision {
+	if b == SynByte && !wasEscaped {
+		return DecisionDropAaInjection
+	}
+	switch b {
+	case ACKByte:
+		m.state = StateWaitTerminatorSyn
+		return DecisionForward
+	case NACKByte:
+		if m.slaveRetxCount < MaxRetxPerPhase {
+			m.slaveRetxCount++
+			m.state = StateSlaveRetx
+			return DecisionForward
+		}
+		// Retx budget exhausted (v8 invariant I6).
+		m.state = StateAborted
+		return DecisionForward
+	default:
+		// Malformed during target-ACK wait.
+		m.state = StateAborted
+		return DecisionProtocolFault
+	}
+}
+
+// feedSlaveRetx handles the SLAVE_RETX state. Per v6 §3, on initiator
+// NACK the target re-sends its response (NN' DATA CRC). The first
+// byte after the NACK is the resent NN'; transition to SLAVE_LENGTH
+// and feed the byte through that handler.
+func (m *Machine) feedSlaveRetx(b byte, wasEscaped bool) Decision {
+	if b == SynByte && !wasEscaped {
+		return DecisionDropAaInjection
+	}
+	// Reset target-response tracking for the retransmit and consume this byte
+	// as the resent NN'. We mirror feedSlaveLength's logic inline so
+	// that the single Feed call's Decision is computed under
+	// SLAVE_RETX's branch (per v8 I9 classify-then-transition).
+	if b > 16 {
+		m.state = StateAborted
+		return DecisionProtocolFault
+	}
+	m.slaveNN = b
+	if b == 0 {
+		m.state = StateSlaveCRC
+	} else {
+		m.state = StateSlaveData
+	}
+	m.masterBytesConsumed = 0
+	return DecisionForward
+}
+
+// feedWaitTerminatorSyn handles the WAIT_TERMINATOR_SYN state. Per
+// v6 §3 the terminator IS a raw 0xAA byte (wasEscaped=false). Unlike
+// every other active phase, raw 0xAA here is FORWARDED (not dropped
+// as AA-injection) — it is the legitimate end-of-telegram marker.
+//
+// Anything else is a protocol fault. After the terminator, FSM
+// returns to IDLE (v8 §3 success exit).
+func (m *Machine) feedWaitTerminatorSyn(b byte, wasEscaped bool) Decision {
+	if b == SynByte && !wasEscaped {
+		// Terminator SYN observed. Return to IDLE.
+		m.ResetToIdle()
+		return DecisionForward
+	}
+	// Any non-SYN byte at this point is unexpected.
+	m.state = StateAborted
+	return DecisionProtocolFault
 }

--- a/protocol/telegram_fsm/fsm.go
+++ b/protocol/telegram_fsm/fsm.go
@@ -1,0 +1,463 @@
+// Package telegram_fsm implements the per-telegram phase state machine
+// described in helianthus-docs-ebus/architecture/adaptermux/
+// frame-atomic-visibility-v8.md §3 + v6 §3.
+//
+// This is the shared library for v8 §1.11: "modelled-on (not literal
+// reuse of) the existing passive_transaction_reconstructor.go in
+// helianthus-ebusgateway." The FSM transition logic is the same as
+// what the passive reconstructor already implements, but extracted
+// into a self-contained pure-state-machine package consumable by:
+//
+//   - The proxy classifier in helianthus-ebus-adapter-proxy (Step B3,
+//     wiring the AA-aware escape decoder + per-session staging buffer
+//   - this FSM into the adapter-facing read path).
+//   - The gateway's own bus.go for active-client echo matching
+//     (future work, not in v8 scope).
+//   - Future passive observers.
+//
+// The FSM is intentionally:
+//
+//   - **Pure**. No I/O, no goroutines, no clocks. Transitions are
+//     synchronous functions of (current state, input byte).
+//   - **Allocation-free in the Feed hot path**. No slices grown per
+//     byte, no maps, no fmt.Sprintf inside Feed. The String() methods
+//     do use fmt.Sprintf as a fallback for unknown enum values; those
+//     are not on the hot path.
+//   - **Single-byte serial**. Callers feed one decoded byte at a time
+//     per v8 invariant I9 (classify under current phase, then
+//     transition).
+//   - **NOT thread-safe**. Per v8 invariant I11, callers serialize
+//     access on a per-session goroutine.
+//
+// This first iteration (Step B2) covers the active write-out path:
+// IDLE, ARBITRATING, MASTER_HEADER, MASTER_DATA, MASTER_CRC,
+// WAIT_MASTER_ACK. Subsequent iterations will add SLAVE_* phases,
+// MASTER_RETX / SLAVE_RETX, PASSIVE_TRACKING, and WAIT_TERMINATOR_SYN.
+package telegram_fsm
+
+import "fmt"
+
+// State enumerates the phases of an eBUS telegram per v6 §3. Each
+// State has a per-phase rule inside Machine.Feed; the transition to
+// the next state is committed inside Feed after the per-byte
+// classification per v8 invariant I9 (classify under current phase,
+// then transition).
+//
+// v8's PASSIVE_TRACKING composite state and the SLAVE_* phases land
+// in subsequent commits.
+type State uint8
+
+const (
+	// StateIdle is the genuinely-quiet phase between telegrams. The
+	// proxy forwards every byte unconditionally; AA-injection during
+	// IDLE is forwarded as wire AUTO-SYN by design (per v8 §3 IDLE
+	// pass-through, honest residual §14).
+	StateIdle State = iota
+
+	// StateArbitrating is the brief window between an ENH STARTED
+	// event for an active session and the first echo byte. Per v8
+	// §4: raw 0xAA in ARBITRATING is adapter-spurious AA-injection
+	// (no real wire bytes should arrive in this window besides the
+	// arbitration result), so it is dropped.
+	StateArbitrating
+
+	// StateMasterHeader consumes the 5 initiator-frame header bytes:
+	// QQ (source address), ZZ (destination address), PB (primary
+	// command), SB (secondary command), NN (data length).
+	StateMasterHeader
+
+	// StateMasterData consumes the NN data bytes after the header,
+	// where NN was the 5th MASTER_HEADER byte.
+	StateMasterData
+
+	// StateMasterCRC consumes the single CRC byte that follows
+	// MASTER_DATA. Per v8 §1.6 the proxy can validate the CRC against
+	// the initiator-frame bytes it observed; mismatch is admin-logged.
+	StateMasterCRC
+
+	// StateWaitMasterAck waits for the target's ACK (0x00) or NACK
+	// (0xFF) after the initiator CRC. ACK leads to SLAVE_LENGTH for
+	// initiator-target, WAIT_TERMINATOR_SYN for initiator-initiator
+	// or broadcast (ZZ=0xFE). NACK with retx_count<1 leads to
+	// MASTER_RETX; NACK with retx_count>=1 leads to ABORTED. Per v8
+	// invariant I6 (retx cap = 1 per phase).
+	StateWaitMasterAck
+
+	// StateAborted is a terminal state reached on protocol fault or
+	// NACK exhaustion. Per v8 §8 the FSM emits an admin event and
+	// returns to IDLE without injecting synthetic byte-stream events.
+	StateAborted
+)
+
+// String returns a short identifier suitable for admin logs.
+func (s State) String() string {
+	switch s {
+	case StateIdle:
+		return "IDLE"
+	case StateArbitrating:
+		return "ARBITRATING"
+	case StateMasterHeader:
+		return "MASTER_HEADER"
+	case StateMasterData:
+		return "MASTER_DATA"
+	case StateMasterCRC:
+		return "MASTER_CRC"
+	case StateWaitMasterAck:
+		return "WAIT_MASTER_ACK"
+	case StateAborted:
+		return "ABORTED"
+	default:
+		return fmt.Sprintf("State(%d)", s)
+	}
+}
+
+// IsTerminal reports whether the state is a terminal one (telegram
+// has either successfully completed or aborted). Terminal states
+// must transition back to IDLE before the next telegram begins.
+//
+// In this initial implementation only ABORTED is terminal; DONE
+// (success terminator) is represented by a transition back to IDLE
+// after WAIT_TERMINATOR_SYN sees its SYN (added in a later Step B2
+// iteration once WAIT_TERMINATOR_SYN is wired).
+func (s State) IsTerminal() bool {
+	return s == StateAborted
+}
+
+// Decision describes the action the FSM dictates for a single input
+// byte. Machine.Feed returns this; callers act on it (forward, drop,
+// or admin-event-and-forward) before feeding the next byte.
+//
+// Decisions are tagged with their interpretive role so the caller
+// can route the byte to:
+//
+//   - The session's TCP egress queue (DecisionForward).
+//   - The bit bucket (DecisionDropAaInjection).
+//   - The byte stream AND the protocol-fault admin channel
+//     (DecisionProtocolFault — per v8 invariant I10, the byte is
+//     forwarded to preserve wire fidelity AND an admin event is
+//     surfaced for operator visibility).
+type Decision uint8
+
+const (
+	// DecisionForward means the byte is a legitimate part of the
+	// telegram in its current phase and should be emitted to all
+	// downstream observers.
+	DecisionForward Decision = iota
+
+	// DecisionDropAaInjection means the byte is an adapter-spurious
+	// 0xAA that should not reach any observer. The FSM does NOT
+	// advance; the next byte is still classified under the same
+	// phase. Per v8 §4 (AA-injection filter).
+	DecisionDropAaInjection
+
+	// DecisionProtocolFault means the byte is neither a legitimate
+	// phase byte nor an absorbable AA-injection. Callers should
+	// emit an admin event AND forward the byte (per v8 invariant I10:
+	// PROTOCOL_FAULT visibility — drop nothing from the byte stream,
+	// admin-log the fault). The FSM transitions to ABORTED.
+	DecisionProtocolFault
+)
+
+// String returns a short identifier suitable for admin logs.
+func (d Decision) String() string {
+	switch d {
+	case DecisionForward:
+		return "forward"
+	case DecisionDropAaInjection:
+		return "drop_aa_injection"
+	case DecisionProtocolFault:
+		return "protocol_fault"
+	default:
+		return fmt.Sprintf("Decision(%d)", d)
+	}
+}
+
+// Machine is a single-telegram FSM instance. Construct with New().
+//
+// Machine is NOT thread-safe. Per v8 invariant I11, callers must
+// serialize Feed() on a per-session goroutine.
+//
+// The zero value is NOT usable; use New().
+type Machine struct {
+	state State
+
+	// masterNN holds the data-length byte observed in MASTER_HEADER.
+	// Used by MASTER_DATA to count down bytes to consume before
+	// transitioning to MASTER_CRC.
+	masterNN byte
+
+	// masterBytesConsumed counts bytes consumed in the current phase.
+	// Reset on every phase transition. Used by MASTER_HEADER
+	// (counting to 5), MASTER_DATA (counting to masterNN), and
+	// MASTER_CRC (counting to 1).
+	masterBytesConsumed byte
+
+	// masterDest is the ZZ byte from MASTER_HEADER. Determines
+	// post-MASTER_CRC routing: broadcast (0xFE) → terminator;
+	// otherwise → WAIT_MASTER_ACK.
+	masterDest byte
+
+	// masterRetxCount counts initiator-frame retransmissions per v8
+	// invariant I6. Bounded at MaxRetxPerPhase = 1 per eBUS V1.3.1.
+	masterRetxCount byte
+}
+
+// MaxRetxPerPhase is the eBUS V1.3.1 single-retransmit cap per phase
+// (v8 I6). The initiator may retransmit its frame once on NACK from
+// target; the target may retransmit its response once on NACK from
+// the initiator. After one retransmit, the next NACK aborts the
+// telegram.
+const MaxRetxPerPhase byte = 1
+
+// BroadcastDestination is the eBUS broadcast ZZ value (0xFE). Per
+// v6 §3 an initiator frame with ZZ=0xFE skips the WAIT_MASTER_ACK / target
+// phases and goes directly to WAIT_TERMINATOR_SYN.
+const BroadcastDestination byte = 0xFE
+
+// ACKByte (0x00) is the target's positive acknowledgement after
+// receiving a valid initiator CRC. Per v6 §3 it leads to either
+// SLAVE_LENGTH (for initiator-target frames) or WAIT_TERMINATOR_SYN
+// (for initiator-initiator frames).
+const ACKByte byte = 0x00
+
+// NACKByte (0xFF) is the target's negative acknowledgement. Per v6
+// §3 / v8 I6 it triggers a MASTER_RETX (if retx_count<1) or ABORTED
+// (if retx_count>=1).
+const NACKByte byte = 0xFF
+
+// SynByte (0xAA) is the eBUS AUTO-SYN value. Per v8 §4, raw 0xAA
+// (was_escaped=false) in active-write phases is AA-injection from
+// adapter buffering and is dropped; escape-decoded 0xAA
+// (was_escaped=true) is a legitimate payload byte.
+const SynByte byte = 0xAA
+
+// New returns a Machine in StateIdle, ready to accept its first
+// byte via Feed().
+func New() *Machine {
+	return &Machine{state: StateIdle}
+}
+
+// State returns the Machine's current state. Useful for admin
+// observability and tests.
+func (m *Machine) State() State {
+	return m.state
+}
+
+// ResetToIdle returns the Machine to StateIdle and clears all
+// per-telegram state. Useful after a transport RESETTED event (v8
+// invariant I5) or after consuming a WAIT_TERMINATOR_SYN.
+func (m *Machine) ResetToIdle() {
+	m.state = StateIdle
+	m.masterNN = 0
+	m.masterBytesConsumed = 0
+	m.masterDest = 0
+	m.masterRetxCount = 0
+}
+
+// Feed consumes one decoded byte and returns the Decision for that
+// byte. Per v8 invariant I9, the Decision is classified under the
+// CURRENT state, then (if the byte completes the phase, e.g., the
+// 5th MASTER_HEADER byte) the Machine transitions to the next phase
+// before Feed returns. Callers see the Decision computed against
+// the phase that owned the byte; subsequent State() calls reflect
+// the post-transition state.
+//
+// The boolean wasEscaped distinguishes a wire-emitted 0xAA byte
+// (wasEscaped=false, the AUTO-SYN) from an escape-decoded logical
+// 0xAA byte (wasEscaped=true, payload). Per v8 §4 the AA-injection
+// filter uses this provenance.
+//
+// Feed is NOT safe for concurrent use; callers must serialize per
+// v8 invariant I11.
+func (m *Machine) Feed(b byte, wasEscaped bool) Decision {
+	switch m.state {
+	case StateIdle:
+		return m.feedIdle(b, wasEscaped)
+	case StateArbitrating:
+		return m.feedArbitrating(b, wasEscaped)
+	case StateMasterHeader:
+		return m.feedMasterHeader(b, wasEscaped)
+	case StateMasterData:
+		return m.feedMasterData(b, wasEscaped)
+	case StateMasterCRC:
+		return m.feedMasterCRC(b, wasEscaped)
+	case StateWaitMasterAck:
+		return m.feedWaitMasterAck(b, wasEscaped)
+	case StateAborted:
+		// Per v8 §8: after ABORTED, callers should ResetToIdle
+		// before feeding more bytes. Feeding while ABORTED is a
+		// caller bug; report PROTOCOL_FAULT to surface it.
+		return DecisionProtocolFault
+	default:
+		// Defensive: unreachable for the current State enum.
+		return DecisionProtocolFault
+	}
+}
+
+// EnterArbitrating transitions the Machine from IDLE to ARBITRATING
+// in response to an ENH STARTED control event for this session. The
+// next Feed() call will be classified under STATE_ARBITRATING.
+//
+// Per v6 §3 the STARTED→ARBITRATING transition is event-driven (not
+// byte-driven), so it lives outside Feed.
+func (m *Machine) EnterArbitrating() {
+	m.state = StateArbitrating
+}
+
+// feedIdle handles the IDLE state. Per v8 §3 IDLE pass-through, every
+// byte is forwarded regardless of value. Wire AUTO-SYNs and
+// adapter-spurious AA-injection are indistinguishable in IDLE without
+// wire-time information (honest residual §14).
+func (m *Machine) feedIdle(b byte, wasEscaped bool) Decision {
+	_ = b
+	_ = wasEscaped
+	return DecisionForward
+}
+
+// feedArbitrating handles the ARBITRATING state. Per v8 §4: no real
+// wire bytes should arrive in this window (the adapter holds the wire
+// for arbitration outcome resolution). Any byte that does is either
+// adapter-spurious AA-injection (drop) or a genuine fault (admin).
+func (m *Machine) feedArbitrating(b byte, wasEscaped bool) Decision {
+	if b == SynByte && !wasEscaped {
+		return DecisionDropAaInjection
+	}
+	// Some adapters may emit the resolved-source byte here as a normal
+	// echo when arbitration succeeds. For now treat any non-SYN byte
+	// as the first MASTER_HEADER byte (QQ): forward, transition to
+	// MASTER_HEADER, and arrange for the byte to count in MASTER_HEADER.
+	//
+	// The transition is committed AFTER returning (v8 I9: classify
+	// under current state first); the next state advance happens in
+	// transitionAfterArbitrating.
+	m.transitionAfterArbitrating(b)
+	return DecisionForward
+}
+
+// transitionAfterArbitrating commits the post-classification state
+// change for the ARBITRATING state. The byte that triggered the
+// transition is the first MASTER_HEADER byte (QQ); record it as
+// consumed inside the new state.
+func (m *Machine) transitionAfterArbitrating(b byte) {
+	m.state = StateMasterHeader
+	m.masterBytesConsumed = 1
+	// QQ is recorded but not validated here; v8 §1.7's
+	// initiator-class validation happens in a future iteration that
+	// wires the AddressClassOf check.
+	_ = b
+}
+
+// feedMasterHeader handles the MASTER_HEADER state. The state
+// consumes 5 bytes: QQ, ZZ, PB, SB, NN. The 2nd byte (ZZ) is
+// remembered to route post-CRC; the 5th byte (NN) is the data length.
+func (m *Machine) feedMasterHeader(b byte, wasEscaped bool) Decision {
+	if b == SynByte && !wasEscaped {
+		// Raw 0xAA during MASTER_HEADER is AA-injection (v8 §4).
+		return DecisionDropAaInjection
+	}
+	// Consume byte. masterBytesConsumed reflects bytes already
+	// consumed BEFORE this one (initialized to 1 by ARBITRATING for
+	// QQ; or 0 for direct entry — kept compatible with both paths).
+	switch m.masterBytesConsumed {
+	case 1:
+		// 2nd byte is ZZ (destination).
+		m.masterDest = b
+	case 4:
+		// 5th byte is NN (data length).
+		m.masterNN = b
+		if b > 16 {
+			// Per v8 §1.7: NN > 16 violates eBUS V1.3.1 spec (max 16
+			// data bytes). Fault.
+			m.state = StateAborted
+			return DecisionProtocolFault
+		}
+	}
+	m.masterBytesConsumed++
+
+	if m.masterBytesConsumed >= 5 {
+		// MASTER_HEADER complete. Decide next state based on NN.
+		if m.masterNN == 0 {
+			// No data bytes; skip MASTER_DATA, go straight to CRC.
+			m.state = StateMasterCRC
+			m.masterBytesConsumed = 0
+		} else {
+			m.state = StateMasterData
+			m.masterBytesConsumed = 0
+		}
+	}
+	return DecisionForward
+}
+
+// feedMasterData handles the MASTER_DATA state. Consumes masterNN
+// bytes then transitions to MASTER_CRC.
+func (m *Machine) feedMasterData(b byte, wasEscaped bool) Decision {
+	if b == SynByte && !wasEscaped {
+		return DecisionDropAaInjection
+	}
+	m.masterBytesConsumed++
+	if m.masterBytesConsumed >= m.masterNN {
+		m.state = StateMasterCRC
+		m.masterBytesConsumed = 0
+	}
+	return DecisionForward
+}
+
+// feedMasterCRC handles the MASTER_CRC state. Consumes the single
+// CRC byte. Per v6 §3: if ZZ == 0xFE (broadcast) the FSM goes to
+// WAIT_TERMINATOR_SYN; otherwise to WAIT_MASTER_ACK. In this initial
+// Step B2 iteration WAIT_TERMINATOR_SYN is not yet wired, so the
+// broadcast path falls back to IDLE (caller is expected to forward
+// the post-CRC SYN as terminator) — this will be tightened in a
+// subsequent commit when WAIT_TERMINATOR_SYN is added.
+func (m *Machine) feedMasterCRC(b byte, wasEscaped bool) Decision {
+	if b == SynByte && !wasEscaped {
+		return DecisionDropAaInjection
+	}
+	_ = b // CRC validation deferred to v8 §1.6 implementation.
+	if m.masterDest == BroadcastDestination {
+		// Broadcast: skip ACK phase, return to IDLE pending terminator.
+		// (WAIT_TERMINATOR_SYN added in a later commit.)
+		m.ResetToIdle()
+	} else {
+		m.state = StateWaitMasterAck
+	}
+	return DecisionForward
+}
+
+// feedWaitMasterAck handles the WAIT_MASTER_ACK state. Expects ACK
+// (0x00), NACK (0xFF), or AA-injection. Any other byte is a protocol
+// fault.
+func (m *Machine) feedWaitMasterAck(b byte, wasEscaped bool) Decision {
+	if b == SynByte && !wasEscaped {
+		return DecisionDropAaInjection
+	}
+	switch b {
+	case ACKByte:
+		// ACK accepted. Next state in v6 §3 is SLAVE_LENGTH for
+		// initiator-target or WAIT_TERMINATOR_SYN for
+		// initiator-initiator. Target phases land in a follow-up
+		// commit; for now ABORT to IDLE so behavior is well-defined.
+		m.ResetToIdle()
+		return DecisionForward
+	case NACKByte:
+		if m.masterRetxCount < MaxRetxPerPhase {
+			m.masterRetxCount++
+			// Per v6 §3, MASTER_RETX state resets header tracking
+			// and waits for the resend of QQ. In this initial
+			// iteration, restart MASTER_HEADER directly (MASTER_RETX
+			// state added in a follow-up commit).
+			m.state = StateMasterHeader
+			m.masterBytesConsumed = 0
+			m.masterNN = 0
+			m.masterDest = 0
+			return DecisionForward
+		}
+		// Retx budget exhausted (v8 invariant I6).
+		m.state = StateAborted
+		return DecisionForward
+	default:
+		// Any other byte during ACK wait is malformed.
+		m.state = StateAborted
+		return DecisionProtocolFault
+	}
+}

--- a/protocol/telegram_fsm/fsm.go
+++ b/protocol/telegram_fsm/fsm.go
@@ -29,16 +29,16 @@
 //   - **NOT thread-safe**. Per v8 invariant I11, callers serialize
 //     access on a per-session goroutine.
 //
-// Step B2 covers the full active-session path:
-//   - IDLE, ARBITRATING (event-driven entry)
+// Step B2 covers the full active-session path AND the PASSIVE_TRACKING
+// composite state for foreign-initiator telegrams:
+//   - IDLE, ARBITRATING (event-driven entry via EnterArbitrating)
 //   - MASTER_HEADER, MASTER_DATA, MASTER_CRC, WAIT_MASTER_ACK, MASTER_RETX
 //   - SLAVE_LENGTH, SLAVE_DATA, SLAVE_CRC, WAIT_SLAVE_ACK, SLAVE_RETX
 //   - WAIT_TERMINATOR_SYN (success terminator)
 //   - ABORTED (terminal fault)
+//   - PASSIVE_TRACKING (composite, entered via EnterPassiveTracking)
 //
-// The PASSIVE_TRACKING composite state for foreign-initiator telegrams
-// lands in a subsequent commit (Step B2 part 3). Step B3 wires this
-// FSM into the proxy's adapter-facing read path.
+// Step B3 wires this FSM into the proxy's adapter-facing read path.
 package telegram_fsm
 
 import "fmt"
@@ -49,8 +49,8 @@ import "fmt"
 // classification per v8 invariant I9 (classify under current phase,
 // then transition).
 //
-// v8's PASSIVE_TRACKING composite state for foreign-initiator
-// telegrams lands in a subsequent commit (Step B2 part 3).
+// StatePassiveTracking is the v8 §3.1 composite state used for
+// foreign-initiator telegrams; see the type docs below.
 type State uint8
 
 const (
@@ -135,6 +135,24 @@ const (
 	// NACK exhaustion. Per v8 §8 the FSM emits an admin event and
 	// returns to IDLE without injecting synthetic byte-stream events.
 	StateAborted
+
+	// StatePassiveTracking is the composite state for foreign-initiator
+	// telegrams per v8 §3 / §3.1. Internally the FSM runs the SAME
+	// per-byte sub-phase logic as active mode (MASTER_HEADER → … →
+	// WAIT_TERMINATOR_SYN, including MASTER_RETX and SLAVE_RETX), but
+	// the Machine reports State() == StatePassiveTracking to the
+	// caller so the classifier can route bytes through a no-staging
+	// path (the proxy did not originate the bytes, so there's no
+	// staging buffer to FIFO-match against).
+	//
+	// Entry: callers invoke EnterPassiveTracking() when they observe
+	// the first non-SYN byte after IDLE without their own STARTED
+	// event preceding (i.e., a foreign initiator won arbitration on the
+	// wire). The entering byte counts as MASTER_HEADER byte 0 (QQ).
+	//
+	// Exit: terminator SYN observed in WAIT_TERMINATOR_SYN sub-phase
+	// → return to StateIdle (passive flag cleared by ResetToIdle).
+	StatePassiveTracking
 )
 
 // String returns a short identifier suitable for admin logs.
@@ -168,6 +186,8 @@ func (s State) String() string {
 		return "WAIT_TERMINATOR_SYN"
 	case StateAborted:
 		return "ABORTED"
+	case StatePassiveTracking:
+		return "PASSIVE_TRACKING"
 	default:
 		return fmt.Sprintf("State(%d)", s)
 	}
@@ -271,6 +291,15 @@ type Machine struct {
 	// slaveRetxCount counts target-response retransmissions per v8
 	// invariant I6. Independent of masterRetxCount.
 	slaveRetxCount byte
+
+	// passive indicates that the Machine is tracking a foreign-
+	// initiator telegram (PASSIVE_TRACKING composite state per v8
+	// §3.1). When true, State() returns StatePassiveTracking instead
+	// of the internal sub-phase. The per-phase Feed handlers behave
+	// identically regardless of this flag — the difference is purely
+	// the entry point (EnterArbitrating vs EnterPassiveTracking) and
+	// the externally-reported State.
+	passive bool
 }
 
 // MaxRetxPerPhase is the eBUS V1.3.1 single-retransmit cap per phase
@@ -308,10 +337,44 @@ func New() *Machine {
 	return &Machine{state: StateIdle}
 }
 
-// State returns the Machine's current state. Useful for admin
-// observability and tests.
+// State returns the Machine's current state. When the Machine is
+// tracking a foreign-initiator telegram (after EnterPassiveTracking),
+// State() returns StatePassiveTracking for any non-IDLE non-terminal
+// internal sub-phase — this is the user-facing composite state per
+// v8 §3.1.
+//
+// IMPORTANT: terminal states (StateAborted) are NEVER masked by the
+// composite — they pass through directly. This preserves the
+// IsTerminal()-based termination contract for callers that detect
+// "telegram finished with fault" via `m.State().IsTerminal()`.
+// Without this carve-out, passive-mode NACK exhaustion would surface
+// as StatePassiveTracking (not terminal) and the caller would miss
+// the abort signal.
+//
+// To inspect the internal sub-phase during passive tracking (e.g.,
+// for testing), use InternalState().
+//
+// Once the FSM exits passive tracking (terminator SYN observed →
+// IDLE, or RESETTED), State() returns the actual state again.
 func (m *Machine) State() State {
+	if m.passive && m.state != StateIdle && !m.state.IsTerminal() {
+		return StatePassiveTracking
+	}
 	return m.state
+}
+
+// InternalState returns the internal sub-phase regardless of passive
+// mode. Useful for tests that need to assert the exact sub-phase
+// during foreign-telegram tracking.
+func (m *Machine) InternalState() State {
+	return m.state
+}
+
+// IsPassive reports whether the Machine is currently tracking a
+// foreign-initiator telegram (entered via EnterPassiveTracking).
+// Returns false in IDLE, in active mode, or after ResetToIdle.
+func (m *Machine) IsPassive() bool {
+	return m.passive
 }
 
 // ResetToIdle returns the Machine to StateIdle and clears all
@@ -325,6 +388,7 @@ func (m *Machine) ResetToIdle() {
 	m.masterRetxCount = 0
 	m.slaveNN = 0
 	m.slaveRetxCount = 0
+	m.passive = false
 }
 
 // Feed consumes one decoded byte and returns the Decision for that
@@ -389,6 +453,39 @@ func (m *Machine) Feed(b byte, wasEscaped bool) Decision {
 // byte-driven), so it lives outside Feed.
 func (m *Machine) EnterArbitrating() {
 	m.state = StateArbitrating
+	m.passive = false
+}
+
+// EnterPassiveTracking transitions the Machine from IDLE directly to
+// the MASTER_HEADER sub-phase under the PASSIVE_TRACKING composite
+// state. Per v8 §3.1: callers invoke this when they observe the first
+// non-SYN byte after IDLE without a preceding STARTED-for-us event
+// (i.e., a foreign initiator won arbitration on the wire). The
+// entering byte counts as MASTER_HEADER byte 0 (foreign initiator's
+// QQ); the NEXT Feed() call will process byte 1 (ZZ) per the
+// MASTER_HEADER handler.
+//
+// In passive mode, all per-phase Feed handlers behave identically to
+// active mode: same AA-injection drop rules, same NACK retx caps,
+// same WAIT_TERMINATOR_SYN exit. The Machine reports State() ==
+// StatePassiveTracking externally; internal sub-phase tracking is
+// available via InternalState().
+//
+// Exit: when the FSM reaches StateIdle (via WAIT_TERMINATOR_SYN
+// observed, or via abort), the passive flag is cleared and the
+// Machine is ready to enter either active or passive tracking again.
+//
+// EnterPassiveTracking is NOT safe for concurrent use; callers
+// serialize per v8 invariant I11.
+func (m *Machine) EnterPassiveTracking() {
+	m.state = StateMasterHeader
+	m.masterBytesConsumed = 1
+	m.masterNN = 0
+	m.masterDest = 0
+	m.masterRetxCount = 0
+	m.slaveNN = 0
+	m.slaveRetxCount = 0
+	m.passive = true
 }
 
 // feedIdle handles the IDLE state. Per v8 §3 IDLE pass-through, every

--- a/protocol/telegram_fsm/fsm_test.go
+++ b/protocol/telegram_fsm/fsm_test.go
@@ -235,11 +235,10 @@ func TestMasterDataAcceptsEscapedAA(t *testing.T) {
 	}
 }
 
-// TestMasterCRCBroadcastReturnsToIdle verifies broadcast (ZZ=0xFE)
-// short-circuit: post-CRC the FSM returns to IDLE (skipping ACK).
-// Note: WAIT_TERMINATOR_SYN is not yet wired in this iteration; the
-// CRC byte itself is forwarded and the FSM resets.
-func TestMasterCRCBroadcastReturnsToIdle(t *testing.T) {
+// TestMasterCRCBroadcastEntersWaitTerminator verifies broadcast
+// (ZZ=0xFE) short-circuit: post-CRC the FSM enters WAIT_TERMINATOR_SYN
+// (skipping ACK). The final SYN then returns to IDLE.
+func TestMasterCRCBroadcastEntersWaitTerminator(t *testing.T) {
 	t.Parallel()
 	m := New()
 	m.EnterArbitrating()
@@ -255,8 +254,16 @@ func TestMasterCRCBroadcastReturnsToIdle(t *testing.T) {
 	if got != DecisionForward {
 		t.Fatalf("CRC decision = %v, want DecisionForward", got)
 	}
+	if m.State() != StateWaitTerminatorSyn {
+		t.Fatalf("post-CRC broadcast state = %v, want StateWaitTerminatorSyn", m.State())
+	}
+	// Final terminator SYN returns to IDLE.
+	got = m.Feed(0xAA, false)
+	if got != DecisionForward {
+		t.Fatalf("terminator decision = %v, want DecisionForward", got)
+	}
 	if m.State() != StateIdle {
-		t.Fatalf("post-CRC broadcast state = %v, want StateIdle", m.State())
+		t.Fatalf("post-terminator state = %v, want StateIdle", m.State())
 	}
 }
 
@@ -295,9 +302,8 @@ func TestWaitMasterAckDropsRawSyn(t *testing.T) {
 	}
 }
 
-// TestWaitMasterAckAcceptsAck verifies ACK advances toward the next
-// phase. In this initial iteration, ACK returns to IDLE (target phases
-// not yet wired).
+// TestWaitMasterAckAcceptsAck verifies ACK advances to SLAVE_LENGTH
+// for the target response phase.
 func TestWaitMasterAckAcceptsAck(t *testing.T) {
 	t.Parallel()
 	m := setupAtWaitMasterAck(t)
@@ -305,14 +311,14 @@ func TestWaitMasterAckAcceptsAck(t *testing.T) {
 	if got != DecisionForward {
 		t.Fatalf("decision = %v, want DecisionForward", got)
 	}
-	if m.State() != StateIdle {
-		t.Fatalf("post-ACK state = %v, want StateIdle (target phases not yet wired)", m.State())
+	if m.State() != StateSlaveLength {
+		t.Fatalf("post-ACK state = %v, want StateSlaveLength", m.State())
 	}
 }
 
 // TestWaitMasterAckNackTriggersRetx verifies v8 invariant I6:
-// first NACK triggers MASTER_RETX (FSM returns to MASTER_HEADER for
-// the resend; retx_count increments).
+// first NACK triggers MASTER_RETX state; the next byte then
+// re-enters MASTER_HEADER for the resend.
 func TestWaitMasterAckNackTriggersRetx(t *testing.T) {
 	t.Parallel()
 	m := setupAtWaitMasterAck(t)
@@ -320,8 +326,16 @@ func TestWaitMasterAckNackTriggersRetx(t *testing.T) {
 	if got != DecisionForward {
 		t.Fatalf("decision = %v, want DecisionForward", got)
 	}
+	if m.State() != StateMasterRetx {
+		t.Fatalf("state = %v, want StateMasterRetx (explicit retx state)", m.State())
+	}
+	// Next byte is the resent QQ; transitions into MASTER_HEADER.
+	got = m.Feed(0x10, false)
+	if got != DecisionForward {
+		t.Fatalf("post-retx QQ decision = %v, want DecisionForward", got)
+	}
 	if m.State() != StateMasterHeader {
-		t.Fatalf("state = %v, want StateMasterHeader (retx restarts header)", m.State())
+		t.Fatalf("post-retx QQ state = %v, want StateMasterHeader", m.State())
 	}
 }
 
@@ -332,8 +346,10 @@ func TestWaitMasterAckSecondNackAborts(t *testing.T) {
 	m := setupAtWaitMasterAck(t)
 	// First NACK → MASTER_RETX
 	m.Feed(NACKByte, false)
-	// Resend full header
-	for _, b := range []byte{0x10, 0x08, 0xB5, 0x09, 0x00} {
+	// Next byte is resent QQ — enters MASTER_HEADER fresh
+	m.Feed(0x10, false)
+	// Resend remaining header bytes (ZZ PB SB NN=0)
+	for _, b := range []byte{0x08, 0xB5, 0x09, 0x00} {
 		m.Feed(b, false)
 	}
 	// CRC
@@ -416,13 +432,20 @@ func TestRetxCapMatchesSpec(t *testing.T) {
 func TestStateAndDecisionStringsAreReadable(t *testing.T) {
 	t.Parallel()
 	stateCases := map[State]string{
-		StateIdle:          "IDLE",
-		StateArbitrating:   "ARBITRATING",
-		StateMasterHeader:  "MASTER_HEADER",
-		StateMasterData:    "MASTER_DATA",
-		StateMasterCRC:     "MASTER_CRC",
-		StateWaitMasterAck: "WAIT_MASTER_ACK",
-		StateAborted:       "ABORTED",
+		StateIdle:              "IDLE",
+		StateArbitrating:       "ARBITRATING",
+		StateMasterHeader:      "MASTER_HEADER",
+		StateMasterData:        "MASTER_DATA",
+		StateMasterCRC:         "MASTER_CRC",
+		StateWaitMasterAck:     "WAIT_MASTER_ACK",
+		StateMasterRetx:        "MASTER_RETX",
+		StateSlaveLength:       "SLAVE_LENGTH",
+		StateSlaveData:         "SLAVE_DATA",
+		StateSlaveCRC:          "SLAVE_CRC",
+		StateWaitSlaveAck:      "WAIT_SLAVE_ACK",
+		StateSlaveRetx:         "SLAVE_RETX",
+		StateWaitTerminatorSyn: "WAIT_TERMINATOR_SYN",
+		StateAborted:           "ABORTED",
 	}
 	for s, want := range stateCases {
 		if got := s.String(); got != want {
@@ -448,12 +471,339 @@ func TestStateIsTerminal(t *testing.T) {
 	if !StateAborted.IsTerminal() {
 		t.Error("StateAborted.IsTerminal() = false, want true")
 	}
-	nonTerminal := []State{StateIdle, StateArbitrating, StateMasterHeader, StateMasterData, StateMasterCRC, StateWaitMasterAck}
+	nonTerminal := []State{
+		StateIdle, StateArbitrating,
+		StateMasterHeader, StateMasterData, StateMasterCRC,
+		StateWaitMasterAck, StateMasterRetx,
+		StateSlaveLength, StateSlaveData, StateSlaveCRC,
+		StateWaitSlaveAck, StateSlaveRetx,
+		StateWaitTerminatorSyn,
+	}
 	for _, s := range nonTerminal {
 		if s.IsTerminal() {
 			t.Errorf("%v.IsTerminal() = true, want false", s)
 		}
 	}
+}
+
+// setupAtSlaveLength advances the Machine through a complete initiator
+// half (QQ ZZ PB SB NN=0 CRC ACK) so the FSM lands in SLAVE_LENGTH
+// ready for the target's response.
+func setupAtSlaveLength(t *testing.T) *Machine {
+	t.Helper()
+	m := setupAtWaitMasterAck(t)
+	if got := m.Feed(ACKByte, false); got != DecisionForward {
+		t.Fatalf("setup ACK decision = %v, want DecisionForward", got)
+	}
+	if m.State() != StateSlaveLength {
+		t.Fatalf("setup state = %v, want StateSlaveLength", m.State())
+	}
+	return m
+}
+
+// TestSlaveLengthConsumesNNAndEntersSlaveData covers normal target
+// response: NN' > 0 goes to SLAVE_DATA.
+func TestSlaveLengthConsumesNNAndEntersSlaveData(t *testing.T) {
+	t.Parallel()
+	m := setupAtSlaveLength(t)
+	got := m.Feed(0x03, false) // NN' = 3
+	if got != DecisionForward {
+		t.Fatalf("decision = %v, want DecisionForward", got)
+	}
+	if m.State() != StateSlaveData {
+		t.Fatalf("state = %v, want StateSlaveData", m.State())
+	}
+}
+
+// TestSlaveLengthZeroGoesDirectToSlaveCRC verifies NN'=0 short-circuit
+// to SLAVE_CRC. Used by frames where the target has no response payload
+// (e.g., initiator-initiator semantics).
+func TestSlaveLengthZeroGoesDirectToSlaveCRC(t *testing.T) {
+	t.Parallel()
+	m := setupAtSlaveLength(t)
+	got := m.Feed(0x00, false)
+	if got != DecisionForward {
+		t.Fatalf("decision = %v, want DecisionForward", got)
+	}
+	if m.State() != StateSlaveCRC {
+		t.Fatalf("state = %v, want StateSlaveCRC", m.State())
+	}
+}
+
+// TestSlaveLengthRejectsNNAbove16 verifies v8 §1.7 + V1.3.1 spec:
+// target response > 16 data bytes is illegal.
+func TestSlaveLengthRejectsNNAbove16(t *testing.T) {
+	t.Parallel()
+	m := setupAtSlaveLength(t)
+	got := m.Feed(0x11, false) // NN' = 17
+	if got != DecisionProtocolFault {
+		t.Fatalf("decision = %v, want DecisionProtocolFault", got)
+	}
+	if m.State() != StateAborted {
+		t.Fatalf("state = %v, want StateAborted", m.State())
+	}
+}
+
+// TestSlaveLengthAcceptsNNExactly16 verifies the NN'=16 boundary
+// (max valid).
+func TestSlaveLengthAcceptsNNExactly16(t *testing.T) {
+	t.Parallel()
+	m := setupAtSlaveLength(t)
+	got := m.Feed(0x10, false) // NN' = 16
+	if got != DecisionForward {
+		t.Fatalf("decision = %v, want DecisionForward", got)
+	}
+	if m.State() != StateSlaveData {
+		t.Fatalf("state = %v, want StateSlaveData", m.State())
+	}
+}
+
+// TestSlaveDataConsumesNNBytesThenCRC walks the full SLAVE_DATA
+// counter for NN'=2.
+func TestSlaveDataConsumesNNBytesThenCRC(t *testing.T) {
+	t.Parallel()
+	m := setupAtSlaveLength(t)
+	m.Feed(0x02, false) // NN' = 2 → SLAVE_DATA
+	runFeedSequence(t, m, []feedStep{
+		{b: 0xC0, want: DecisionForward, wantState: StateSlaveData},
+		{b: 0xC1, want: DecisionForward, wantState: StateSlaveCRC},
+	})
+}
+
+// TestSlavePhaseDropsRawSyn verifies AA-injection filter active
+// throughout the target-response half (SLAVE_LENGTH, SLAVE_DATA, SLAVE_CRC,
+// WAIT_SLAVE_ACK). Each phase drops raw 0xAA without advancing.
+func TestSlavePhaseDropsRawSyn(t *testing.T) {
+	t.Parallel()
+	// SLAVE_LENGTH
+	m := setupAtSlaveLength(t)
+	if got := m.Feed(0xAA, false); got != DecisionDropAaInjection {
+		t.Fatalf("SLAVE_LENGTH: decision = %v, want DropAaInjection", got)
+	}
+	if m.State() != StateSlaveLength {
+		t.Fatalf("SLAVE_LENGTH stays after drop: state = %v", m.State())
+	}
+	// SLAVE_DATA
+	m = setupAtSlaveLength(t)
+	m.Feed(0x02, false) // → SLAVE_DATA
+	if got := m.Feed(0xAA, false); got != DecisionDropAaInjection {
+		t.Fatalf("SLAVE_DATA: decision = %v, want DropAaInjection", got)
+	}
+	if m.State() != StateSlaveData {
+		t.Fatalf("SLAVE_DATA stays after drop: state = %v", m.State())
+	}
+	// SLAVE_CRC
+	m = setupAtSlaveLength(t)
+	m.Feed(0x00, false) // NN'=0 → SLAVE_CRC
+	if got := m.Feed(0xAA, false); got != DecisionDropAaInjection {
+		t.Fatalf("SLAVE_CRC: decision = %v, want DropAaInjection", got)
+	}
+	if m.State() != StateSlaveCRC {
+		t.Fatalf("SLAVE_CRC stays after drop: state = %v", m.State())
+	}
+	// WAIT_SLAVE_ACK
+	m = setupAtSlaveLength(t)
+	m.Feed(0x00, false) // → SLAVE_CRC
+	m.Feed(0x42, false) // CRC → WAIT_SLAVE_ACK
+	if got := m.Feed(0xAA, false); got != DecisionDropAaInjection {
+		t.Fatalf("WAIT_SLAVE_ACK: decision = %v, want DropAaInjection", got)
+	}
+	if m.State() != StateWaitSlaveAck {
+		t.Fatalf("WAIT_SLAVE_ACK stays after drop: state = %v", m.State())
+	}
+}
+
+// TestMasterRetxDropsRawSyn verifies v8 §4: raw 0xAA in MASTER_RETX
+// is AA-injection (no real wire bytes should arrive between the NACK
+// and the resent QQ). Drop, stay.
+func TestMasterRetxDropsRawSyn(t *testing.T) {
+	t.Parallel()
+	m := setupAtWaitMasterAck(t)
+	m.Feed(NACKByte, false) // → MASTER_RETX
+	if m.State() != StateMasterRetx {
+		t.Fatalf("setup state = %v, want StateMasterRetx", m.State())
+	}
+	got := m.Feed(0xAA, false)
+	if got != DecisionDropAaInjection {
+		t.Fatalf("decision = %v, want DecisionDropAaInjection", got)
+	}
+	if m.State() != StateMasterRetx {
+		t.Fatalf("state = %v, want StateMasterRetx (no advance)", m.State())
+	}
+}
+
+// TestSlaveRetxDropsRawSyn verifies v8 §4: raw 0xAA in SLAVE_RETX
+// is AA-injection (no real wire bytes should arrive between the NACK
+// and the resent NN'). Drop, stay.
+func TestSlaveRetxDropsRawSyn(t *testing.T) {
+	t.Parallel()
+	m := setupAtWaitSlaveAck(t)
+	m.Feed(NACKByte, false) // → SLAVE_RETX
+	if m.State() != StateSlaveRetx {
+		t.Fatalf("setup state = %v, want StateSlaveRetx", m.State())
+	}
+	got := m.Feed(0xAA, false)
+	if got != DecisionDropAaInjection {
+		t.Fatalf("decision = %v, want DecisionDropAaInjection", got)
+	}
+	if m.State() != StateSlaveRetx {
+		t.Fatalf("state = %v, want StateSlaveRetx (no advance)", m.State())
+	}
+}
+
+// TestRetxCountersAreIndependent verifies masterRetxCount and
+// slaveRetxCount are independent per v8 I6. A master phase that
+// completed without NACK leaves the master budget at 0; a subsequent
+// slave NACK must still get SLAVE_RETX (not be blocked by some
+// fictitious shared cap). And vice-versa.
+func TestRetxCountersAreIndependent(t *testing.T) {
+	t.Parallel()
+	// Forward direction: master phase succeeds, slave NACK works.
+	m := setupAtWaitSlaveAck(t) // master ACKed cleanly, no master NACK
+	got := m.Feed(NACKByte, false)
+	if got != DecisionForward {
+		t.Fatalf("forward slave NACK decision = %v, want DecisionForward", got)
+	}
+	if m.State() != StateSlaveRetx {
+		t.Fatalf("forward slave NACK state = %v, want StateSlaveRetx (master budget must not block)", m.State())
+	}
+
+	// Inverse direction: master NACK + retry succeeds, slave still has
+	// its full budget. To exercise: do master NACK, complete the retx,
+	// then do a slave NACK and verify SLAVE_RETX (not abort).
+	m = setupAtWaitMasterAck(t)
+	m.Feed(NACKByte, false) // → MASTER_RETX
+	// Retx header (QQ ZZ PB SB NN=0)
+	for _, b := range []byte{0x10, 0x08, 0xB5, 0x09, 0x00} {
+		m.Feed(b, false)
+	}
+	m.Feed(0x42, false)    // CRC → WAIT_MASTER_ACK
+	m.Feed(ACKByte, false) // → SLAVE_LENGTH
+	m.Feed(0x00, false)    // NN'=0 → SLAVE_CRC
+	m.Feed(0x42, false)    // CRC → WAIT_SLAVE_ACK
+	if m.State() != StateWaitSlaveAck {
+		t.Fatalf("setup post-master-retx state = %v, want StateWaitSlaveAck", m.State())
+	}
+	// Now slave NACK — must enter SLAVE_RETX, not ABORT.
+	got = m.Feed(NACKByte, false)
+	if got != DecisionForward {
+		t.Fatalf("inverse slave NACK decision = %v, want DecisionForward", got)
+	}
+	if m.State() != StateSlaveRetx {
+		t.Fatalf("inverse slave NACK state = %v, want StateSlaveRetx (master retx must not exhaust slave budget)", m.State())
+	}
+}
+
+// TestWaitSlaveAckAcceptsAck verifies ACK → WAIT_TERMINATOR_SYN.
+func TestWaitSlaveAckAcceptsAck(t *testing.T) {
+	t.Parallel()
+	m := setupAtWaitSlaveAck(t)
+	got := m.Feed(ACKByte, false)
+	if got != DecisionForward {
+		t.Fatalf("decision = %v, want DecisionForward", got)
+	}
+	if m.State() != StateWaitTerminatorSyn {
+		t.Fatalf("state = %v, want StateWaitTerminatorSyn", m.State())
+	}
+	// Final SYN returns to IDLE.
+	got = m.Feed(SynByte, false)
+	if got != DecisionForward {
+		t.Fatalf("terminator decision = %v, want DecisionForward", got)
+	}
+	if m.State() != StateIdle {
+		t.Fatalf("post-terminator state = %v, want StateIdle", m.State())
+	}
+}
+
+// TestWaitSlaveAckNackTriggersSlaveRetx verifies first NACK →
+// SLAVE_RETX; next byte is the resent NN'.
+func TestWaitSlaveAckNackTriggersSlaveRetx(t *testing.T) {
+	t.Parallel()
+	m := setupAtWaitSlaveAck(t)
+	got := m.Feed(NACKByte, false)
+	if got != DecisionForward {
+		t.Fatalf("decision = %v, want DecisionForward", got)
+	}
+	if m.State() != StateSlaveRetx {
+		t.Fatalf("state = %v, want StateSlaveRetx", m.State())
+	}
+	// Next byte is the resent NN'. Direct entry to SLAVE_DATA / SLAVE_CRC.
+	got = m.Feed(0x00, false) // NN' = 0 → straight to SLAVE_CRC
+	if got != DecisionForward {
+		t.Fatalf("retx NN' decision = %v, want DecisionForward", got)
+	}
+	if m.State() != StateSlaveCRC {
+		t.Fatalf("retx NN'=0 state = %v, want StateSlaveCRC", m.State())
+	}
+}
+
+// TestWaitSlaveAckSecondNackAborts verifies v8 I6: slave_retx_count
+// caps at 1; second NACK aborts.
+func TestWaitSlaveAckSecondNackAborts(t *testing.T) {
+	t.Parallel()
+	m := setupAtWaitSlaveAck(t)
+	// First NACK → SLAVE_RETX
+	m.Feed(NACKByte, false)
+	// Resent NN'=0 → SLAVE_CRC
+	m.Feed(0x00, false)
+	// Resent CRC → WAIT_SLAVE_ACK
+	m.Feed(0x42, false)
+	if m.State() != StateWaitSlaveAck {
+		t.Fatalf("post-target-retx state = %v, want StateWaitSlaveAck", m.State())
+	}
+	// Second NACK
+	got := m.Feed(NACKByte, false)
+	if got != DecisionForward {
+		t.Fatalf("decision = %v, want DecisionForward", got)
+	}
+	if m.State() != StateAborted {
+		t.Fatalf("state = %v, want StateAborted", m.State())
+	}
+}
+
+// TestWaitTerminatorSynForwardsRawSynUnlikeOtherPhases is the v8 §4
+// carve-out: WAIT_TERMINATOR_SYN is the ONE phase where raw 0xAA is
+// legitimate (it's the terminator). Forward, transition to IDLE.
+func TestWaitTerminatorSynForwardsRawSynUnlikeOtherPhases(t *testing.T) {
+	t.Parallel()
+	m := setupAtWaitSlaveAck(t)
+	m.Feed(ACKByte, false) // → WAIT_TERMINATOR_SYN
+	got := m.Feed(0xAA, false)
+	if got != DecisionForward {
+		t.Fatalf("terminator decision = %v, want DecisionForward", got)
+	}
+	if m.State() != StateIdle {
+		t.Fatalf("post-terminator state = %v, want StateIdle", m.State())
+	}
+}
+
+// TestWaitTerminatorSynRejectsNonSyn verifies non-SYN bytes during
+// WAIT_TERMINATOR_SYN are protocol faults.
+func TestWaitTerminatorSynRejectsNonSyn(t *testing.T) {
+	t.Parallel()
+	m := setupAtWaitSlaveAck(t)
+	m.Feed(ACKByte, false) // → WAIT_TERMINATOR_SYN
+	got := m.Feed(0x42, false)
+	if got != DecisionProtocolFault {
+		t.Fatalf("decision = %v, want DecisionProtocolFault", got)
+	}
+	if m.State() != StateAborted {
+		t.Fatalf("state = %v, want StateAborted", m.State())
+	}
+}
+
+// setupAtWaitSlaveAck advances through initiator+target halves so the
+// FSM lands in WAIT_SLAVE_ACK ready for the initiator's ACK/NACK.
+// Uses NN=0 / NN'=0 for brevity.
+func setupAtWaitSlaveAck(t *testing.T) *Machine {
+	t.Helper()
+	m := setupAtSlaveLength(t)
+	m.Feed(0x00, false) // NN' = 0 → SLAVE_CRC
+	m.Feed(0x42, false) // CRC → WAIT_SLAVE_ACK
+	if m.State() != StateWaitSlaveAck {
+		t.Fatalf("setup state = %v, want StateWaitSlaveAck", m.State())
+	}
+	return m
 }
 
 // setupAtWaitMasterAck constructs a Machine that has progressed

--- a/protocol/telegram_fsm/fsm_test.go
+++ b/protocol/telegram_fsm/fsm_test.go
@@ -652,25 +652,25 @@ func TestSlaveRetxDropsRawSyn(t *testing.T) {
 }
 
 // TestRetxCountersAreIndependent verifies masterRetxCount and
-// slaveRetxCount are independent per v8 I6. A master phase that
-// completed without NACK leaves the master budget at 0; a subsequent
-// slave NACK must still get SLAVE_RETX (not be blocked by some
+// slaveRetxCount are independent per v8 I6. An initiator phase that
+// completed without NACK leaves the initiator budget at 0; a subsequent
+// target NACK must still get SLAVE_RETX (not be blocked by some
 // fictitious shared cap). And vice-versa.
 func TestRetxCountersAreIndependent(t *testing.T) {
 	t.Parallel()
-	// Forward direction: master phase succeeds, slave NACK works.
-	m := setupAtWaitSlaveAck(t) // master ACKed cleanly, no master NACK
+	// Forward direction: initiator phase succeeds, target NACK works.
+	m := setupAtWaitSlaveAck(t) // initiator ACKed cleanly, no initiator NACK
 	got := m.Feed(NACKByte, false)
 	if got != DecisionForward {
-		t.Fatalf("forward slave NACK decision = %v, want DecisionForward", got)
+		t.Fatalf("forward target NACK decision = %v, want DecisionForward", got)
 	}
 	if m.State() != StateSlaveRetx {
-		t.Fatalf("forward slave NACK state = %v, want StateSlaveRetx (master budget must not block)", m.State())
+		t.Fatalf("forward target NACK state = %v, want StateSlaveRetx (initiator budget must not block)", m.State())
 	}
 
-	// Inverse direction: master NACK + retry succeeds, slave still has
-	// its full budget. To exercise: do master NACK, complete the retx,
-	// then do a slave NACK and verify SLAVE_RETX (not abort).
+	// Inverse direction: initiator NACK + retry succeeds, target still has
+	// its full budget. To exercise: do initiator NACK, complete the retx,
+	// then do a target NACK and verify SLAVE_RETX (not abort).
 	m = setupAtWaitMasterAck(t)
 	m.Feed(NACKByte, false) // → MASTER_RETX
 	// Retx header (QQ ZZ PB SB NN=0)
@@ -682,15 +682,15 @@ func TestRetxCountersAreIndependent(t *testing.T) {
 	m.Feed(0x00, false)    // NN'=0 → SLAVE_CRC
 	m.Feed(0x42, false)    // CRC → WAIT_SLAVE_ACK
 	if m.State() != StateWaitSlaveAck {
-		t.Fatalf("setup post-master-retx state = %v, want StateWaitSlaveAck", m.State())
+		t.Fatalf("setup post-initiator-retx state = %v, want StateWaitSlaveAck", m.State())
 	}
-	// Now slave NACK — must enter SLAVE_RETX, not ABORT.
+	// Now target NACK — must enter SLAVE_RETX, not ABORT.
 	got = m.Feed(NACKByte, false)
 	if got != DecisionForward {
-		t.Fatalf("inverse slave NACK decision = %v, want DecisionForward", got)
+		t.Fatalf("inverse target NACK decision = %v, want DecisionForward", got)
 	}
 	if m.State() != StateSlaveRetx {
-		t.Fatalf("inverse slave NACK state = %v, want StateSlaveRetx (master retx must not exhaust slave budget)", m.State())
+		t.Fatalf("inverse target NACK state = %v, want StateSlaveRetx (initiator retx must not exhaust target budget)", m.State())
 	}
 }
 
@@ -823,4 +823,320 @@ func setupAtWaitMasterAck(t *testing.T) *Machine {
 		t.Fatalf("setup pre-condition: state = %v, want StateWaitMasterAck", m.State())
 	}
 	return m
+}
+
+// ===== PASSIVE_TRACKING tests =====
+
+// TestEnterPassiveTrackingPutsCompositeStateOnExternalAPI verifies the
+// user-facing State() returns StatePassiveTracking once
+// EnterPassiveTracking has been called, while InternalState() exposes
+// the sub-phase (MASTER_HEADER initially).
+func TestEnterPassiveTrackingPutsCompositeStateOnExternalAPI(t *testing.T) {
+	t.Parallel()
+	m := New()
+	if m.IsPassive() {
+		t.Fatalf("New().IsPassive() = true, want false")
+	}
+	m.EnterPassiveTracking()
+	if m.State() != StatePassiveTracking {
+		t.Fatalf("State() = %v, want StatePassiveTracking", m.State())
+	}
+	if m.InternalState() != StateMasterHeader {
+		t.Fatalf("InternalState() = %v, want StateMasterHeader", m.InternalState())
+	}
+	if !m.IsPassive() {
+		t.Fatalf("IsPassive() = false, want true")
+	}
+}
+
+// TestPassiveTrackingConsumes4MoreHeaderBytes verifies the entering
+// byte counted as QQ (byte 0 of the 5-byte header), so the next 4
+// bytes complete MASTER_HEADER. The State() stays StatePassiveTracking
+// throughout, while InternalState() advances.
+func TestPassiveTrackingConsumes4MoreHeaderBytes(t *testing.T) {
+	t.Parallel()
+	m := New()
+	m.EnterPassiveTracking() // entering byte was 0x10 (QQ); masterBytesConsumed=1
+	// Now feed ZZ PB SB NN=2 (4 bytes to finish header).
+	for _, b := range []byte{0x08, 0xB5, 0x09, 0x02} {
+		got := m.Feed(b, false)
+		if got != DecisionForward {
+			t.Fatalf("byte 0x%02X: decision = %v, want DecisionForward", b, got)
+		}
+		if m.State() != StatePassiveTracking {
+			t.Fatalf("byte 0x%02X: external state = %v, want StatePassiveTracking", b, m.State())
+		}
+	}
+	if m.InternalState() != StateMasterData {
+		t.Fatalf("InternalState() after header complete = %v, want StateMasterData", m.InternalState())
+	}
+}
+
+// TestPassiveTrackingDropsRawSyn verifies the AA-injection filter
+// applies identically in passive mode. Raw 0xAA mid-header → drop,
+// stay in PASSIVE_TRACKING.
+func TestPassiveTrackingDropsRawSyn(t *testing.T) {
+	t.Parallel()
+	m := New()
+	m.EnterPassiveTracking()
+	got := m.Feed(0xAA, false)
+	if got != DecisionDropAaInjection {
+		t.Fatalf("decision = %v, want DecisionDropAaInjection", got)
+	}
+	if m.State() != StatePassiveTracking {
+		t.Fatalf("state = %v, want StatePassiveTracking (no advance on drop)", m.State())
+	}
+}
+
+// TestPassiveTrackingAcceptsEscapedAAAsPayload verifies escape-decoded
+// 0xAA bytes flow through as legitimate payload (was_escaped=true), no
+// drop, FSM advances.
+func TestPassiveTrackingAcceptsEscapedAAAsPayload(t *testing.T) {
+	t.Parallel()
+	m := New()
+	m.EnterPassiveTracking() // QQ already consumed
+	// Header: ZZ PB SB NN=1
+	for _, b := range []byte{0x08, 0xB5, 0x09, 0x01} {
+		m.Feed(b, false)
+	}
+	// Single data byte is logical 0xAA (escape-decoded).
+	got := m.Feed(0xAA, true)
+	if got != DecisionForward {
+		t.Fatalf("escape-decoded AA decision = %v, want DecisionForward", got)
+	}
+	if m.InternalState() != StateMasterCRC {
+		t.Fatalf("internal state = %v, want StateMasterCRC (NN=1 satisfied)", m.InternalState())
+	}
+	if m.State() != StatePassiveTracking {
+		t.Fatalf("external state = %v, want StatePassiveTracking", m.State())
+	}
+}
+
+// TestPassiveTrackingFullFlowExitsToIdle walks the FULL foreign-
+// telegram lifecycle: header → data → CRC → initiator ACK → target length
+// → target data → target CRC → target ACK → terminator SYN → IDLE.
+// State() returns StatePassiveTracking throughout, then StateIdle at
+// the end (passive flag cleared via ResetToIdle).
+func TestPassiveTrackingFullFlowExitsToIdle(t *testing.T) {
+	t.Parallel()
+	m := New()
+	m.EnterPassiveTracking() // QQ=0x10 (passed externally)
+	runFeedSequence(t, m, []feedStep{
+		{b: 0x08, want: DecisionForward, wantState: StatePassiveTracking},    // ZZ (not broadcast)
+		{b: 0xB5, want: DecisionForward, wantState: StatePassiveTracking},    // PB
+		{b: 0x09, want: DecisionForward, wantState: StatePassiveTracking},    // SB
+		{b: 0x01, want: DecisionForward, wantState: StatePassiveTracking},    // NN=1 → SLAVE_LENGTH after data
+		{b: 0xC0, want: DecisionForward, wantState: StatePassiveTracking},    // single data byte
+		{b: 0x42, want: DecisionForward, wantState: StatePassiveTracking},    // CRC → WAIT_MASTER_ACK
+		{b: ACKByte, want: DecisionForward, wantState: StatePassiveTracking}, // initiator ACK → SLAVE_LENGTH
+		{b: 0x00, want: DecisionForward, wantState: StatePassiveTracking},    // NN'=0 → SLAVE_CRC
+		{b: 0x42, want: DecisionForward, wantState: StatePassiveTracking},    // target CRC → WAIT_SLAVE_ACK
+		{b: ACKByte, want: DecisionForward, wantState: StatePassiveTracking}, // initiator ACK → WAIT_TERMINATOR_SYN
+		{b: 0xAA, want: DecisionForward, wantState: StateIdle},               // terminator SYN → IDLE
+	})
+	if m.IsPassive() {
+		t.Fatalf("IsPassive() = true after terminator, want false (cleared by ResetToIdle)")
+	}
+}
+
+// TestPassiveTrackingNackTriggersRetxJustLikeActive verifies that
+// NACK handling in WAIT_MASTER_ACK works identically in passive mode:
+// first NACK → MASTER_RETX, next byte enters fresh MASTER_HEADER.
+func TestPassiveTrackingNackTriggersRetxJustLikeActive(t *testing.T) {
+	t.Parallel()
+	m := New()
+	m.EnterPassiveTracking() // QQ
+	// Header ZZ PB SB NN=0 + CRC
+	for _, b := range []byte{0x08, 0xB5, 0x09, 0x00, 0x42} {
+		m.Feed(b, false)
+	}
+	if m.InternalState() != StateWaitMasterAck {
+		t.Fatalf("setup InternalState = %v, want StateWaitMasterAck", m.InternalState())
+	}
+	got := m.Feed(NACKByte, false)
+	if got != DecisionForward {
+		t.Fatalf("NACK decision = %v, want DecisionForward", got)
+	}
+	if m.InternalState() != StateMasterRetx {
+		t.Fatalf("post-NACK internal state = %v, want StateMasterRetx", m.InternalState())
+	}
+	if m.State() != StatePassiveTracking {
+		t.Fatalf("post-NACK external state = %v, want StatePassiveTracking", m.State())
+	}
+	// Next byte is resent QQ.
+	got = m.Feed(0x10, false)
+	if got != DecisionForward {
+		t.Fatalf("retx QQ decision = %v, want DecisionForward", got)
+	}
+	if m.InternalState() != StateMasterHeader {
+		t.Fatalf("retx QQ internal state = %v, want StateMasterHeader", m.InternalState())
+	}
+}
+
+// TestPassiveTrackingBroadcastEntersWaitTerminator verifies the
+// broadcast (ZZ=0xFE) short-circuit works in passive mode: MASTER_CRC
+// → WAIT_TERMINATOR_SYN (skip ACK).
+func TestPassiveTrackingBroadcastEntersWaitTerminator(t *testing.T) {
+	t.Parallel()
+	m := New()
+	m.EnterPassiveTracking() // QQ
+	// Header: ZZ=0xFE (broadcast) PB SB NN=0 + CRC
+	for _, b := range []byte{0xFE, 0xB5, 0x09, 0x00, 0x42} {
+		m.Feed(b, false)
+	}
+	if m.InternalState() != StateWaitTerminatorSyn {
+		t.Fatalf("broadcast passive state = %v, want StateWaitTerminatorSyn", m.InternalState())
+	}
+	if m.State() != StatePassiveTracking {
+		t.Fatalf("external state = %v, want StatePassiveTracking", m.State())
+	}
+	// Terminator SYN → IDLE
+	got := m.Feed(0xAA, false)
+	if got != DecisionForward {
+		t.Fatalf("terminator decision = %v, want DecisionForward", got)
+	}
+	if m.State() != StateIdle {
+		t.Fatalf("post-terminator state = %v, want StateIdle", m.State())
+	}
+}
+
+// TestPassiveTrackingResetClearsPassiveFlag verifies ResetToIdle
+// (called e.g. on RESETTED transport event) clears the passive flag
+// AND the internal state.
+func TestPassiveTrackingResetClearsPassiveFlag(t *testing.T) {
+	t.Parallel()
+	m := New()
+	m.EnterPassiveTracking()
+	m.Feed(0x08, false) // advance to byte 2 of MASTER_HEADER
+	if !m.IsPassive() {
+		t.Fatalf("mid-passive IsPassive = false")
+	}
+	m.ResetToIdle()
+	if m.IsPassive() {
+		t.Fatalf("post-reset IsPassive = true, want false")
+	}
+	if m.State() != StateIdle {
+		t.Fatalf("post-reset State = %v, want StateIdle", m.State())
+	}
+	if m.InternalState() != StateIdle {
+		t.Fatalf("post-reset InternalState = %v, want StateIdle", m.InternalState())
+	}
+}
+
+// TestPassiveTrackingNNAbove16Aborts verifies spec-violation handling
+// works identically in passive mode: NN > 16 → ABORTED.
+func TestPassiveTrackingNNAbove16Aborts(t *testing.T) {
+	t.Parallel()
+	m := New()
+	m.EnterPassiveTracking() // QQ
+	// Header: ZZ PB SB NN=17 (spec violation)
+	for _, b := range []byte{0x08, 0xB5, 0x09} {
+		m.Feed(b, false)
+	}
+	got := m.Feed(0x11, false) // NN=17
+	if got != DecisionProtocolFault {
+		t.Fatalf("decision = %v, want DecisionProtocolFault", got)
+	}
+	if m.InternalState() != StateAborted {
+		t.Fatalf("internal state = %v, want StateAborted", m.InternalState())
+	}
+}
+
+// TestPassiveAbortExposesStateAbortedNotComposite is the regression
+// test for Codex PR #163 BLOCKER: terminal states (StateAborted) must
+// NOT be masked by the PASSIVE_TRACKING composite. Otherwise callers
+// using `m.State().IsTerminal()` to detect telegram-finished-with-fault
+// would miss passive-mode aborts (e.g., NACK exhaustion).
+//
+// Scenario: passive WAIT_MASTER_ACK, NACK with retx_count already at
+// max → ABORTED. State() must return StateAborted directly, NOT
+// StatePassiveTracking. IsTerminal() must report true.
+func TestPassiveAbortExposesStateAbortedNotComposite(t *testing.T) {
+	t.Parallel()
+	m := New()
+	m.EnterPassiveTracking()
+	// Header: ZZ PB SB NN=0
+	for _, b := range []byte{0x08, 0xB5, 0x09, 0x00} {
+		m.Feed(b, false)
+	}
+	m.Feed(0x42, false) // CRC → WAIT_MASTER_ACK
+	// First NACK → MASTER_RETX
+	m.Feed(NACKByte, false)
+	// Resent QQ ZZ PB SB NN=0
+	for _, b := range []byte{0x10, 0x08, 0xB5, 0x09, 0x00} {
+		m.Feed(b, false)
+	}
+	m.Feed(0x42, false) // CRC → WAIT_MASTER_ACK (post retx)
+	if m.InternalState() != StateWaitMasterAck {
+		t.Fatalf("setup InternalState = %v, want StateWaitMasterAck", m.InternalState())
+	}
+	// Second NACK → ABORTED. With the BUGGY masking, State() would
+	// have returned StatePassiveTracking here, missing the abort.
+	got := m.Feed(NACKByte, false)
+	if got != DecisionForward {
+		t.Fatalf("second NACK decision = %v, want DecisionForward", got)
+	}
+	if m.InternalState() != StateAborted {
+		t.Fatalf("InternalState after NACK exhaustion = %v, want StateAborted", m.InternalState())
+	}
+	// THE CRITICAL ASSERTION: State() must surface the terminal.
+	if m.State() != StateAborted {
+		t.Fatalf("State() after passive NACK exhaustion = %v, want StateAborted (terminal must not be masked by composite)", m.State())
+	}
+	if !m.State().IsTerminal() {
+		t.Fatalf("State().IsTerminal() = false after abort, want true (caller-side termination contract)")
+	}
+}
+
+// TestPassiveProtocolFaultExposesStateAbortedNotComposite covers the
+// other terminal entry path: malformed byte in WAIT_MASTER_ACK during
+// passive tracking → ABORTED. State() must also expose the terminal.
+func TestPassiveProtocolFaultExposesStateAbortedNotComposite(t *testing.T) {
+	t.Parallel()
+	m := New()
+	m.EnterPassiveTracking()
+	for _, b := range []byte{0x08, 0xB5, 0x09, 0x00} {
+		m.Feed(b, false)
+	}
+	m.Feed(0x42, false) // CRC → WAIT_MASTER_ACK
+	// Malformed byte (not ACK/NACK/AA) → PROTOCOL_FAULT + ABORTED.
+	got := m.Feed(0x42, false)
+	if got != DecisionProtocolFault {
+		t.Fatalf("decision = %v, want DecisionProtocolFault", got)
+	}
+	if m.InternalState() != StateAborted {
+		t.Fatalf("InternalState = %v, want StateAborted", m.InternalState())
+	}
+	if m.State() != StateAborted {
+		t.Fatalf("State() = %v, want StateAborted (terminal not masked)", m.State())
+	}
+	if !m.State().IsTerminal() {
+		t.Fatalf("IsTerminal() = false, want true")
+	}
+}
+
+// TestStatePassiveTrackingStringLabel verifies the String() method.
+func TestStatePassiveTrackingStringLabel(t *testing.T) {
+	t.Parallel()
+	if StatePassiveTracking.String() != "PASSIVE_TRACKING" {
+		t.Fatalf("StatePassiveTracking.String() = %q, want %q",
+			StatePassiveTracking.String(), "PASSIVE_TRACKING")
+	}
+}
+
+// TestEnterArbitratingClearsPassiveFlag verifies that
+// EnterArbitrating after a passive abort (e.g., ResetToIdle then a
+// new active session) correctly clears the passive flag.
+func TestEnterArbitratingClearsPassiveFlag(t *testing.T) {
+	t.Parallel()
+	m := New()
+	m.EnterPassiveTracking()
+	m.ResetToIdle()
+	m.EnterArbitrating()
+	if m.IsPassive() {
+		t.Fatalf("IsPassive after EnterArbitrating = true, want false")
+	}
+	if m.State() != StateArbitrating {
+		t.Fatalf("State = %v, want StateArbitrating", m.State())
+	}
 }

--- a/protocol/telegram_fsm/fsm_test.go
+++ b/protocol/telegram_fsm/fsm_test.go
@@ -1,0 +1,476 @@
+package telegram_fsm
+
+import "testing"
+
+// feedStep describes one byte to feed plus the expected outcome.
+type feedStep struct {
+	b          byte
+	wasEscaped bool
+	want       Decision
+	wantState  State // expected state AFTER this byte is consumed
+}
+
+func runFeedSequence(t *testing.T, m *Machine, steps []feedStep) {
+	t.Helper()
+	for i, step := range steps {
+		got := m.Feed(step.b, step.wasEscaped)
+		if got != step.want {
+			t.Fatalf("step %d (b=0x%02X esc=%v): decision %v, want %v",
+				i, step.b, step.wasEscaped, got, step.want)
+		}
+		if m.State() != step.wantState {
+			t.Fatalf("step %d (b=0x%02X esc=%v): state %v, want %v",
+				i, step.b, step.wasEscaped, m.State(), step.wantState)
+		}
+	}
+}
+
+// TestNewIsIdle verifies New returns a Machine in StateIdle.
+func TestNewIsIdle(t *testing.T) {
+	t.Parallel()
+	m := New()
+	if m.State() != StateIdle {
+		t.Fatalf("New().State() = %v, want StateIdle", m.State())
+	}
+}
+
+// TestIdleForwardsEverything verifies v8 §3 IDLE pass-through: every
+// byte in IDLE is forwarded regardless of value or was_escaped.
+func TestIdleForwardsEverything(t *testing.T) {
+	t.Parallel()
+	m := New()
+	runFeedSequence(t, m, []feedStep{
+		{b: 0xAA, wasEscaped: false, want: DecisionForward, wantState: StateIdle},
+		{b: 0xAA, wasEscaped: true, want: DecisionForward, wantState: StateIdle},
+		{b: 0x00, wasEscaped: false, want: DecisionForward, wantState: StateIdle},
+		{b: 0xFF, wasEscaped: false, want: DecisionForward, wantState: StateIdle},
+	})
+}
+
+// TestEnterArbitrating transitions IDLE → ARBITRATING on the
+// STARTED event (not on a byte feed). The state advance is purely
+// event-driven per v6 §3.
+func TestEnterArbitrating(t *testing.T) {
+	t.Parallel()
+	m := New()
+	m.EnterArbitrating()
+	if m.State() != StateArbitrating {
+		t.Fatalf("State after EnterArbitrating = %v, want StateArbitrating", m.State())
+	}
+}
+
+// TestArbitratingDropsRawSyn verifies v8 §4: raw 0xAA in ARBITRATING
+// is adapter-spurious AA-injection. Drop, do not advance.
+func TestArbitratingDropsRawSyn(t *testing.T) {
+	t.Parallel()
+	m := New()
+	m.EnterArbitrating()
+	got := m.Feed(0xAA, false)
+	if got != DecisionDropAaInjection {
+		t.Fatalf("decision = %v, want DecisionDropAaInjection", got)
+	}
+	if m.State() != StateArbitrating {
+		t.Fatalf("state = %v, want StateArbitrating (no advance on drop)", m.State())
+	}
+}
+
+// TestArbitratingFirstByteEntersMasterHeader verifies the
+// ARBITRATING → MASTER_HEADER transition on the first non-SYN byte.
+// The first byte is QQ; it counts as byte 1 of the 5-byte header.
+func TestArbitratingFirstByteEntersMasterHeader(t *testing.T) {
+	t.Parallel()
+	m := New()
+	m.EnterArbitrating()
+	got := m.Feed(0x10, false) // QQ
+	if got != DecisionForward {
+		t.Fatalf("decision = %v, want DecisionForward", got)
+	}
+	if m.State() != StateMasterHeader {
+		t.Fatalf("state = %v, want StateMasterHeader", m.State())
+	}
+}
+
+// TestMasterHeaderConsumes5BytesThenMasterData verifies the full
+// MASTER_HEADER consumption for NN > 0, transitioning to MASTER_DATA.
+func TestMasterHeaderConsumes5BytesThenMasterData(t *testing.T) {
+	t.Parallel()
+	m := New()
+	m.EnterArbitrating()
+	runFeedSequence(t, m, []feedStep{
+		{b: 0x10, want: DecisionForward, wantState: StateMasterHeader}, // QQ
+		{b: 0x08, want: DecisionForward, wantState: StateMasterHeader}, // ZZ
+		{b: 0xB5, want: DecisionForward, wantState: StateMasterHeader}, // PB
+		{b: 0x09, want: DecisionForward, wantState: StateMasterHeader}, // SB
+		{b: 0x03, want: DecisionForward, wantState: StateMasterData},   // NN=3
+	})
+}
+
+// TestMasterHeaderZeroDataGoesDirectToCRC verifies NN=0 short-circuit
+// to MASTER_CRC.
+func TestMasterHeaderZeroDataGoesDirectToCRC(t *testing.T) {
+	t.Parallel()
+	m := New()
+	m.EnterArbitrating()
+	runFeedSequence(t, m, []feedStep{
+		{b: 0x10, want: DecisionForward, wantState: StateMasterHeader},
+		{b: 0x08, want: DecisionForward, wantState: StateMasterHeader},
+		{b: 0xB5, want: DecisionForward, wantState: StateMasterHeader},
+		{b: 0x09, want: DecisionForward, wantState: StateMasterHeader},
+		{b: 0x00, want: DecisionForward, wantState: StateMasterCRC}, // NN=0 → skip to CRC
+	})
+}
+
+// TestMasterHeaderRejectsNNAbove16 verifies v8 §1.7: NN > 16 is a
+// spec violation per eBUS V1.3.1, immediately aborting.
+func TestMasterHeaderRejectsNNAbove16(t *testing.T) {
+	t.Parallel()
+	m := New()
+	m.EnterArbitrating()
+	runFeedSequence(t, m, []feedStep{
+		{b: 0x10, want: DecisionForward, wantState: StateMasterHeader},
+		{b: 0x08, want: DecisionForward, wantState: StateMasterHeader},
+		{b: 0xB5, want: DecisionForward, wantState: StateMasterHeader},
+		{b: 0x09, want: DecisionForward, wantState: StateMasterHeader},
+		{b: 0x11, want: DecisionProtocolFault, wantState: StateAborted}, // NN=17 spec violation
+	})
+}
+
+// TestMasterHeaderAcceptsNNExactly16 verifies the boundary case: NN=16
+// is the maximum valid data length per eBUS V1.3.1, must NOT abort.
+// Pins the `>` comparison in fsm.go against silent regression to `>=`.
+func TestMasterHeaderAcceptsNNExactly16(t *testing.T) {
+	t.Parallel()
+	m := New()
+	m.EnterArbitrating()
+	runFeedSequence(t, m, []feedStep{
+		{b: 0x10, want: DecisionForward, wantState: StateMasterHeader},
+		{b: 0x08, want: DecisionForward, wantState: StateMasterHeader},
+		{b: 0xB5, want: DecisionForward, wantState: StateMasterHeader},
+		{b: 0x09, want: DecisionForward, wantState: StateMasterHeader},
+		{b: 0x10, want: DecisionForward, wantState: StateMasterData}, // NN=16 boundary
+	})
+}
+
+// TestMasterHeaderDropsRawSyn verifies v8 §4: raw 0xAA in MASTER_HEADER
+// (any of the 5 header bytes after QQ) is AA-injection. Drop, stay.
+func TestMasterHeaderDropsRawSyn(t *testing.T) {
+	t.Parallel()
+	m := New()
+	m.EnterArbitrating()
+	m.Feed(0x10, false) // QQ — now in MASTER_HEADER
+	if m.State() != StateMasterHeader {
+		t.Fatalf("setup state = %v, want StateMasterHeader", m.State())
+	}
+	got := m.Feed(0xAA, false)
+	if got != DecisionDropAaInjection {
+		t.Fatalf("decision = %v, want DecisionDropAaInjection", got)
+	}
+	if m.State() != StateMasterHeader {
+		t.Fatalf("state = %v, want StateMasterHeader (no advance)", m.State())
+	}
+}
+
+// TestMasterCRCDropsRawSyn verifies v8 §4: raw 0xAA in MASTER_CRC is
+// AA-injection (the CRC byte should never be 0xAA raw — payload-0xAA
+// encodes as escape-pair, and the actual wire AUTO-SYN only marks
+// terminator AFTER WAIT_TERMINATOR_SYN). Drop, stay in MASTER_CRC.
+func TestMasterCRCDropsRawSyn(t *testing.T) {
+	t.Parallel()
+	m := New()
+	m.EnterArbitrating()
+	for _, b := range []byte{0x10, 0x08, 0xB5, 0x09, 0x00} {
+		m.Feed(b, false)
+	}
+	if m.State() != StateMasterCRC {
+		t.Fatalf("setup state = %v, want StateMasterCRC", m.State())
+	}
+	got := m.Feed(0xAA, false)
+	if got != DecisionDropAaInjection {
+		t.Fatalf("decision = %v, want DecisionDropAaInjection", got)
+	}
+	if m.State() != StateMasterCRC {
+		t.Fatalf("state = %v, want StateMasterCRC (no advance)", m.State())
+	}
+}
+
+// TestMasterDataDropsRawSyn verifies v8 §4: raw 0xAA in MASTER_DATA
+// is AA-injection. Drop, stay in MASTER_DATA.
+func TestMasterDataDropsRawSyn(t *testing.T) {
+	t.Parallel()
+	m := New()
+	m.EnterArbitrating()
+	for _, b := range []byte{0x10, 0x08, 0xB5, 0x09, 0x03} {
+		m.Feed(b, false)
+	}
+	if m.State() != StateMasterData {
+		t.Fatalf("setup state = %v, want StateMasterData", m.State())
+	}
+	got := m.Feed(0xAA, false)
+	if got != DecisionDropAaInjection {
+		t.Fatalf("decision = %v, want DecisionDropAaInjection", got)
+	}
+	if m.State() != StateMasterData {
+		t.Fatalf("state = %v, want StateMasterData (no advance on drop)", m.State())
+	}
+}
+
+// TestMasterDataAcceptsEscapedAA verifies that an escape-decoded
+// logical 0xAA (was_escaped=true) is a legitimate payload byte and
+// advances MASTER_DATA's byte counter.
+func TestMasterDataAcceptsEscapedAA(t *testing.T) {
+	t.Parallel()
+	m := New()
+	m.EnterArbitrating()
+	// QQ ZZ PB SB NN=1 (single data byte)
+	for _, b := range []byte{0x10, 0x08, 0xB5, 0x09, 0x01} {
+		m.Feed(b, false)
+	}
+	// Single data byte is a logical 0xAA (escape-decoded).
+	got := m.Feed(0xAA, true)
+	if got != DecisionForward {
+		t.Fatalf("decision = %v, want DecisionForward (escape-decoded AA is legit payload)", got)
+	}
+	if m.State() != StateMasterCRC {
+		t.Fatalf("state = %v, want StateMasterCRC (NN=1 satisfied)", m.State())
+	}
+}
+
+// TestMasterCRCBroadcastReturnsToIdle verifies broadcast (ZZ=0xFE)
+// short-circuit: post-CRC the FSM returns to IDLE (skipping ACK).
+// Note: WAIT_TERMINATOR_SYN is not yet wired in this iteration; the
+// CRC byte itself is forwarded and the FSM resets.
+func TestMasterCRCBroadcastReturnsToIdle(t *testing.T) {
+	t.Parallel()
+	m := New()
+	m.EnterArbitrating()
+	// QQ ZZ=0xFE PB SB NN=1
+	for _, b := range []byte{0x10, 0xFE, 0xB5, 0x09, 0x01} {
+		m.Feed(b, false)
+	}
+	m.Feed(0xCC, false) // data byte
+	if m.State() != StateMasterCRC {
+		t.Fatalf("pre-CRC state = %v, want StateMasterCRC", m.State())
+	}
+	got := m.Feed(0x55, false) // CRC byte
+	if got != DecisionForward {
+		t.Fatalf("CRC decision = %v, want DecisionForward", got)
+	}
+	if m.State() != StateIdle {
+		t.Fatalf("post-CRC broadcast state = %v, want StateIdle", m.State())
+	}
+}
+
+// TestMasterCRCNonBroadcastGoesToWaitAck verifies non-broadcast frames
+// transition MASTER_CRC → WAIT_MASTER_ACK.
+func TestMasterCRCNonBroadcastGoesToWaitAck(t *testing.T) {
+	t.Parallel()
+	m := New()
+	m.EnterArbitrating()
+	for _, b := range []byte{0x10, 0x08, 0xB5, 0x09, 0x00} { // NN=0
+		m.Feed(b, false)
+	}
+	if m.State() != StateMasterCRC {
+		t.Fatalf("pre-CRC state = %v, want StateMasterCRC", m.State())
+	}
+	got := m.Feed(0x42, false) // CRC byte
+	if got != DecisionForward {
+		t.Fatalf("CRC decision = %v, want DecisionForward", got)
+	}
+	if m.State() != StateWaitMasterAck {
+		t.Fatalf("post-CRC state = %v, want StateWaitMasterAck", m.State())
+	}
+}
+
+// TestWaitMasterAckDropsRawSyn verifies v8 §4: raw 0xAA in
+// WAIT_MASTER_ACK is AA-injection. Drop, stay.
+func TestWaitMasterAckDropsRawSyn(t *testing.T) {
+	t.Parallel()
+	m := setupAtWaitMasterAck(t)
+	got := m.Feed(0xAA, false)
+	if got != DecisionDropAaInjection {
+		t.Fatalf("decision = %v, want DecisionDropAaInjection", got)
+	}
+	if m.State() != StateWaitMasterAck {
+		t.Fatalf("state = %v, want StateWaitMasterAck (no advance)", m.State())
+	}
+}
+
+// TestWaitMasterAckAcceptsAck verifies ACK advances toward the next
+// phase. In this initial iteration, ACK returns to IDLE (target phases
+// not yet wired).
+func TestWaitMasterAckAcceptsAck(t *testing.T) {
+	t.Parallel()
+	m := setupAtWaitMasterAck(t)
+	got := m.Feed(ACKByte, false)
+	if got != DecisionForward {
+		t.Fatalf("decision = %v, want DecisionForward", got)
+	}
+	if m.State() != StateIdle {
+		t.Fatalf("post-ACK state = %v, want StateIdle (target phases not yet wired)", m.State())
+	}
+}
+
+// TestWaitMasterAckNackTriggersRetx verifies v8 invariant I6:
+// first NACK triggers MASTER_RETX (FSM returns to MASTER_HEADER for
+// the resend; retx_count increments).
+func TestWaitMasterAckNackTriggersRetx(t *testing.T) {
+	t.Parallel()
+	m := setupAtWaitMasterAck(t)
+	got := m.Feed(NACKByte, false)
+	if got != DecisionForward {
+		t.Fatalf("decision = %v, want DecisionForward", got)
+	}
+	if m.State() != StateMasterHeader {
+		t.Fatalf("state = %v, want StateMasterHeader (retx restarts header)", m.State())
+	}
+}
+
+// TestWaitMasterAckSecondNackAborts verifies v8 invariant I6: after
+// the spec-mandated single retx, a second NACK aborts the telegram.
+func TestWaitMasterAckSecondNackAborts(t *testing.T) {
+	t.Parallel()
+	m := setupAtWaitMasterAck(t)
+	// First NACK → MASTER_RETX
+	m.Feed(NACKByte, false)
+	// Resend full header
+	for _, b := range []byte{0x10, 0x08, 0xB5, 0x09, 0x00} {
+		m.Feed(b, false)
+	}
+	// CRC
+	m.Feed(0x42, false)
+	if m.State() != StateWaitMasterAck {
+		t.Fatalf("post-retx state = %v, want StateWaitMasterAck", m.State())
+	}
+	// Second NACK
+	got := m.Feed(NACKByte, false)
+	if got != DecisionForward {
+		t.Fatalf("decision = %v, want DecisionForward", got)
+	}
+	if m.State() != StateAborted {
+		t.Fatalf("state = %v, want StateAborted (retx budget exhausted)", m.State())
+	}
+}
+
+// TestWaitMasterAckMalformedByteAborts verifies any byte other than
+// ACK / NACK / AA in WAIT_MASTER_ACK is a protocol fault.
+func TestWaitMasterAckMalformedByteAborts(t *testing.T) {
+	t.Parallel()
+	m := setupAtWaitMasterAck(t)
+	got := m.Feed(0x42, false)
+	if got != DecisionProtocolFault {
+		t.Fatalf("decision = %v, want DecisionProtocolFault", got)
+	}
+	if m.State() != StateAborted {
+		t.Fatalf("state = %v, want StateAborted", m.State())
+	}
+}
+
+// TestAbortedFedReportsFault verifies that feeding bytes while in
+// ABORTED returns DecisionProtocolFault (caller bug to feed without
+// ResetToIdle first).
+func TestAbortedFedReportsFault(t *testing.T) {
+	t.Parallel()
+	m := setupAtWaitMasterAck(t)
+	m.Feed(0x42, false) // → ABORTED
+	if m.State() != StateAborted {
+		t.Fatalf("setup state = %v, want StateAborted", m.State())
+	}
+	got := m.Feed(0x10, false)
+	if got != DecisionProtocolFault {
+		t.Fatalf("decision = %v, want DecisionProtocolFault (feed while ABORTED)", got)
+	}
+}
+
+// TestResetToIdleClearsState verifies ResetToIdle returns to IDLE
+// and clears all per-telegram state, allowing the same Machine to
+// be reused for the next telegram.
+func TestResetToIdleClearsState(t *testing.T) {
+	t.Parallel()
+	m := setupAtWaitMasterAck(t)
+	m.ResetToIdle()
+	if m.State() != StateIdle {
+		t.Fatalf("post-reset state = %v, want StateIdle", m.State())
+	}
+	// Machine should work normally for a fresh telegram.
+	m.EnterArbitrating()
+	got := m.Feed(0x10, false)
+	if got != DecisionForward {
+		t.Fatalf("post-reset arbitration → header: decision = %v, want DecisionForward", got)
+	}
+	if m.State() != StateMasterHeader {
+		t.Fatalf("post-reset arbitration → header: state = %v, want StateMasterHeader", m.State())
+	}
+}
+
+// TestRetxCapMatchesSpec drift-guards the MaxRetxPerPhase constant
+// against the v8 I6 spec value.
+func TestRetxCapMatchesSpec(t *testing.T) {
+	t.Parallel()
+	if MaxRetxPerPhase != 1 {
+		t.Fatalf("MaxRetxPerPhase = %d, want 1 (per spec V1.3.1, v8 I6)", MaxRetxPerPhase)
+	}
+}
+
+// TestStateAndDecisionStringsAreReadable verifies the String()
+// methods produce labels suitable for admin logs.
+func TestStateAndDecisionStringsAreReadable(t *testing.T) {
+	t.Parallel()
+	stateCases := map[State]string{
+		StateIdle:          "IDLE",
+		StateArbitrating:   "ARBITRATING",
+		StateMasterHeader:  "MASTER_HEADER",
+		StateMasterData:    "MASTER_DATA",
+		StateMasterCRC:     "MASTER_CRC",
+		StateWaitMasterAck: "WAIT_MASTER_ACK",
+		StateAborted:       "ABORTED",
+	}
+	for s, want := range stateCases {
+		if got := s.String(); got != want {
+			t.Errorf("State(%d).String() = %q, want %q", s, got, want)
+		}
+	}
+	decisionCases := map[Decision]string{
+		DecisionForward:         "forward",
+		DecisionDropAaInjection: "drop_aa_injection",
+		DecisionProtocolFault:   "protocol_fault",
+	}
+	for d, want := range decisionCases {
+		if got := d.String(); got != want {
+			t.Errorf("Decision(%d).String() = %q, want %q", d, got, want)
+		}
+	}
+}
+
+// TestStateIsTerminal verifies IsTerminal reports ABORTED as
+// terminal and all other states as non-terminal.
+func TestStateIsTerminal(t *testing.T) {
+	t.Parallel()
+	if !StateAborted.IsTerminal() {
+		t.Error("StateAborted.IsTerminal() = false, want true")
+	}
+	nonTerminal := []State{StateIdle, StateArbitrating, StateMasterHeader, StateMasterData, StateMasterCRC, StateWaitMasterAck}
+	for _, s := range nonTerminal {
+		if s.IsTerminal() {
+			t.Errorf("%v.IsTerminal() = true, want false", s)
+		}
+	}
+}
+
+// setupAtWaitMasterAck constructs a Machine that has progressed
+// through IDLE → ARBITRATING → MASTER_HEADER (NN=0) → MASTER_CRC →
+// WAIT_MASTER_ACK with a non-broadcast frame.
+func setupAtWaitMasterAck(t *testing.T) *Machine {
+	t.Helper()
+	m := New()
+	m.EnterArbitrating()
+	// QQ ZZ PB SB NN=0 then CRC. ZZ != 0xFE so the FSM goes to
+	// WAIT_MASTER_ACK after CRC.
+	for _, b := range []byte{0x10, 0x08, 0xB5, 0x09, 0x00} {
+		m.Feed(b, false)
+	}
+	m.Feed(0x42, false) // CRC
+	if m.State() != StateWaitMasterAck {
+		t.Fatalf("setup pre-condition: state = %v, want StateWaitMasterAck", m.State())
+	}
+	return m
+}

--- a/transport/apply_escape_admin_event_test.go
+++ b/transport/apply_escape_admin_event_test.go
@@ -1,0 +1,187 @@
+package transport
+
+import (
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// Phase 1 Step B1 (frame-atomic-visibility v8 §1.3 / §5, invariant
+// I4): deterministic unit tests for applyEscapeAdminEvent — the
+// admin-event-to-counter routing extracted from
+// feedEscapeDecoderLocked per Codex round-3 review on PR #165.
+//
+// The integration tests in enh_transport_v8_counters_test.go cover
+// the wiring for Recovery, BudgetExhausted, and AaAbsorbed via the
+// end-to-end ENH stream path. The wall-clock timeout case cannot be
+// integration-tested deterministically (see the NOTE in that file
+// + Codex round-2 finding) because net.Pipe.Write returning does
+// not prove the decoder has been fed yet. These pure-function tests
+// close that gap: they feed each AdminEvent kind into
+// applyEscapeAdminEvent directly and assert the counter side-effects
+// PLUS the dropEmission return value, without depending on
+// scheduler timing or net.Pipe semantics.
+
+// pinPendingTimeout asserts that AdminEventEscapePendingTimeout
+// increments ONLY the pending-timeout counter and returns
+// dropEmission=false (data-preserving recovery).
+func TestApplyEscapeAdminEvent_PendingTimeout(t *testing.T) {
+	t.Parallel()
+
+	var pendingTimeout, recovery, budgetExhausted, decodeFault atomic.Uint64
+
+	admin := AdminEvent{
+		Kind:     AdminEventEscapePendingTimeout,
+		Duration: 33 * time.Millisecond,
+		Absorbed: 0,
+	}
+	drop := applyEscapeAdminEvent(admin, &pendingTimeout, &recovery, &budgetExhausted, &decodeFault)
+
+	if drop {
+		t.Error("dropEmission=true for PendingTimeout; want false (data-preserving)")
+	}
+	if got := pendingTimeout.Load(); got != 1 {
+		t.Errorf("pendingTimeout=%d; want 1", got)
+	}
+	if got := recovery.Load(); got != 0 {
+		t.Errorf("recovery=%d; want 0 (only pendingTimeout should increment)", got)
+	}
+	if got := budgetExhausted.Load(); got != 0 {
+		t.Errorf("budgetExhausted=%d; want 0", got)
+	}
+	if got := decodeFault.Load(); got != 0 {
+		t.Errorf("decodeFault=%d; want 0 (timeout is NOT a fault — data-preserving)", got)
+	}
+}
+
+func TestApplyEscapeAdminEvent_Recovery(t *testing.T) {
+	t.Parallel()
+
+	var pendingTimeout, recovery, budgetExhausted, decodeFault atomic.Uint64
+
+	admin := AdminEvent{Kind: AdminEventEscapeRecovery, Absorbed: 0}
+	drop := applyEscapeAdminEvent(admin, &pendingTimeout, &recovery, &budgetExhausted, &decodeFault)
+
+	if !drop {
+		t.Error("dropEmission=false for Recovery; want true (fault — drop the byte)")
+	}
+	if got := recovery.Load(); got != 1 {
+		t.Errorf("recovery=%d; want 1", got)
+	}
+	if got := decodeFault.Load(); got != 1 {
+		t.Errorf("decodeFault=%d; want 1 (Recovery is a fault)", got)
+	}
+	if got := pendingTimeout.Load(); got != 0 {
+		t.Errorf("pendingTimeout=%d; want 0", got)
+	}
+	if got := budgetExhausted.Load(); got != 0 {
+		t.Errorf("budgetExhausted=%d; want 0", got)
+	}
+}
+
+func TestApplyEscapeAdminEvent_BudgetExhausted(t *testing.T) {
+	t.Parallel()
+
+	var pendingTimeout, recovery, budgetExhausted, decodeFault atomic.Uint64
+
+	admin := AdminEvent{Kind: AdminEventEscapeBudgetExhausted, Absorbed: MaxAaAbsorptionsPerEscapePair}
+	drop := applyEscapeAdminEvent(admin, &pendingTimeout, &recovery, &budgetExhausted, &decodeFault)
+
+	if !drop {
+		t.Error("dropEmission=false for BudgetExhausted; want true (fault — drop)")
+	}
+	if got := budgetExhausted.Load(); got != 1 {
+		t.Errorf("budgetExhausted=%d; want 1", got)
+	}
+	if got := decodeFault.Load(); got != 1 {
+		t.Errorf("decodeFault=%d; want 1 (BudgetExhausted is a fault)", got)
+	}
+	if got := pendingTimeout.Load(); got != 0 {
+		t.Errorf("pendingTimeout=%d; want 0", got)
+	}
+	if got := recovery.Load(); got != 0 {
+		t.Errorf("recovery=%d; want 0", got)
+	}
+}
+
+func TestApplyEscapeAdminEvent_None(t *testing.T) {
+	t.Parallel()
+
+	var pendingTimeout, recovery, budgetExhausted, decodeFault atomic.Uint64
+
+	admin := AdminEvent{Kind: AdminEventNone}
+	drop := applyEscapeAdminEvent(admin, &pendingTimeout, &recovery, &budgetExhausted, &decodeFault)
+
+	if drop {
+		t.Error("dropEmission=true for None; want false (no event, emission proceeds)")
+	}
+	if got := pendingTimeout.Load(); got != 0 {
+		t.Errorf("pendingTimeout=%d; want 0", got)
+	}
+	if got := recovery.Load(); got != 0 {
+		t.Errorf("recovery=%d; want 0", got)
+	}
+	if got := budgetExhausted.Load(); got != 0 {
+		t.Errorf("budgetExhausted=%d; want 0", got)
+	}
+	if got := decodeFault.Load(); got != 0 {
+		t.Errorf("decodeFault=%d; want 0", got)
+	}
+}
+
+// TestApplyEscapeAdminEvent_TimeoutDoesNotIncrementDecodeFault is a
+// targeted regression guard against the most likely refactor mistake:
+// someone treating PendingTimeout as a "fault" and adding it to
+// DecodeFaultTotal. Per v8 §1.3 the timeout path is data-preserving
+// (the current byte is re-emitted), so it MUST NOT be a fault.
+func TestApplyEscapeAdminEvent_TimeoutDoesNotIncrementDecodeFault(t *testing.T) {
+	t.Parallel()
+
+	var pendingTimeout, recovery, budgetExhausted, decodeFault atomic.Uint64
+
+	// Fire the timeout admin event many times — none should
+	// increment decodeFault.
+	for i := 0; i < 100; i++ {
+		_ = applyEscapeAdminEvent(
+			AdminEvent{Kind: AdminEventEscapePendingTimeout},
+			&pendingTimeout, &recovery, &budgetExhausted, &decodeFault,
+		)
+	}
+
+	if got := pendingTimeout.Load(); got != 100 {
+		t.Errorf("pendingTimeout=%d; want 100", got)
+	}
+	if got := decodeFault.Load(); got != 0 {
+		t.Errorf("decodeFault=%d; want 0 (timeout MUST NOT count toward fault — v8 §1.3 data-preserving invariant)", got)
+	}
+}
+
+// TestApplyEscapeAdminEvent_FaultsBothIncrementDecodeFault is the
+// dual regression guard: Recovery and BudgetExhausted MUST both
+// increment decodeFault (the legacy fault counter operators are
+// already watching). If a refactor decouples them, this test fires.
+func TestApplyEscapeAdminEvent_FaultsBothIncrementDecodeFault(t *testing.T) {
+	t.Parallel()
+
+	var pendingTimeout, recovery, budgetExhausted, decodeFault atomic.Uint64
+
+	_ = applyEscapeAdminEvent(
+		AdminEvent{Kind: AdminEventEscapeRecovery},
+		&pendingTimeout, &recovery, &budgetExhausted, &decodeFault,
+	)
+	_ = applyEscapeAdminEvent(
+		AdminEvent{Kind: AdminEventEscapeBudgetExhausted},
+		&pendingTimeout, &recovery, &budgetExhausted, &decodeFault,
+	)
+
+	if got := recovery.Load(); got != 1 {
+		t.Errorf("recovery=%d; want 1", got)
+	}
+	if got := budgetExhausted.Load(); got != 1 {
+		t.Errorf("budgetExhausted=%d; want 1", got)
+	}
+	// DecodeFault should be 2 (Recovery + BudgetExhausted).
+	if got := decodeFault.Load(); got != 2 {
+		t.Errorf("decodeFault=%d; want 2 (both faults must increment the legacy counter)", got)
+	}
+}

--- a/transport/ebus_escape.go
+++ b/transport/ebus_escape.go
@@ -1,6 +1,9 @@
 package transport
 
-import "fmt"
+import (
+	"fmt"
+	"time"
+)
 
 // EbusEscapeDecoder unescapes eBUS byte-stuffing as documented in
 // john30/ebusd/docs/enhanced_proto.md:
@@ -9,11 +12,39 @@ import "fmt"
 //	wire 0xA9 0x01 → logical 0xAA (data byte equal to SYN value)
 //	any other byte → passes through unchanged
 //
-// The decoder is stateful — the `escape` flag carries across calls so a
-// pair split between Read() boundaries decodes correctly on the next
-// byte. The decoder does NOT own the byte stream: callers invoke Push
-// once per wire byte, and Reset() clears in-flight state at transport
-// lifecycle boundaries (reconnect, RESETTED frame, surface reset).
+// Phase 1 Step B1 (frame-atomic-visibility v8 §1.3, §5, invariant I4)
+// extends the decoder with AA-injection absorption and a wall-clock
+// cap on the pending state. The two motivating defects:
+//
+//   - **AA-injection mid-escape-pair.** When a 0xA9 lead is followed
+//     by spurious 0xAA bytes (the adapter buffer leaking AUTO-SYN
+//     mid-escape-pair, per the round-9 motivating bug), the decoder
+//     silently absorbs up to MaxAaAbsorptionsPerEscapePair (8) of them
+//     and continues waiting for the real second byte. Without this,
+//     every AA-injection mid-escape would corrupt the decoded byte
+//     stream and surface as a phantom PROTOCOL_FAULT downstream.
+//
+//   - **Hard 32 ms wall-clock cap on ESCAPE_PENDING.** Per v8 §1.3:
+//     "Beyond 32 ms, the wire is genuinely broken; better to abandon
+//     and let downstream FSM detect protocol fault." When the cap is
+//     reached, the decoder drops the orphaned 0xA9 plus any absorbed
+//     AAs and re-processes the current byte in NORMAL state to
+//     preserve data for next-byte resync.
+//
+// Per v8 §1.3, a 0xA9 followed by anything OTHER than 0x00 / 0x01 /
+// 0xAA-within-budget is treated as protocol corruption. The decoder
+// emits NOTHING for the failed escape pair (drops both the 0xA9 and
+// the offending byte) and returns to NORMAL state. v6's earlier
+// emit-0xA9-as-raw recovery was rejected because the 0xA9 may have
+// been pure injection noise; emitting it would invent a byte the
+// wire never carried.
+//
+// The decoder is stateful — fields carry across calls so an escape
+// pair split across Read() boundaries decodes correctly. The decoder
+// does NOT own the byte stream: callers invoke Feed (or the legacy
+// Push) once per wire byte, and Reset() clears in-flight state at
+// transport lifecycle boundaries (reconnect, RESETTED frame, surface
+// reset).
 //
 // Concurrency: the decoder is NOT safe for concurrent use. The ENH
 // transport invokes it under readMu, which already serializes byte
@@ -29,68 +60,325 @@ import "fmt"
 // buffers and produced false unexpected_symbol abandons whenever a
 // legitimate frame contained a logical 0xA9 or 0xAA byte (Patterns A
 // and B in batch-19's verification report). This decoder makes the
-// BytesAreUnescaped() contract honest.
+// BytesAreUnescaped() contract honest. The v8 additions (AA absorption
+// + wall-clock cap) layer on top of that without changing the
+// underlying contract.
 type EbusEscapeDecoder struct {
-	escape bool
+	escape         bool
+	leadObservedAt time.Time
+	absorbedCount  int
 }
 
-// Push consumes one wire byte and returns the decoded result.
+// MaxAaAbsorptionsPerEscapePair is the maximum number of consecutive
+// 0xAA bytes the decoder will absorb between the 0xA9 lead and the
+// completion byte (0x00 or 0x01). Per frame-atomic-visibility v8 §5
+// and invariant I4. Beyond this count the decoder declares escape
+// failure (AdminEventEscapeBudgetExhausted).
+//
+// This constant MUST match
+// `protocol.FrameAtomicV8MaxAaAbsorptionsPerEscapePair` in
+// `protocol/frame_atomic_v8_timeouts.go`. The transport package
+// cannot import the protocol package (circular dependency), so the
+// constant is mirrored here with an explicit cross-reference comment.
+const MaxAaAbsorptionsPerEscapePair = 8
+
+// EscapePendingTimeout is the wall-clock cap on the decoder's
+// pending state. Beyond this, the decoder declares ESCAPE_PENDING
+// timeout (AdminEventEscapePendingTimeout). Per v8 §1.3.
+//
+// This constant MUST match `protocol.FrameAtomicV8EscapePendingTimeout`
+// in `protocol/frame_atomic_v8_timeouts.go`. Same mirroring rationale
+// as MaxAaAbsorptionsPerEscapePair.
+const EscapePendingTimeout = 32 * time.Millisecond
+
+// AdminEventKind classifies admin-channel events the decoder emits
+// when it detects fault or recovery conditions per v8 §1.3 / §5.
+// These events live strictly on the proxy admin channel; per v8
+// invariant I1 they are NEVER injected into client byte streams.
+type AdminEventKind int
+
+const (
+	// AdminEventNone means the Feed call produced no admin event.
+	AdminEventNone AdminEventKind = iota
+
+	// AdminEventEscapePendingTimeout means the decoder spent more
+	// than EscapePendingTimeout in pending state without resolving.
+	// The orphaned 0xA9 and any absorbed AAs are dropped; the
+	// current byte is re-processed in NORMAL state. Per v8 §1.3.
+	AdminEventEscapePendingTimeout
+
+	// AdminEventEscapeRecovery means the decoder saw a byte in
+	// pending state that is neither a valid completion byte
+	// (0x00 / 0x01) nor an absorbable 0xAA-within-budget. The
+	// orphaned 0xA9 and any absorbed AAs are dropped; the current
+	// byte is also dropped (treated as continuation of the
+	// corruption). Per v8 §5.
+	AdminEventEscapeRecovery
+
+	// AdminEventEscapeBudgetExhausted means the decoder saw the
+	// (MaxAaAbsorptionsPerEscapePair + 1)-th 0xAA in pending state,
+	// exhausting the count-bounded absorption budget. The orphaned
+	// 0xA9, the 8 absorbed AAs, AND the over-budget 0xAA are ALL
+	// dropped — emit nothing. Per v8 §5 / I4: only the timeout path
+	// re-processes the current byte; the count-bounded path drops
+	// everything so a raw AUTO-SYN cannot leak into the downstream
+	// classifier after declared escape failure.
+	AdminEventEscapeBudgetExhausted
+)
+
+// String returns a human-readable label for the admin event kind.
+// Used in admin-channel logs.
+func (k AdminEventKind) String() string {
+	switch k {
+	case AdminEventNone:
+		return "none"
+	case AdminEventEscapePendingTimeout:
+		return "escape_pending_timeout"
+	case AdminEventEscapeRecovery:
+		return "escape_decoder_recovery"
+	case AdminEventEscapeBudgetExhausted:
+		return "escape_budget_exhausted"
+	default:
+		return "unknown"
+	}
+}
+
+// AdminEvent captures the per-Feed diagnostic that the decoder
+// wishes to surface to the admin channel. Empty (Kind ==
+// AdminEventNone) means no event.
+type AdminEvent struct {
+	Kind     AdminEventKind
+	Duration time.Duration // wall-clock duration in pending state, if relevant
+	Absorbed int           // number of AAs absorbed before the event, if relevant
+}
+
+// Feed consumes one wire byte and returns:
+//   - decoded: the decoded logical byte (valid only when ok=true).
+//   - ok: true if a logical byte is ready; false while accumulating
+//     an escape pair, absorbing an AA-injection, or dropping a
+//     fault.
+//   - wasEscaped: true if `decoded` came from a wire escape pair
+//     (0xA9 0x00 → 0xA9 or 0xA9 0x01 → 0xAA); false for a raw
+//     passthrough byte.
+//   - admin: a diagnostic event for the admin channel, or
+//     AdminEventNone.
+//
+// Callers MUST pass `now` as the monotonic-clock observation time
+// for `raw` (per v8 invariant I0). Tests pass synthetic times. The
+// `now` value is used ONLY for the EscapePendingTimeout wall-clock
+// cap; any caller that doesn't care about admin-channel observability
+// may use the legacy Push method instead.
+//
+// Feed is allocation-free on the hot path.
+func (d *EbusEscapeDecoder) Feed(raw byte, now time.Time) (decoded byte, ok bool, wasEscaped bool, admin AdminEvent) {
+	if d.escape {
+		return d.feedPending(raw, now)
+	}
+	return d.feedNormal(raw, now)
+}
+
+func (d *EbusEscapeDecoder) feedNormal(raw byte, now time.Time) (byte, bool, bool, AdminEvent) {
+	if raw == 0xA9 {
+		// Escape lead — enter pending state, remember when the lead
+		// arrived for the wall-clock cap. Do not emit yet.
+		d.escape = true
+		d.leadObservedAt = now
+		d.absorbedCount = 0
+		return 0, false, false, AdminEvent{}
+	}
+	// Plain wire byte. WasEscaped=false because no escape pair was
+	// used. A wire AUTO-SYN (0xAA) flows through here as
+	// (0xAA, wasEscaped=false) — the classifier in v8 §4 uses this
+	// provenance to distinguish wire AUTO-SYN from escape-decoded
+	// payload 0xAA.
+	return raw, true, false, AdminEvent{}
+}
+
+func (d *EbusEscapeDecoder) feedPending(raw byte, now time.Time) (byte, bool, bool, AdminEvent) {
+	// Wall-clock cap fires before the byte-value branches. Per v8
+	// §1.3: "Beyond 32 ms, the wire is genuinely broken; better to
+	// abandon and let downstream FSM detect protocol fault." Only
+	// honor the cap when `leadObservedAt` is non-zero — a zero time
+	// is a legacy signal from the Push wrapper meaning "no clock
+	// available, skip wall-clock cap" (preserves Push's
+	// no-time-dependence behavior).
+	if !d.leadObservedAt.IsZero() {
+		elapsed := now.Sub(d.leadObservedAt)
+		if elapsed > EscapePendingTimeout {
+			absorbed := d.absorbedCount
+			d.escape = false
+			d.leadObservedAt = time.Time{}
+			d.absorbedCount = 0
+			// Re-process the current byte in NORMAL state to preserve
+			// it for next-byte resync (v8 §1.3 polish commit).
+			decoded, ok, wasEscaped, _ := d.feedNormal(raw, now)
+			return decoded, ok, wasEscaped, AdminEvent{
+				Kind:     AdminEventEscapePendingTimeout,
+				Duration: elapsed,
+				Absorbed: absorbed,
+			}
+		}
+	}
+
+	switch raw {
+	case 0x01:
+		// 0xA9 0x01 → logical 0xAA, wasEscaped=true.
+		d.escape = false
+		d.leadObservedAt = time.Time{}
+		d.absorbedCount = 0
+		return 0xAA, true, true, AdminEvent{}
+
+	case 0x00:
+		// 0xA9 0x00 → logical 0xA9, wasEscaped=true.
+		d.escape = false
+		d.leadObservedAt = time.Time{}
+		d.absorbedCount = 0
+		return 0xA9, true, true, AdminEvent{}
+
+	case 0xAA:
+		// AA-injection mid-escape-pair. Absorb if budget allows.
+		if d.absorbedCount < MaxAaAbsorptionsPerEscapePair {
+			d.absorbedCount++
+			return 0, false, false, AdminEvent{}
+		}
+		// Budget exhausted. Per v8 §5 / I4: drop the 0xA9, all
+		// absorbed AAs, AND this over-budget AA. Emit NOTHING. Only
+		// the timeout path (wall-clock cap above) re-processes the
+		// current byte; the count-exhausted path drops everything so
+		// an over-budget raw AUTO-SYN cannot leak into the
+		// downstream classifier after declared escape failure.
+		absorbed := d.absorbedCount
+		elapsed := time.Duration(0)
+		if !d.leadObservedAt.IsZero() {
+			elapsed = now.Sub(d.leadObservedAt)
+		}
+		d.escape = false
+		d.leadObservedAt = time.Time{}
+		d.absorbedCount = 0
+		return 0, false, false, AdminEvent{
+			Kind:     AdminEventEscapeBudgetExhausted,
+			Duration: elapsed,
+			Absorbed: absorbed,
+		}
+
+	default:
+		// Malformed escape: byte is neither a valid completion
+		// (0x00 / 0x01) nor an absorbable 0xAA-within-budget. Drop
+		// the 0xA9 plus absorbed AAs AND drop this byte (treat as
+		// continuation of corruption). Emit admin event.
+		absorbed := d.absorbedCount
+		elapsed := time.Duration(0)
+		if !d.leadObservedAt.IsZero() {
+			elapsed = now.Sub(d.leadObservedAt)
+		}
+		d.escape = false
+		d.leadObservedAt = time.Time{}
+		d.absorbedCount = 0
+		return 0, false, false, AdminEvent{
+			Kind:     AdminEventEscapeRecovery,
+			Duration: elapsed,
+			Absorbed: absorbed,
+		}
+	}
+}
+
+// Push consumes one wire byte and returns the decoded result. This
+// is the legacy entry point — it forwards to Feed with a zero time,
+// which suppresses the wall-clock cap (the AA absorption budget
+// still applies). Use Feed directly when you need the wall-clock cap
+// and admin-channel observability.
+//
+// DEPRECATED RECOMMENDATION: new callers should use Feed(b, now)
+// instead of Push. Feed is the v8 entry point — it accepts an
+// explicit monotonic-clock observation time (per v8 invariant I0),
+// enforces the 32 ms wall-clock cap on the pending state, and
+// surfaces AdminEvent diagnostics that the transport layer routes
+// to dedicated counters (EscapePendingTimeoutTotal,
+// EscapeRecoveryTotal, EscapeBudgetExhaustedTotal,
+// EscapeAaAbsorbedTotal). Push exists ONLY to preserve binary
+// compatibility for legacy callers (the existing F-23 contract +
+// the existing transport-level integration tests) and DOES NOT
+// emit the wall-clock cap signal even when a real stale-pair
+// scenario occurs.
+//
+// V8 BEHAVIOR CHANGES vs the pre-v8 Push:
+//
+//   - 0xA9 followed by 0xAA — pre-v8: returned err (invalid pair).
+//     Post-v8: 0xAA is silently absorbed as the first AA-injection
+//     byte; the decoder remains in pending state, ok=false, err=nil.
+//     Up to MaxAaAbsorptionsPerEscapePair absorptions are tolerated
+//     before a real completion (0x00/0x01) or budget-exhaustion.
+//   - 0xA9 followed by ≥9 consecutive 0xAA — pre-v8 had no concept
+//     of this; the first 0xAA after the lead errored.
+//     Post-v8: the 9th 0xAA exhausts the budget; Push returns err
+//     (budget-exhausted) and the decoder drops everything.
+//   - 0xA9 followed by any other invalid byte (e.g. 0xFF) — pre-v8
+//     and post-v8 both return err and drop the pair.
+//
+// External callers that depended on "0xA9 0xAA → err" as a
+// dropped-byte signal must migrate to Feed and inspect the admin
+// channel directly. There are no production callers of Push left
+// in helianthus-ebusgo after this PR (ENHTransport now uses Feed);
+// the method survives for legacy tests + any future external
+// linkage that might pin Push's signature.
 //
 // Return values:
 //
 //	decoded     — the logical byte to emit (valid only when ok=true)
 //	ok          — true if a logical byte is ready; false while still
-//	              accumulating (the escape lead 0xA9 was just consumed)
+//	              accumulating (the escape lead 0xA9 was just
+//	              consumed, an AA-injection was absorbed, or a fault
+//	              dropped the current byte)
 //	wasEscaped  — true if `decoded` came from a wire escape pair
 //	              (0xA9 0x00 → 0xA9 or 0xA9 0x01 → 0xAA); false for a
 //	              raw passthrough byte
-//	err         — non-nil iff a 0xA9 lead was followed by an invalid
-//	              second byte (anything other than 0x00 or 0x01); the
-//	              decoder clears its `escape` state before returning so
-//	              the next call resumes cleanly on the next wire byte
+//	err         — non-nil iff Feed emitted AdminEventEscapeRecovery
+//	              or AdminEventEscapeBudgetExhausted (mapped to err
+//	              for legacy callers that expect the pre-v8 fault
+//	              contract). The decoder clears its escape state
+//	              before returning, so the next call resumes cleanly.
 //
 // On err != nil the caller should count the fault and continue;
-// emission of the offending pair is suppressed (ok=false, decoded
-// undefined). The next Push resumes clean decoding.
+// emission of the offending pair/byte is suppressed (ok=false,
+// decoded undefined). The next Push resumes clean decoding.
 func (d *EbusEscapeDecoder) Push(raw byte) (decoded byte, ok bool, wasEscaped bool, err error) {
-	if d.escape {
-		// We previously consumed a 0xA9 lead; `raw` is the second byte
-		// of the escape pair. Clear the flag first so a malformed pair
-		// (returning an error) does not strand us mid-pair on the next
-		// call — see error-resume note in the func docstring.
-		d.escape = false
-		switch raw {
-		case 0x00:
-			return 0xA9, true, true, nil
-		case 0x01:
-			return 0xAA, true, true, nil
-		default:
-			return 0, false, false, fmt.Errorf("ebus escape: 0xA9 0x%02X is not a valid pair (expected 0x00 or 0x01)", raw)
-		}
+	// Pass time.Time{} (zero time) to disable the wall-clock cap.
+	// Push has no clock injection point so it cannot enforce the cap
+	// honestly — Feed is the v8 entry point that does.
+	decoded, ok, wasEscaped, admin := d.Feed(raw, time.Time{})
+	switch admin.Kind {
+	case AdminEventEscapeRecovery:
+		return 0, false, false, fmt.Errorf("ebus escape: 0xA9 0x%02X is not a valid pair (expected 0x00 or 0x01)", raw)
+	case AdminEventEscapeBudgetExhausted:
+		return 0, false, false, fmt.Errorf("ebus escape: AA-injection budget (%d) exhausted in pending state", MaxAaAbsorptionsPerEscapePair)
 	}
-	if raw == 0xA9 {
-		// Escape lead. Buffer the state; do not emit yet.
-		d.escape = true
-		return 0, false, false, nil
-	}
-	return raw, true, false, nil
+	return decoded, ok, wasEscaped, nil
 }
 
 // Reset clears any in-flight escape state. Call at every transport
 // lifecycle boundary that invalidates an in-progress wire pair:
 // reconnect, adapter-surfaced RESETTED frame, or any other state
-// discard. Do NOT call on read timeout — a 0xA9 lead may have arrived
-// just before the timeout and its pair may legitimately arrive on the
-// next read.
+// discard. Do NOT call on read timeout — a 0xA9 lead may have
+// arrived just before the timeout and its pair may legitimately
+// arrive on the next read.
 func (d *EbusEscapeDecoder) Reset() {
 	d.escape = false
+	d.leadObservedAt = time.Time{}
+	d.absorbedCount = 0
 }
 
 // HasPendingEscape reports whether the decoder is mid-pair (a 0xA9
-// lead has been consumed and we are awaiting the second byte). Useful
-// for diagnostics and for callers that want to flag mid-frame
-// interruption when a transport-level boundary fires while the
-// decoder is mid-pair.
+// lead has been consumed and we are awaiting the second byte or
+// absorbing AA-injection). Useful for diagnostics and for callers
+// that want to flag mid-frame interruption when a transport-level
+// boundary fires while the decoder is mid-pair.
 func (d *EbusEscapeDecoder) HasPendingEscape() bool {
 	return d.escape
+}
+
+// AbsorbedCount returns the number of 0xAA bytes absorbed in the
+// current pending sequence. Returns 0 when not pending. Exposed for
+// testing and admin-channel observability.
+func (d *EbusEscapeDecoder) AbsorbedCount() int {
+	return d.absorbedCount
 }

--- a/transport/ebus_escape_v8_test.go
+++ b/transport/ebus_escape_v8_test.go
@@ -1,0 +1,447 @@
+package transport
+
+import (
+	"testing"
+	"time"
+)
+
+// Phase 1 Step B1 (frame-atomic-visibility v8 §1.3 / §5, invariant
+// I4): unit tests for the v8 AA-aware escape decoder. The legacy
+// Push tests in ebus_escape_test.go continue to pin the un-clocked
+// (legacy) contract; this file pins the v8 Feed contract — AA
+// absorption, wall-clock cap, admin events, data-preserving
+// recovery on timeout.
+
+// TestFeed_PlainPassthrough pins the no-escape path under Feed:
+// every non-0xA9 wire byte emits unchanged with WasEscaped=false on
+// the first call. No admin event.
+func TestFeed_PlainPassthrough(t *testing.T) {
+	t.Parallel()
+
+	d := &EbusEscapeDecoder{}
+	t0 := time.Unix(0, 0)
+	for _, raw := range []byte{0x00, 0x01, 0x08, 0x55, 0x7F, 0x80, 0xA8, 0xAA, 0xFE, 0xFF} {
+		got, ok, wasEscaped, admin := d.Feed(raw, t0)
+		if !ok {
+			t.Fatalf("Feed(0x%02X): ok=false; want true (plain passthrough)", raw)
+		}
+		if got != raw {
+			t.Fatalf("Feed(0x%02X): decoded=0x%02X; want passthrough", raw, got)
+		}
+		if wasEscaped {
+			t.Fatalf("Feed(0x%02X): wasEscaped=true; want false for raw byte", raw)
+		}
+		if admin.Kind != AdminEventNone {
+			t.Fatalf("Feed(0x%02X): admin.Kind=%v; want AdminEventNone", raw, admin.Kind)
+		}
+	}
+}
+
+// TestFeed_A9_01_DecodesToAA pins the canonical
+// `wire 0xA9 0x01 → logical 0xAA, wasEscaped=true` rule under Feed.
+// No admin event on the happy path.
+func TestFeed_A9_01_DecodesToAA(t *testing.T) {
+	t.Parallel()
+
+	d := &EbusEscapeDecoder{}
+	t0 := time.Unix(0, 0)
+
+	_, ok, _, admin := d.Feed(0xA9, t0)
+	if ok {
+		t.Fatal("Feed(0xA9): ok=true on lead; want false")
+	}
+	if admin.Kind != AdminEventNone {
+		t.Fatalf("Feed(0xA9): admin.Kind=%v; want AdminEventNone", admin.Kind)
+	}
+	if !d.HasPendingEscape() {
+		t.Fatal("HasPendingEscape() = false after lead; want true")
+	}
+
+	got, ok, wasEscaped, admin := d.Feed(0x01, t0.Add(1*time.Millisecond))
+	if !ok || got != 0xAA || !wasEscaped {
+		t.Fatalf("Feed(0x01): got=(0x%02X, ok=%v, wasEscaped=%v); want (0xAA, true, true)", got, ok, wasEscaped)
+	}
+	if admin.Kind != AdminEventNone {
+		t.Fatalf("Feed(0x01) completion: admin.Kind=%v; want AdminEventNone", admin.Kind)
+	}
+	if d.HasPendingEscape() {
+		t.Fatal("HasPendingEscape() = true after completion; want false")
+	}
+}
+
+// TestFeed_A9_00_DecodesToA9 pins the
+// `wire 0xA9 0x00 → logical 0xA9, wasEscaped=true` rule under Feed.
+func TestFeed_A9_00_DecodesToA9(t *testing.T) {
+	t.Parallel()
+
+	d := &EbusEscapeDecoder{}
+	t0 := time.Unix(0, 0)
+
+	if _, ok, _, _ := d.Feed(0xA9, t0); ok {
+		t.Fatal("Feed(0xA9): ok=true on lead; want false")
+	}
+	got, ok, wasEscaped, admin := d.Feed(0x00, t0.Add(1*time.Millisecond))
+	if !ok || got != 0xA9 || !wasEscaped {
+		t.Fatalf("Feed(0x00): got=(0x%02X, ok=%v, wasEscaped=%v); want (0xA9, true, true)", got, ok, wasEscaped)
+	}
+	if admin.Kind != AdminEventNone {
+		t.Fatalf("admin.Kind=%v; want AdminEventNone", admin.Kind)
+	}
+}
+
+// TestFeed_A9_AA_Absorbed_Then_01 pins the core v8 AA-absorption
+// path: a 0xA9 lead followed by one 0xAA injection then 0x01 must
+// (a) absorb the 0xAA without emission, (b) accept the 0x01 as the
+// real completion and emit 0xAA wasEscaped=true.
+func TestFeed_A9_AA_Absorbed_Then_01(t *testing.T) {
+	t.Parallel()
+
+	d := &EbusEscapeDecoder{}
+	t0 := time.Unix(0, 0)
+
+	if _, ok, _, _ := d.Feed(0xA9, t0); ok {
+		t.Fatal("Feed(0xA9): ok=true; want false")
+	}
+	// AA-injection within budget.
+	_, ok, _, admin := d.Feed(0xAA, t0.Add(1*time.Millisecond))
+	if ok {
+		t.Fatal("Feed(0xAA) after lead: ok=true; want false (absorbed)")
+	}
+	if admin.Kind != AdminEventNone {
+		t.Fatalf("absorption admin.Kind=%v; want AdminEventNone", admin.Kind)
+	}
+	if d.AbsorbedCount() != 1 {
+		t.Fatalf("AbsorbedCount=%d after 1 AA; want 1", d.AbsorbedCount())
+	}
+
+	// Now the real completion.
+	got, ok, wasEscaped, admin := d.Feed(0x01, t0.Add(2*time.Millisecond))
+	if !ok || got != 0xAA || !wasEscaped {
+		t.Fatalf("Feed(0x01) post-absorb: got=(0x%02X, ok=%v, wasEscaped=%v); want (0xAA, true, true)", got, ok, wasEscaped)
+	}
+	if admin.Kind != AdminEventNone {
+		t.Fatalf("completion admin.Kind=%v; want AdminEventNone", admin.Kind)
+	}
+	if d.AbsorbedCount() != 0 {
+		t.Fatalf("AbsorbedCount=%d after completion; want 0 (reset)", d.AbsorbedCount())
+	}
+}
+
+// TestFeed_A9_MaxAA_Then_01 exercises the upper edge of the
+// absorption budget: 8 AAs absorbed, then 0x01 must still complete
+// cleanly. Verifies MaxAaAbsorptionsPerEscapePair == 8 is the
+// "inclusive ceiling" — absorb 8, then complete on the 9th call.
+func TestFeed_A9_MaxAA_Then_01(t *testing.T) {
+	t.Parallel()
+
+	d := &EbusEscapeDecoder{}
+	t0 := time.Unix(0, 0)
+
+	if _, ok, _, _ := d.Feed(0xA9, t0); ok {
+		t.Fatal("Feed(0xA9): ok=true; want false")
+	}
+	for i := 0; i < MaxAaAbsorptionsPerEscapePair; i++ {
+		_, ok, _, admin := d.Feed(0xAA, t0.Add(time.Duration(i+1)*time.Millisecond))
+		if ok {
+			t.Fatalf("Feed(0xAA) iter %d: ok=true; want false (absorbed)", i)
+		}
+		if admin.Kind != AdminEventNone {
+			t.Fatalf("Feed(0xAA) iter %d: admin.Kind=%v; want None", i, admin.Kind)
+		}
+	}
+	if d.AbsorbedCount() != MaxAaAbsorptionsPerEscapePair {
+		t.Fatalf("AbsorbedCount=%d after %d AAs; want %d",
+			d.AbsorbedCount(), MaxAaAbsorptionsPerEscapePair, MaxAaAbsorptionsPerEscapePair)
+	}
+
+	// 9th byte is the real completion.
+	got, ok, wasEscaped, admin := d.Feed(0x01, t0.Add(20*time.Millisecond))
+	if !ok || got != 0xAA || !wasEscaped {
+		t.Fatalf("Feed(0x01) post-max-absorb: got=(0x%02X, ok=%v, wasEscaped=%v); want (0xAA, true, true)", got, ok, wasEscaped)
+	}
+	if admin.Kind != AdminEventNone {
+		t.Fatalf("completion admin.Kind=%v; want None", admin.Kind)
+	}
+}
+
+// TestFeed_BudgetExhausted_AA_Over9 pins the count-bound failure:
+// 9 consecutive AAs (one over the budget) yields
+// AdminEventEscapeBudgetExhausted; the 9th AA AND all 8 absorbed
+// AAs AND the 0xA9 are ALL dropped — emit nothing.
+func TestFeed_BudgetExhausted_AA_Over9(t *testing.T) {
+	t.Parallel()
+
+	d := &EbusEscapeDecoder{}
+	t0 := time.Unix(0, 0)
+
+	if _, ok, _, _ := d.Feed(0xA9, t0); ok {
+		t.Fatal("Feed(0xA9): ok=true; want false")
+	}
+	for i := 0; i < MaxAaAbsorptionsPerEscapePair; i++ {
+		_, _, _, admin := d.Feed(0xAA, t0.Add(time.Duration(i+1)*time.Millisecond))
+		if admin.Kind != AdminEventNone {
+			t.Fatalf("Feed(0xAA) iter %d: premature admin event %v", i, admin.Kind)
+		}
+	}
+
+	// 9th AA — exceeds budget.
+	got, ok, wasEscaped, admin := d.Feed(0xAA, t0.Add(20*time.Millisecond))
+	if ok {
+		t.Fatalf("Feed(over-budget 0xAA): ok=true; want false (drop, emit nothing)")
+	}
+	if got != 0 {
+		t.Errorf("decoded=0x%02X; want 0 (sentinel) on drop", got)
+	}
+	if wasEscaped {
+		t.Error("wasEscaped=true; want false on drop")
+	}
+	if admin.Kind != AdminEventEscapeBudgetExhausted {
+		t.Fatalf("admin.Kind=%v; want AdminEventEscapeBudgetExhausted", admin.Kind)
+	}
+	if admin.Absorbed != MaxAaAbsorptionsPerEscapePair {
+		t.Errorf("admin.Absorbed=%d; want %d", admin.Absorbed, MaxAaAbsorptionsPerEscapePair)
+	}
+	if d.HasPendingEscape() {
+		t.Error("decoder still pending after exhaustion; want cleared")
+	}
+	if d.AbsorbedCount() != 0 {
+		t.Errorf("AbsorbedCount=%d; want 0 after exhaustion", d.AbsorbedCount())
+	}
+
+	// Resume: next byte decodes cleanly.
+	got, ok, _, admin = d.Feed(0x55, t0.Add(30*time.Millisecond))
+	if !ok || got != 0x55 || admin.Kind != AdminEventNone {
+		t.Errorf("resume Feed(0x55): got=(0x%02X, ok=%v, admin.Kind=%v); want (0x55, true, None)",
+			got, ok, admin.Kind)
+	}
+}
+
+// TestFeed_InvalidSecondByte pins the malformed-pair drop path: a
+// 0xA9 followed by 0xFF (not 0x00/0x01/0xAA) yields
+// AdminEventEscapeRecovery; both bytes are dropped.
+func TestFeed_InvalidSecondByte(t *testing.T) {
+	t.Parallel()
+
+	d := &EbusEscapeDecoder{}
+	t0 := time.Unix(0, 0)
+
+	if _, ok, _, _ := d.Feed(0xA9, t0); ok {
+		t.Fatal("Feed(0xA9): ok=true; want false")
+	}
+	got, ok, wasEscaped, admin := d.Feed(0xFF, t0.Add(1*time.Millisecond))
+	if ok {
+		t.Fatal("Feed(0xFF) after lead: ok=true; want false (drop)")
+	}
+	if got != 0 || wasEscaped {
+		t.Errorf("got=(0x%02X, wasEscaped=%v); want (0, false)", got, wasEscaped)
+	}
+	if admin.Kind != AdminEventEscapeRecovery {
+		t.Fatalf("admin.Kind=%v; want AdminEventEscapeRecovery", admin.Kind)
+	}
+	if d.HasPendingEscape() {
+		t.Error("decoder still pending after recovery; want cleared")
+	}
+
+	// Resume.
+	got, ok, _, admin = d.Feed(0x55, t0.Add(2*time.Millisecond))
+	if !ok || got != 0x55 || admin.Kind != AdminEventNone {
+		t.Errorf("resume Feed(0x55): got=(0x%02X, ok=%v, admin.Kind=%v); want (0x55, true, None)",
+			got, ok, admin.Kind)
+	}
+}
+
+// TestFeed_WallClockCap_BeyondTimeout pins the 32 ms timeout
+// behavior: a 0xA9 followed by a byte > EscapePendingTimeout later
+// yields AdminEventEscapePendingTimeout; the current byte is
+// re-processed in NORMAL state (data-preserving recovery).
+func TestFeed_WallClockCap_BeyondTimeout(t *testing.T) {
+	t.Parallel()
+
+	d := &EbusEscapeDecoder{}
+	t0 := time.Unix(0, 0)
+
+	if _, ok, _, _ := d.Feed(0xA9, t0); ok {
+		t.Fatal("Feed(0xA9): ok=true; want false")
+	}
+	// Advance past the cap by 1 ms.
+	tLate := t0.Add(EscapePendingTimeout + 1*time.Millisecond)
+
+	got, ok, wasEscaped, admin := d.Feed(0x55, tLate)
+	if !ok {
+		t.Fatal("Feed(0x55) post-timeout: ok=false; want true (re-processed in NORMAL)")
+	}
+	if got != 0x55 {
+		t.Errorf("decoded=0x%02X; want 0x55 (re-processed plain byte)", got)
+	}
+	if wasEscaped {
+		t.Error("wasEscaped=true; want false on plain re-processed byte")
+	}
+	if admin.Kind != AdminEventEscapePendingTimeout {
+		t.Fatalf("admin.Kind=%v; want AdminEventEscapePendingTimeout", admin.Kind)
+	}
+	if admin.Duration <= EscapePendingTimeout {
+		t.Errorf("admin.Duration=%v; want > %v", admin.Duration, EscapePendingTimeout)
+	}
+	if d.HasPendingEscape() {
+		t.Error("decoder still pending after timeout; want cleared")
+	}
+}
+
+// TestFeed_WallClockCap_BoundaryExact pins the strict-greater-than
+// semantics: exactly EscapePendingTimeout elapsed does NOT trigger
+// the cap (only `> EscapePendingTimeout` does). Documents the
+// boundary behavior.
+func TestFeed_WallClockCap_BoundaryExact(t *testing.T) {
+	t.Parallel()
+
+	d := &EbusEscapeDecoder{}
+	t0 := time.Unix(0, 0)
+
+	if _, ok, _, _ := d.Feed(0xA9, t0); ok {
+		t.Fatal("Feed(0xA9): ok=true; want false")
+	}
+	// Advance to EXACTLY the cap.
+	tBoundary := t0.Add(EscapePendingTimeout)
+	got, ok, wasEscaped, admin := d.Feed(0x01, tBoundary)
+	if !ok || got != 0xAA || !wasEscaped {
+		t.Fatalf("Feed(0x01) at boundary: got=(0x%02X, ok=%v, wasEscaped=%v); want clean completion", got, ok, wasEscaped)
+	}
+	if admin.Kind != AdminEventNone {
+		t.Fatalf("admin.Kind=%v; want AdminEventNone at boundary", admin.Kind)
+	}
+}
+
+// TestFeed_WallClockCap_TimeoutBytePreservedAsEscape exercises a
+// subtle case: the timeout fires, the current byte is re-processed
+// in NORMAL state, and the current byte happens to BE a new 0xA9.
+// The byte must start a new pending state (not get dropped).
+func TestFeed_WallClockCap_TimeoutBytePreservedAsEscape(t *testing.T) {
+	t.Parallel()
+
+	d := &EbusEscapeDecoder{}
+	t0 := time.Unix(0, 0)
+
+	if _, ok, _, _ := d.Feed(0xA9, t0); ok {
+		t.Fatal("Feed(0xA9): ok=true; want false")
+	}
+	tLate := t0.Add(EscapePendingTimeout + 1*time.Millisecond)
+	got, ok, wasEscaped, admin := d.Feed(0xA9, tLate)
+	if ok {
+		t.Fatal("Feed(0xA9) post-timeout: ok=true; want false (new lead, accumulating)")
+	}
+	if got != 0 || wasEscaped {
+		t.Errorf("got=(0x%02X, wasEscaped=%v); want (0, false) on new lead", got, wasEscaped)
+	}
+	if admin.Kind != AdminEventEscapePendingTimeout {
+		t.Fatalf("admin.Kind=%v; want AdminEventEscapePendingTimeout", admin.Kind)
+	}
+	if !d.HasPendingEscape() {
+		t.Error("HasPendingEscape=false after re-entering on new 0xA9; want true")
+	}
+
+	// Now complete the NEW pair cleanly.
+	got, ok, wasEscaped, admin = d.Feed(0x01, tLate.Add(1*time.Millisecond))
+	if !ok || got != 0xAA || !wasEscaped {
+		t.Fatalf("new pair completion: got=(0x%02X, ok=%v, wasEscaped=%v); want (0xAA, true, true)", got, ok, wasEscaped)
+	}
+	if admin.Kind != AdminEventNone {
+		t.Errorf("admin.Kind=%v; want None on completion", admin.Kind)
+	}
+}
+
+// TestFeed_Reset_ClearsAbsorbedAndLeadTime pins that Reset() wipes
+// the v8 fields (absorbedCount, leadObservedAt) in addition to the
+// legacy `escape` flag.
+func TestFeed_Reset_ClearsAbsorbedAndLeadTime(t *testing.T) {
+	t.Parallel()
+
+	d := &EbusEscapeDecoder{}
+	t0 := time.Unix(0, 0)
+
+	_, _, _, _ = d.Feed(0xA9, t0)
+	_, _, _, _ = d.Feed(0xAA, t0.Add(1*time.Millisecond))
+	if !d.HasPendingEscape() || d.AbsorbedCount() != 1 {
+		t.Fatalf("precondition: pending=%v absorbed=%d; want true, 1",
+			d.HasPendingEscape(), d.AbsorbedCount())
+	}
+
+	d.Reset()
+	if d.HasPendingEscape() {
+		t.Error("HasPendingEscape() = true after Reset(); want false")
+	}
+	if d.AbsorbedCount() != 0 {
+		t.Errorf("AbsorbedCount=%d after Reset(); want 0", d.AbsorbedCount())
+	}
+
+	// Verify the reset cleared the wall-clock anchor: a fresh lead
+	// followed by an immediate AAa across what WOULD have been a
+	// timeout from the OLD anchor must NOT trigger the cap.
+	_, ok, _, _ := d.Feed(0xA9, t0.Add(100*time.Millisecond))
+	if ok {
+		t.Fatal("fresh lead post-reset: ok=true; want false")
+	}
+	got, ok, wasEscaped, admin := d.Feed(0x01, t0.Add(101*time.Millisecond))
+	if !ok || got != 0xAA || !wasEscaped {
+		t.Fatalf("completion post-reset: got=(0x%02X, ok=%v, wasEscaped=%v); want (0xAA, true, true)", got, ok, wasEscaped)
+	}
+	if admin.Kind != AdminEventNone {
+		t.Errorf("admin.Kind=%v; want None (reset cleared the timeout anchor)", admin.Kind)
+	}
+}
+
+// TestFeed_Push_LegacyContract_WithAbsorption pins the Push wrapper:
+// Push silently absorbs AAs (it does NOT report admin events) and
+// completes cleanly when a valid 0x00/0x01 follows. This is a v8
+// BEHAVIOR CHANGE relative to pre-v8 Push, which would have
+// returned an err on Push(0xA9)+Push(0xAA). Documented intentional
+// change — the AA absorption is now a SUCCESS path.
+func TestFeed_Push_LegacyContract_WithAbsorption(t *testing.T) {
+	t.Parallel()
+
+	d := &EbusEscapeDecoder{}
+
+	if _, ok, _, err := d.Push(0xA9); err != nil || ok {
+		t.Fatalf("Push(0xA9): err=%v ok=%v; want nil false", err, ok)
+	}
+	// First AA — absorbed silently. Pre-v8 this would have errored.
+	_, ok, _, err := d.Push(0xAA)
+	if err != nil {
+		t.Errorf("Push(0xAA) after lead: err=%v; want nil (v8 absorbs)", err)
+	}
+	if ok {
+		t.Error("Push(0xAA) after lead: ok=true; want false (absorbed)")
+	}
+	// Then real completion.
+	got, ok, wasEscaped, err := d.Push(0x01)
+	if err != nil || !ok || got != 0xAA || !wasEscaped {
+		t.Fatalf("Push(0x01) completion: got=(0x%02X, ok=%v, wasEscaped=%v, err=%v); want (0xAA, true, true, nil)",
+			got, ok, wasEscaped, err)
+	}
+}
+
+// TestFeed_Push_BudgetExhausted_StillReturnsErr pins that the
+// legacy Push wrapper still maps budget-exhaustion to err for
+// callers that depend on the err signal.
+func TestFeed_Push_BudgetExhausted_StillReturnsErr(t *testing.T) {
+	t.Parallel()
+
+	d := &EbusEscapeDecoder{}
+
+	_, _, _, _ = d.Push(0xA9)
+	for i := 0; i < MaxAaAbsorptionsPerEscapePair; i++ {
+		if _, _, _, err := d.Push(0xAA); err != nil {
+			t.Fatalf("Push(0xAA) iter %d: err=%v; want nil", i, err)
+		}
+	}
+	// Over-budget.
+	_, ok, _, err := d.Push(0xAA)
+	if err == nil {
+		t.Fatal("Push(over-budget 0xAA): err=nil; want non-nil")
+	}
+	if ok {
+		t.Error("Push(over-budget 0xAA): ok=true; want false")
+	}
+	if d.HasPendingEscape() {
+		t.Error("decoder still pending after exhaustion via Push; want cleared")
+	}
+}

--- a/transport/enh_transport.go
+++ b/transport/enh_transport.go
@@ -193,7 +193,54 @@ type ENHTransport struct {
 	// byte. Exposed via DecodeFaultTotal() for transport-level
 	// observability. Atomic because external readers (gateway metrics
 	// snapshot) read it without holding readMu.
+	//
+	// Phase 1 Step B1 (frame-atomic-visibility v8 §1.3 / §5,
+	// invariant I4) — the counter is now incremented by BOTH legacy
+	// "0xA9 + invalid second byte" faults (AdminEventEscapeRecovery)
+	// AND v8 AA-injection budget exhaustion
+	// (AdminEventEscapeBudgetExhausted). The latter is a new fault
+	// mode introduced by v8's bounded AA absorption; semantically
+	// both indicate "the escape decoder gave up on a pending pair",
+	// so they share this single fault counter. The decomposed
+	// counters below (escapeBudgetExhaustedTotal,
+	// escapeRecoveryTotal) give granular visibility for operators
+	// who want to attribute decodeFaultTotal to a specific cause.
 	decodeFaultTotal atomic.Uint64
+
+	// escapePendingTimeoutTotal counts wire 0xA9 leads that spent
+	// more than EscapePendingTimeout (32 ms) in pending state without
+	// resolution, per v8 §1.3. Non-fatal: the decoder drops the
+	// orphaned 0xA9 plus any absorbed AAs and re-processes the
+	// current byte in NORMAL state to preserve data for next-byte
+	// resync. Distinct from decodeFaultTotal because timeout is a
+	// different failure mode (wire/adapter pathologically slow vs.
+	// malformed escape pair). Exposed via EscapePendingTimeoutTotal()
+	// for transport-level observability.
+	escapePendingTimeoutTotal atomic.Uint64
+
+	// escapeRecoveryTotal counts AdminEventEscapeRecovery emissions —
+	// a wire 0xA9 followed by a byte that is neither a valid
+	// completion (0x00 / 0x01) nor an absorbable 0xAA-within-budget.
+	// The decoder drops the 0xA9, absorbed AAs, AND the offending
+	// byte. Subset of decodeFaultTotal; exposed for granular
+	// operator visibility.
+	escapeRecoveryTotal atomic.Uint64
+
+	// escapeBudgetExhaustedTotal counts AdminEventEscapeBudgetExhausted
+	// emissions — a wire 0xA9 followed by more than
+	// MaxAaAbsorptionsPerEscapePair (8) consecutive 0xAA bytes. The
+	// decoder drops the 0xA9, all 8 absorbed AAs, and the
+	// over-budget AA. Subset of decodeFaultTotal; exposed for
+	// granular operator visibility.
+	escapeBudgetExhaustedTotal atomic.Uint64
+
+	// escapeAaAbsorbedTotal counts the cumulative number of 0xAA
+	// bytes the decoder absorbed mid-escape-pair across all
+	// transactions. Each absorption is a successful in-budget event
+	// (NOT a fault). Tracks the AA-injection load the v8 absorber is
+	// catching. Note: this is per-byte, not per-pair — a single pair
+	// that absorbed 3 AAs increments this counter by 3.
+	escapeAaAbsorbedTotal atomic.Uint64
 }
 
 // NewENHTransport creates a new ENH transport with read/write timeouts.
@@ -1331,13 +1378,12 @@ func (t *ENHTransport) resetPendingEscapeBeforeEmissionLocked() {
 	}
 }
 
-// feedEscapeDecoderLocked advances the F-23 eBUS escape decoder by one
+// feedEscapeDecoderLocked advances the eBUS escape decoder by one
 // wire byte WITHOUT making an emission decision. Returns the decoded
-// logical byte and its WasEscaped flag when a logical symbol is ready
-// (ok=true), or ok=false while accumulating an escape pair / on
-// invalid-pair fault. Invalid pairs increment decodeFaultTotal and
-// clear the decoder's internal state so subsequent calls resume
-// cleanly. Caller must hold readMu.
+// logical byte and its WasEscaped flag when a logical symbol is
+// ready (ok=true), or ok=false while accumulating an escape pair,
+// absorbing AA-injection mid-pair, or dropping a fault. Caller must
+// hold readMu.
 //
 // This primitive MUST be called on every wire byte the transport
 // observes, including bytes that are dropped by application-layer
@@ -1346,17 +1392,113 @@ func (t *ENHTransport) resetPendingEscapeBeforeEmissionLocked() {
 // 0xA9 lead stranded, and the next non-dropped byte would falsely
 // complete the stale pair (Codex bot P2 on PR-1: discarded-byte
 // discontinuity preserving pending escape).
+//
+// Phase 1 Step B1 (frame-atomic-visibility v8 §1.3 / §5, invariant
+// I4): the underlying decoder is now the v8 AA-aware version with
+// bounded AA-injection absorption (up to
+// MaxAaAbsorptionsPerEscapePair) and a wall-clock cap on the pending
+// state (EscapePendingTimeout). The StreamEvent contract is
+// preserved — callers see exactly the same `(decoded, ok,
+// wasEscaped)` triple. The v8 additions are surfaced via
+// transport-level admin counters:
+//
+//   - escapeAaAbsorbedTotal — every absorbed mid-pair 0xAA
+//     increments this (per-byte).
+//   - escapePendingTimeoutTotal — every 32 ms wall-clock cap hit.
+//     The orphaned 0xA9 is dropped; the current byte is
+//     re-processed in NORMAL state and emitted if it produces a
+//     decoded byte (data-preserving recovery).
+//   - escapeRecoveryTotal — 0xA9 followed by a byte that is neither
+//     0x00/0x01 nor an absorbable 0xAA. The 0xA9, absorbed AAs,
+//     AND the offending byte are all dropped. Increments
+//     decodeFaultTotal too (subset).
+//   - escapeBudgetExhaustedTotal — over-budget AA after 8
+//     absorptions. The 0xA9, 8 absorbed AAs, AND the over-budget
+//     AA are all dropped. Increments decodeFaultTotal too (subset).
 func (t *ENHTransport) feedEscapeDecoderLocked(raw byte) (decoded byte, ok bool, wasEscaped bool) {
-	var err error
-	decoded, ok, wasEscaped, err = t.escDecoder.Push(raw)
-	if err != nil {
-		// Invalid escape pair: increment the fault counter and drop.
-		// The decoder cleared its in-flight state before returning, so
-		// subsequent bytes resume cleanly.
-		t.decodeFaultTotal.Add(1)
+	// Snapshot the in-budget AA count BEFORE Feed so we can
+	// distinguish "AA absorbed this call" from "AA absorbed earlier".
+	absorbedBefore := t.escDecoder.AbsorbedCount()
+
+	var admin AdminEvent
+	decoded, ok, wasEscaped, admin = t.escDecoder.Feed(raw, time.Now())
+
+	// Account for any AA absorbed by this specific Feed call. The
+	// absorber increments AbsorbedCount when a 0xAA arrives mid-pair
+	// within budget, and resets to 0 on any exit from pending. So
+	// the per-call delta is +1 if we absorbed; otherwise 0 or
+	// negative-on-exit (which we map to 0).
+	if delta := t.escDecoder.AbsorbedCount() - absorbedBefore; delta > 0 {
+		t.escapeAaAbsorbedTotal.Add(uint64(delta))
+	}
+
+	if applyEscapeAdminEvent(
+		admin,
+		&t.escapePendingTimeoutTotal,
+		&t.escapeRecoveryTotal,
+		&t.escapeBudgetExhaustedTotal,
+		&t.decodeFaultTotal,
+	) {
+		// Drop-everything fault path (Recovery or BudgetExhausted) —
+		// emission suppressed regardless of what the decoder returned
+		// for this byte. The decoder cleared its in-flight state
+		// before returning, so subsequent bytes resume cleanly.
 		return 0, false, false
 	}
+	// AdminEventNone or AdminEventEscapePendingTimeout:
+	// data-preserving paths. For Timeout, the current byte was
+	// re-processed in NORMAL state by the decoder and may have
+	// produced a decoded byte (`decoded`, `ok`, `wasEscaped` reflect
+	// that re-processing); the counter was already bumped inside
+	// applyEscapeAdminEvent.
 	return decoded, ok, wasEscaped
+}
+
+// applyEscapeAdminEvent routes a v8 escape-decoder admin event to
+// the four transport-level counters and reports whether the caller
+// must drop the current byte's emission. Extracted from
+// feedEscapeDecoderLocked so the routing logic is directly unit-
+// testable without standing up a full ENHTransport (per Codex
+// round-3 review on PR #165 — "visually parallel wiring is not
+// executable coverage").
+//
+// Returns dropEmission=true when admin.Kind indicates a drop-
+// everything fault (AdminEventEscapeRecovery or
+// AdminEventEscapeBudgetExhausted). Returns false for AdminEventNone
+// (no event) and AdminEventEscapePendingTimeout (data-preserving —
+// the current byte was re-processed in NORMAL state by the decoder
+// and the caller should emit whatever the decoder returned).
+//
+// The function is allocation-free and operates only on the four
+// atomic counter pointers passed in; it does not depend on any
+// ENHTransport state, making it pure-function testable.
+func applyEscapeAdminEvent(
+	admin AdminEvent,
+	pendingTimeoutCtr, recoveryCtr, budgetExhaustedCtr, decodeFaultCtr *atomic.Uint64,
+) (dropEmission bool) {
+	switch admin.Kind {
+	case AdminEventEscapePendingTimeout:
+		// 32 ms cap hit. The decoder already re-processed the
+		// current byte in NORMAL state; the caller emits whatever
+		// the decoder returned. Surface the timeout via its own
+		// counter — NOT a fault (decodeFaultCtr stays put).
+		pendingTimeoutCtr.Add(1)
+		return false
+	case AdminEventEscapeRecovery:
+		// Invalid second byte. Drop the 0xA9, any absorbed AAs, AND
+		// the offending byte. Fault.
+		recoveryCtr.Add(1)
+		decodeFaultCtr.Add(1)
+		return true
+	case AdminEventEscapeBudgetExhausted:
+		// AA-injection budget exhausted. Drop the 0xA9, the 8
+		// absorbed AAs, AND the over-budget AA. Fault.
+		budgetExhaustedCtr.Add(1)
+		decodeFaultCtr.Add(1)
+		return true
+	}
+	// AdminEventNone — no admin event, nothing to do.
+	return false
 }
 
 // appendDecodedByteLocked emits a fully-decoded logical byte to
@@ -1394,14 +1536,73 @@ func (t *ENHTransport) appendWireSynLocked() {
 	}
 }
 
-// DecodeFaultTotal returns the cumulative count of invalid eBUS escape
-// pairs observed on the wire (a 0xA9 lead followed by a byte other
-// than 0x00 or 0x01). Non-fatal — the decoder drops the offending
-// pair and resumes on the next byte. Exposed for transport-level
-// observability surfaces (gateway metrics snapshot, admin endpoints).
-// Safe to call without holding readMu.
+// DecodeFaultTotal returns the cumulative count of invalid eBUS
+// escape sequences observed on the wire. Non-fatal — the decoder
+// drops the offending pair (and any absorbed AAs) and resumes on
+// the next byte. Exposed for transport-level observability surfaces
+// (gateway metrics snapshot, admin endpoints). Safe to call without
+// holding readMu.
+//
+// Phase 1 Step B1 (frame-atomic-visibility v8) widened the
+// definition to include BOTH:
+//
+//   - "0xA9 + invalid second byte" (the legacy fault, now
+//     AdminEventEscapeRecovery) — see EscapeRecoveryTotal.
+//   - "0xA9 + 8 AAs + over-budget AA" (a new v8 fault,
+//     AdminEventEscapeBudgetExhausted) — see
+//     EscapeBudgetExhaustedTotal.
+//
+// The 32 ms wall-clock timeout (AdminEventEscapePendingTimeout) is
+// NOT counted here because it is a data-preserving recovery (the
+// current byte is re-processed in NORMAL state and may emit
+// normally). See EscapePendingTimeoutTotal for that counter.
 func (t *ENHTransport) DecodeFaultTotal() uint64 {
 	return t.decodeFaultTotal.Load()
+}
+
+// EscapePendingTimeoutTotal returns the cumulative count of v8 32 ms
+// wall-clock cap hits on the escape decoder's pending state. Per v8
+// §1.3: beyond 32 ms the wire is considered genuinely broken, so the
+// decoder drops the orphaned 0xA9 plus any absorbed AAs and
+// re-processes the current byte in NORMAL state to preserve data
+// for next-byte resync. Non-fatal, data-preserving — distinct from
+// DecodeFaultTotal which counts drop-everything faults. Safe to call
+// without holding readMu.
+func (t *ENHTransport) EscapePendingTimeoutTotal() uint64 {
+	return t.escapePendingTimeoutTotal.Load()
+}
+
+// EscapeRecoveryTotal returns the cumulative count of v8
+// AdminEventEscapeRecovery events: a 0xA9 lead followed by a byte
+// that is neither 0x00/0x01 nor an absorbable 0xAA-within-budget.
+// Subset of DecodeFaultTotal. Exposed for granular operator
+// visibility into the fault mix (legacy invalid-pair vs. v8
+// budget-exhausted). Safe to call without holding readMu.
+func (t *ENHTransport) EscapeRecoveryTotal() uint64 {
+	return t.escapeRecoveryTotal.Load()
+}
+
+// EscapeBudgetExhaustedTotal returns the cumulative count of v8
+// AdminEventEscapeBudgetExhausted events: a 0xA9 lead followed by
+// more than MaxAaAbsorptionsPerEscapePair (8) consecutive 0xAA
+// bytes. Subset of DecodeFaultTotal. Exposed for granular operator
+// visibility — a non-zero rate here suggests adapter buffer
+// pathology (sustained AA-injection mid-escape) and may correlate
+// with round-9 absorb fires. Safe to call without holding readMu.
+func (t *ENHTransport) EscapeBudgetExhaustedTotal() uint64 {
+	return t.escapeBudgetExhaustedTotal.Load()
+}
+
+// EscapeAaAbsorbedTotal returns the cumulative number of 0xAA bytes
+// absorbed mid-escape-pair across all transactions. Each absorption
+// is a successful in-budget event (NOT a fault). Per-byte, not
+// per-pair — a single pair that absorbed 3 AAs increments this
+// counter by 3. Useful for measuring the AA-injection load the v8
+// absorber is catching; pair with EscapeBudgetExhaustedTotal to
+// detect a budget that is too small. Safe to call without holding
+// readMu.
+func (t *ENHTransport) EscapeAaAbsorbedTotal() uint64 {
+	return t.escapeAaAbsorbedTotal.Load()
 }
 
 // PostGrantWindowExpiredCount returns the cumulative count of

--- a/transport/enh_transport_v8_counters_test.go
+++ b/transport/enh_transport_v8_counters_test.go
@@ -1,0 +1,256 @@
+package transport_test
+
+import (
+	"net"
+	"testing"
+	"time"
+
+	"github.com/Project-Helianthus/helianthus-ebusgo/transport"
+)
+
+// Phase 1 Step B1 (frame-atomic-visibility v8 §1.3 / §5, invariant
+// I4): integration tests at the ENHTransport boundary verifying
+// that the v8 admin events from the AA-aware escape decoder are
+// correctly routed to the public counter accessors. These tests are
+// the regression guard for Codex's round-1 MINOR finding — the
+// decoder-only tests in ebus_escape_v8_test.go prove the decoder
+// emits admin events; these tests prove the ENHTransport
+// feedEscapeDecoderLocked plumbing wires those events to the right
+// counters.
+
+// TestENHCounters_PlainBytes_AllZero pins the baseline — a stream
+// with no escape sequences must leave all v8 counters at zero.
+func TestENHCounters_PlainBytes_AllZero(t *testing.T) {
+	t.Parallel()
+
+	client, server := net.Pipe()
+	defer func() { _ = client.Close() }()
+	defer func() { _ = server.Close() }()
+
+	enh := transport.NewENHTransport(client, 500*time.Millisecond, 500*time.Millisecond)
+	feedENHReceivedBytes(t, server, []byte{0x00, 0x55, 0xFE, 0x7F})
+
+	_ = drainBytes(t, enh, 4)
+
+	assertCountersZero(t, enh)
+}
+
+// TestENHCounters_AaAbsorbed pins that an in-budget AA-injection
+// increments EscapeAaAbsorbedTotal per absorbed byte and leaves the
+// fault counters at zero (clean recovery).
+func TestENHCounters_AaAbsorbed(t *testing.T) {
+	t.Parallel()
+
+	client, server := net.Pipe()
+	defer func() { _ = client.Close() }()
+	defer func() { _ = server.Close() }()
+
+	enh := transport.NewENHTransport(client, 500*time.Millisecond, 500*time.Millisecond)
+	// 0xA9 (lead), 0xAA (absorbed), 0xAA (absorbed), 0x01 (real completion → emits 0xAA WasEscaped=true)
+	feedENHReceivedBytes(t, server, []byte{0xA9, 0xAA, 0xAA, 0x01})
+
+	events := drainBytes(t, enh, 1)
+	if events[0].Byte != 0xAA || !events[0].WasEscaped {
+		t.Fatalf("decoded event = {Byte=0x%02X WasEscaped=%v}; want {0xAA true}",
+			events[0].Byte, events[0].WasEscaped)
+	}
+
+	if got := enh.EscapeAaAbsorbedTotal(); got != 2 {
+		t.Errorf("EscapeAaAbsorbedTotal() = %d; want 2 (one per absorbed AA)", got)
+	}
+	if got := enh.EscapeRecoveryTotal(); got != 0 {
+		t.Errorf("EscapeRecoveryTotal() = %d; want 0 (clean recovery)", got)
+	}
+	if got := enh.EscapeBudgetExhaustedTotal(); got != 0 {
+		t.Errorf("EscapeBudgetExhaustedTotal() = %d; want 0", got)
+	}
+	if got := enh.EscapePendingTimeoutTotal(); got != 0 {
+		t.Errorf("EscapePendingTimeoutTotal() = %d; want 0", got)
+	}
+	if got := enh.DecodeFaultTotal(); got != 0 {
+		t.Errorf("DecodeFaultTotal() = %d; want 0 (absorption is not a fault)", got)
+	}
+}
+
+// TestENHCounters_InvalidSecondByte_Recovery pins that
+// AdminEventEscapeRecovery (0xA9 followed by a byte that's not
+// 0x00/0x01/0xAA) increments both EscapeRecoveryTotal and
+// DecodeFaultTotal, drops the offending bytes, and leaves the
+// stream consistent for subsequent bytes.
+func TestENHCounters_InvalidSecondByte_Recovery(t *testing.T) {
+	t.Parallel()
+
+	client, server := net.Pipe()
+	defer func() { _ = client.Close() }()
+	defer func() { _ = server.Close() }()
+
+	enh := transport.NewENHTransport(client, 500*time.Millisecond, 500*time.Millisecond)
+	// 0xA9 (lead), 0xFF (invalid → recovery, drop both), 0x55 (plain byte, emitted)
+	feedENHReceivedBytes(t, server, []byte{0xA9, 0xFF, 0x55})
+
+	events := drainBytes(t, enh, 1)
+	if events[0].Byte != 0x55 || events[0].WasEscaped {
+		t.Fatalf("decoded event = {Byte=0x%02X WasEscaped=%v}; want {0x55 false}",
+			events[0].Byte, events[0].WasEscaped)
+	}
+
+	if got := enh.EscapeRecoveryTotal(); got != 1 {
+		t.Errorf("EscapeRecoveryTotal() = %d; want 1", got)
+	}
+	if got := enh.DecodeFaultTotal(); got != 1 {
+		t.Errorf("DecodeFaultTotal() = %d; want 1 (recovery is a fault)", got)
+	}
+	if got := enh.EscapeBudgetExhaustedTotal(); got != 0 {
+		t.Errorf("EscapeBudgetExhaustedTotal() = %d; want 0", got)
+	}
+	if got := enh.EscapeAaAbsorbedTotal(); got != 0 {
+		t.Errorf("EscapeAaAbsorbedTotal() = %d; want 0 (no AA absorbed before recovery)", got)
+	}
+}
+
+// TestENHCounters_BudgetExhausted pins that
+// AdminEventEscapeBudgetExhausted (0xA9 + 9 consecutive AAs)
+// increments both EscapeBudgetExhaustedTotal and DecodeFaultTotal,
+// AND increments EscapeAaAbsorbedTotal by exactly
+// MaxAaAbsorptionsPerEscapePair (the 8 absorbed AAs, NOT the
+// over-budget 9th).
+func TestENHCounters_BudgetExhausted(t *testing.T) {
+	t.Parallel()
+
+	client, server := net.Pipe()
+	defer func() { _ = client.Close() }()
+	defer func() { _ = server.Close() }()
+
+	enh := transport.NewENHTransport(client, 500*time.Millisecond, 500*time.Millisecond)
+	// 0xA9 + 9 consecutive AAs (1 over budget).
+	stream := []byte{0xA9}
+	for i := 0; i < transport.MaxAaAbsorptionsPerEscapePair+1; i++ {
+		stream = append(stream, 0xAA)
+	}
+	// Trailing plain byte to confirm clean resume.
+	stream = append(stream, 0x77)
+	feedENHReceivedBytes(t, server, stream)
+
+	events := drainBytes(t, enh, 1)
+	if events[0].Byte != 0x77 || events[0].WasEscaped {
+		t.Fatalf("post-exhaust event = {Byte=0x%02X WasEscaped=%v}; want {0x77 false}",
+			events[0].Byte, events[0].WasEscaped)
+	}
+
+	if got := enh.EscapeBudgetExhaustedTotal(); got != 1 {
+		t.Errorf("EscapeBudgetExhaustedTotal() = %d; want 1", got)
+	}
+	if got := enh.DecodeFaultTotal(); got != 1 {
+		t.Errorf("DecodeFaultTotal() = %d; want 1", got)
+	}
+	if got := enh.EscapeAaAbsorbedTotal(); got != uint64(transport.MaxAaAbsorptionsPerEscapePair) {
+		t.Errorf("EscapeAaAbsorbedTotal() = %d; want %d (only the in-budget AAs count)",
+			got, transport.MaxAaAbsorptionsPerEscapePair)
+	}
+	if got := enh.EscapeRecoveryTotal(); got != 0 {
+		t.Errorf("EscapeRecoveryTotal() = %d; want 0", got)
+	}
+}
+
+// NOTE — wall-clock timeout NOT covered by an end-to-end ENH
+// integration test in this file.
+//
+// Codex round-2 review on PR #165 correctly observed that any
+// integration test that relies on a wall-clock sleep between two
+// net.Pipe writes has an unavoidable race: net.Pipe.Write returns
+// when the matching Read consumes the bytes from the underlying
+// conn, but it does NOT prove the transport's read loop has yet
+// fed those bytes through the escape decoder (the decoder feed
+// happens AFTER conn.Read returns, in the same goroutine but
+// after a Parse step). If the scheduler delays the reader, the
+// test's wall-clock sleep can elapse before the decoder records
+// the lead's `leadObservedAt`, and the timeout will not fire.
+//
+// Coverage of the wall-clock timeout contract is split across four
+// deterministic layers — collectively they pin every layer of the
+// pipeline without the scheduler race:
+//
+//   1. **Decoder semantics** —
+//      `ebus_escape_v8_test.go::TestFeed_WallClockCap_*` uses
+//      synthetic times to assert the decoder emits
+//      AdminEventEscapePendingTimeout under the right elapsed
+//      condition (3 tests: beyond-cap, exact-boundary,
+//      timeout-byte-is-a-new-0xA9).
+//   2. **Constant alignment** — `v8_constant_drift_test.go` asserts
+//      `transport.EscapePendingTimeout ==
+//      protocol.FrameAtomicV8EscapePendingTimeout` so the 32 ms
+//      value cannot regress.
+//   3. **ENHTransport admin-event-to-counter routing** —
+//      `apply_escape_admin_event_test.go` directly unit-tests the
+//      `applyEscapeAdminEvent` free function (extracted from
+//      `feedEscapeDecoderLocked` per Codex round-3) with each
+//      AdminEvent kind as input. The PendingTimeout branch is
+//      executable-tested for: counter increment, NO decodeFault
+//      increment (data-preserving invariant), dropEmission=false.
+//   4. **ENHTransport plumbing for other admin event kinds** —
+//      this file pins Recovery, BudgetExhausted, and AaAbsorbed
+//      via the end-to-end ENH stream path (5 deterministic tests).
+//      The PendingTimeout integration path is the ONLY admin event
+//      kind without an end-to-end test; the deterministic unit
+//      test in #3 above covers the routing contract that the
+//      end-to-end test would otherwise exercise.
+//
+// If a future refactor changes the routing shape (e.g. moves
+// counter increments back into a non-extractable inline switch),
+// the unit test in #3 would need to be re-derived; either a
+// clock-injection hook on ENHTransport or a test-only "wait until
+// decoder pending" synchronization barrier would unlock a true
+// end-to-end timeout integration test.
+
+// TestENHCounters_AccumulatesAcrossEvents pins that the counters
+// accumulate monotonically across multiple events of the same kind
+// in a single ENHTransport instance.
+func TestENHCounters_AccumulatesAcrossEvents(t *testing.T) {
+	t.Parallel()
+
+	client, server := net.Pipe()
+	defer func() { _ = client.Close() }()
+	defer func() { _ = server.Close() }()
+
+	enh := transport.NewENHTransport(client, 500*time.Millisecond, 500*time.Millisecond)
+	// Two consecutive recovery faults, then plain byte to confirm
+	// the decoder is still healthy.
+	feedENHReceivedBytes(t, server, []byte{
+		0xA9, 0xFF, // recovery #1
+		0xA9, 0xFE, // recovery #2
+		0x33, // plain byte (emitted)
+	})
+
+	events := drainBytes(t, enh, 1)
+	if events[0].Byte != 0x33 || events[0].WasEscaped {
+		t.Fatalf("final event = {Byte=0x%02X WasEscaped=%v}; want {0x33 false}",
+			events[0].Byte, events[0].WasEscaped)
+	}
+
+	if got := enh.EscapeRecoveryTotal(); got != 2 {
+		t.Errorf("EscapeRecoveryTotal() = %d; want 2 (monotonic accumulation)", got)
+	}
+	if got := enh.DecodeFaultTotal(); got != 2 {
+		t.Errorf("DecodeFaultTotal() = %d; want 2", got)
+	}
+}
+
+// assertCountersZero is a helper used by the baseline test.
+func assertCountersZero(t *testing.T, enh *transport.ENHTransport) {
+	t.Helper()
+	if got := enh.EscapeAaAbsorbedTotal(); got != 0 {
+		t.Errorf("EscapeAaAbsorbedTotal() = %d; want 0", got)
+	}
+	if got := enh.EscapePendingTimeoutTotal(); got != 0 {
+		t.Errorf("EscapePendingTimeoutTotal() = %d; want 0", got)
+	}
+	if got := enh.EscapeRecoveryTotal(); got != 0 {
+		t.Errorf("EscapeRecoveryTotal() = %d; want 0", got)
+	}
+	if got := enh.EscapeBudgetExhaustedTotal(); got != 0 {
+		t.Errorf("EscapeBudgetExhaustedTotal() = %d; want 0", got)
+	}
+	if got := enh.DecodeFaultTotal(); got != 0 {
+		t.Errorf("DecodeFaultTotal() = %d; want 0", got)
+	}
+}

--- a/transport/v8_constant_drift_test.go
+++ b/transport/v8_constant_drift_test.go
@@ -1,0 +1,49 @@
+package transport_test
+
+import (
+	"testing"
+
+	"github.com/Project-Helianthus/helianthus-ebusgo/protocol"
+	"github.com/Project-Helianthus/helianthus-ebusgo/transport"
+)
+
+// Phase 1 Step B1 (frame-atomic-visibility v8 §1.3 / §5, invariant
+// I4): the transport package mirrors two v8 constants from the
+// protocol package because production-code in transport cannot
+// import protocol (circular dependency). External test code is the
+// ONLY layer that can hold both packages and prove the mirror has
+// not drifted.
+//
+// These tests are the drift guard. If they fail, either:
+//   - protocol/frame_atomic_v8_timeouts.go changed and transport
+//     was not updated, or
+//   - transport/ebus_escape.go changed the mirror to a different
+//     literal without updating the protocol source of truth.
+//
+// Either way, the mismatch is a bug: protocol is the source of
+// truth (v8 design constants live there) and transport must
+// faithfully mirror.
+
+// TestV8DriftGuard_MaxAaAbsorptionsPerEscapePair asserts the
+// AA-injection absorption budget matches across packages.
+func TestV8DriftGuard_MaxAaAbsorptionsPerEscapePair(t *testing.T) {
+	t.Parallel()
+
+	if transport.MaxAaAbsorptionsPerEscapePair != protocol.FrameAtomicV8MaxAaAbsorptionsPerEscapePair {
+		t.Fatalf("v8 constant drift: transport.MaxAaAbsorptionsPerEscapePair=%d, protocol.FrameAtomicV8MaxAaAbsorptionsPerEscapePair=%d; both must match (v8 §5 / I4)",
+			transport.MaxAaAbsorptionsPerEscapePair,
+			protocol.FrameAtomicV8MaxAaAbsorptionsPerEscapePair)
+	}
+}
+
+// TestV8DriftGuard_EscapePendingTimeout asserts the 32 ms
+// wall-clock cap matches across packages.
+func TestV8DriftGuard_EscapePendingTimeout(t *testing.T) {
+	t.Parallel()
+
+	if transport.EscapePendingTimeout != protocol.FrameAtomicV8EscapePendingTimeout {
+		t.Fatalf("v8 constant drift: transport.EscapePendingTimeout=%v, protocol.FrameAtomicV8EscapePendingTimeout=%v; both must match (v8 §1.3)",
+			transport.EscapePendingTimeout,
+			protocol.FrameAtomicV8EscapePendingTimeout)
+	}
+}


### PR DESCRIPTION
## Summary

Promotes the `frame-atomic-visibility` integration branch in `helianthus-ebusgo` onto `main`. This unblocks the gateway's go.mod ebusgo pin re-bump from a frame-atomic-visibility pseudo-version (current pin in gateway v0.5.0) to a main-branch pseudo-version (target for gateway v0.5.1).

## What's in this release

6 stacked PRs (#160 through #165) form the complete v8 protocol-side rollout:

| Step | PR | What |
|---|---|---|
| A | #160 | Per-phase timeout constants for frame-atomic-v8 |
| B2 part 1 | #161 | Shared telegram-phase FSM library (active write path) |
| B2 part 2 | #162 | Target-response phases + retx states + terminator SYN |
| B2.3 | #163 | `StatePassiveTracking` composite state |
| B4 | #164 | Gate round-9 absorb on `inSendRawWithEchoActiveEchoWait` |
| B1 | #165 | v8 AA-aware escape decoder in ebusgo transport |

Each individual PR was Codex dual-reviewed (1-2 rounds each), tested under -race, and squash-merged into the integration branch.

## Consumers

- **helianthus-ebusgateway v0.5.0** (released 2026-05-20) is already deployed against frame-atomic-visibility HEAD via pseudo-version pin `v0.5.1-0.20260519172908-3fca19de9735`. This promotion to main provides a stable main-branch reference for the gateway's v0.5.1 pin re-bump.

## API additions (no breaking changes)

- New package: `protocol/telegram_fsm` (state machine for telegram phase tracking).
- New methods on `protocol.Bus`: `Round9AbsorbEntered()` counter accessor + supporting predicate `inSendRawWithEchoActiveEchoWait()`.
- New methods on `transport`: AA-aware escape decoder (`EbusEscapeDecoder.Feed`, `AdminEventKind`, `AdminEvent`).

## Squash-merge

Per project convention (`one issue/PR per repo, squash+merge`), this PR is squash-merged. Individual sub-PR history is preserved on the integration branch's commits (#160-#165 merge commits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)