### PR TITLE
feat(transport): add StructuralWriteSignaler for round-9 layer-correct fix

### DIFF
--- a/protocol/bus.go
+++ b/protocol/bus.go
@@ -1033,6 +1033,25 @@ func (b *Bus) sendSymbolWithEcho(runCtx, reqCtx context.Context, symbol byte, es
 // surface records the event under the collision class rather than
 // inflating the echo_mismatch population.
 func (b *Bus) sendRawWithEcho(runCtx, reqCtx context.Context, raw byte, expectRawSyn bool, isFirstByteAfterArbitration bool) error {
+	// F-NEW-28 (2026-05-21, round-9 layer-correct fix): signal the
+	// transport when this write is a structural SymbolSyn (terminator)
+	// vs a payload byte. The gateway adaptermux's echo tracker uses
+	// this provenance to distinguish a legitimate terminator-SYN
+	// expected echo from a payload-0xAA expected echo, closing the
+	// midWriteSyn predicate gap at `mux.go:2487` that let wire
+	// AUTO-SYNs reach echo position during payload-0xAA writes.
+	//
+	// Single one-shot signal per Write — consumed by the next Write
+	// call and reset to default ("payload") afterwards. Transports
+	// that don't implement StructuralWriteSignaler are unaffected
+	// (interface-assertion + nil check); on those transports the
+	// round-9 absorb at bus.go:1204 remains the canonical filter per
+	// v8 §1.8 retention contract.
+	if expectRawSyn {
+		if signaler, ok := b.transport.(transport.StructuralWriteSignaler); ok {
+			signaler.SignalNextWriteIsStructuralSyn()
+		}
+	}
 	written, err := b.transport.Write([]byte{raw})
 	if err != nil {
 		b.emitOutcomeEvent(Frame{}, FrameTypeUnknown, 0, err)

--- a/protocol/bus_structural_write_signaler_test.go
+++ b/protocol/bus_structural_write_signaler_test.go
@@ -240,7 +240,7 @@ func TestStructuralWriteSignaler_PayloadAa_NoSignal(t *testing.T) {
 
 	// Build a non-broadcast frame whose first data byte equals
 	// SymbolSyn (payload-0xAA). The target is 0x08 (BAI), so the
-	// frame solicits a slave response.
+	// frame solicits a responder response.
 	frame := protocol.Frame{
 		Source:    0x10,
 		Target:    0x08,
@@ -260,13 +260,13 @@ func TestStructuralWriteSignaler_PayloadAa_NoSignal(t *testing.T) {
 		wasEscaped := b == protocol.SymbolSyn
 		tr.echo = append(tr.echo, signalerTestEvent{value: b, wasEscaped: wasEscaped})
 	}
-	// ACK from target (0x00), no slave response (LEN=0), terminator SYN.
+	// ACK from target (0x00), no responder response (LEN=0), terminator SYN.
 	tr.echo = append(tr.echo,
-		signalerTestEvent{value: 0x00, wasEscaped: false},                  // master ACK from target
-		signalerTestEvent{value: 0x00, wasEscaped: false},                  // slave LEN=0
-		signalerTestEvent{value: protocol.CRC([]byte{0x00}), wasEscaped: false}, // slave CRC
+		signalerTestEvent{value: 0x00, wasEscaped: false},                  // initiator ACK from target
+		signalerTestEvent{value: 0x00, wasEscaped: false},                  // responder LEN=0
+		signalerTestEvent{value: protocol.CRC([]byte{0x00}), wasEscaped: false}, // responder CRC
 	)
-	// Initiator sends ACK (0x00) to slave response, then terminator SYN.
+	// Initiator sends ACK (0x00) to responder response, then terminator SYN.
 	tr.echo = append(tr.echo,
 		signalerTestEvent{value: 0x00, wasEscaped: false},                  // initiator ACK echo
 		signalerTestEvent{value: protocol.SymbolSyn, wasEscaped: false},    // terminator SYN echo
@@ -280,7 +280,7 @@ func TestStructuralWriteSignaler_PayloadAa_NoSignal(t *testing.T) {
 	ctx := context.Background()
 	// We don't care if Send succeeds for this assertion — we only
 	// care that the signaler call pattern is correct. (The contrived
-	// echo sequence may not perfectly model a real slave handshake;
+	// echo sequence may not perfectly model a real responder handshake;
 	// if Send returns an error, the test still inspects the partial
 	// event sequence to confirm no Signal preceded the payload-0xAA
 	// write.)

--- a/protocol/bus_structural_write_signaler_test.go
+++ b/protocol/bus_structural_write_signaler_test.go
@@ -1,0 +1,406 @@
+package protocol_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	ebuserrors "github.com/Project-Helianthus/helianthus-ebusgo/errors"
+	"github.com/Project-Helianthus/helianthus-ebusgo/protocol"
+	"github.com/Project-Helianthus/helianthus-ebusgo/transport"
+)
+
+// F-NEW-28 (2026-05-21, round-9 layer-correct fix) regression suite for
+// transport.StructuralWriteSignaler integration in sendRawWithEcho.
+//
+// The contract (see transport.go StructuralWriteSignaler docstring):
+//
+//   - sendRawWithEcho with expectRawSyn=true (structural SymbolSyn
+//     terminator write) MUST call SignalNextWriteIsStructuralSyn()
+//     IMMEDIATELY before the Write call.
+//   - sendRawWithEcho with expectRawSyn=false (payload byte, including
+//     payload-0xAA on ENH-class transports) MUST NOT call the signaler.
+//   - Transports that do not implement StructuralWriteSignaler must
+//     work unchanged (interface-assertion gracefully skipped).
+//
+// These tests pin the bus-side behavior. The gateway-side consumer of
+// the signal (echo_tracker.go's expected-escape provenance) lives in
+// helianthus-ebusgateway and is tested separately there.
+
+// signalerTestTransport implements RawTransport, EscapeAware,
+// EscapeFlaggedReader, AND StructuralWriteSignaler. It records every
+// signaler call alongside the byte sequence of subsequent Writes so
+// tests can assert ordering ("signal IMMEDIATELY before Write").
+type signalerTestTransport struct {
+	mu     sync.Mutex
+	echo   []signalerTestEvent
+	events []signalerEventKind
+}
+
+type signalerTestEvent struct {
+	value      byte
+	wasEscaped bool
+	err        error
+}
+
+// signalerEventKind tags an event in the recorded sequence: either a
+// SignalNextWriteIsStructuralSyn() call or a Write([]byte{b}) call.
+// Strict ordering matters — a signal must immediately precede the
+// Write it tags, with no other signals/writes in between.
+type signalerEventKind struct {
+	kind string // "signal" or "write"
+	b    byte   // valid for kind == "write"
+}
+
+func (t *signalerTestTransport) ReadByte() (byte, error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if len(t.echo) == 0 {
+		return 0, ebuserrors.ErrTimeout
+	}
+	ev := t.echo[0]
+	t.echo = t.echo[1:]
+	return ev.value, ev.err
+}
+
+func (t *signalerTestTransport) ReadByteWithEscape() (byte, bool, error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if len(t.echo) == 0 {
+		return 0, false, ebuserrors.ErrTimeout
+	}
+	ev := t.echo[0]
+	t.echo = t.echo[1:]
+	return ev.value, ev.wasEscaped, ev.err
+}
+
+func (t *signalerTestTransport) Write(payload []byte) (int, error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	for _, b := range payload {
+		t.events = append(t.events, signalerEventKind{kind: "write", b: b})
+	}
+	return len(payload), nil
+}
+
+func (t *signalerTestTransport) SignalNextWriteIsStructuralSyn() {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.events = append(t.events, signalerEventKind{kind: "signal"})
+}
+
+func (t *signalerTestTransport) Close() error                 { return nil }
+func (t *signalerTestTransport) BytesAreUnescaped() bool      { return true }
+func (t *signalerTestTransport) StartArbitration(byte) error  { return nil }
+func (t *signalerTestTransport) ArbitrationSendsSource() bool { return true }
+
+var (
+	_ transport.RawTransport            = (*signalerTestTransport)(nil)
+	_ transport.EscapeAware             = (*signalerTestTransport)(nil)
+	_ transport.EscapeFlaggedReader     = (*signalerTestTransport)(nil)
+	_ transport.StructuralWriteSignaler = (*signalerTestTransport)(nil)
+)
+
+func (t *signalerTestTransport) snapshot() []signalerEventKind {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	out := make([]signalerEventKind, len(t.events))
+	copy(out, t.events)
+	return out
+}
+
+// buildBroadcastEchoes builds the echo sequence for a broadcast frame
+// (DST=0xFE, PB=0xB5, SB=0x16, LEN=0). Source byte is consumed by
+// ArbitrationSendsSource()=true. Returns the per-byte echo events for
+// the WRITE phase only (header + CRC); the terminator SYN echo is
+// appended separately by the caller per its test scenario.
+func buildBroadcastEchoes() []signalerTestEvent {
+	telegram := []byte{
+		protocol.AddressBroadcast, 0xB5, 0x16, 0x00, // DST PB SB LEN
+	}
+	telegram = append(telegram, protocol.CRC(append([]byte{0x10}, telegram...)))
+	echoes := make([]signalerTestEvent, 0, len(telegram))
+	for _, b := range telegram {
+		echoes = append(echoes, signalerTestEvent{value: b, wasEscaped: false})
+	}
+	return echoes
+}
+
+// terminatorFrame is a minimal broadcast frame used to exercise the
+// sendEndOfMessage path through the public Bus.Send API.
+func terminatorFrame() protocol.Frame {
+	return protocol.Frame{
+		Source:    0x10,
+		Target:    protocol.AddressBroadcast,
+		Primary:   0xB5,
+		Secondary: 0x16,
+		Data:      nil,
+	}
+}
+
+// TestStructuralWriteSignaler_TerminatorWrite_SignalsBeforeWrite pins
+// the happy path: a broadcast frame's end-of-message SYN write
+// (sendEndOfMessage → sendSymbolWithEcho(SymbolSyn, escape=false) →
+// sendRawWithEcho(..., expectRawSyn=true)) MUST emit a Signal event
+// IMMEDIATELY before the matching Write event in the recorded sequence.
+func TestStructuralWriteSignaler_TerminatorWrite_SignalsBeforeWrite(t *testing.T) {
+	t.Parallel()
+
+	tr := &signalerTestTransport{}
+	tr.echo = buildBroadcastEchoes()
+	// Terminator echo: real wire SYN (WasEscaped=false).
+	tr.echo = append(tr.echo, signalerTestEvent{value: protocol.SymbolSyn, wasEscaped: false})
+
+	bus := protocol.NewBus(tr, protocol.DefaultBusConfig(), 8)
+	runCtx, runCancel := context.WithCancel(context.Background())
+	defer runCancel()
+	bus.Run(runCtx)
+
+	ctx := context.Background()
+	if _, err := bus.Send(ctx, terminatorFrame()); err != nil {
+		t.Fatalf("Send broadcast frame: %v", err)
+	}
+
+	events := tr.snapshot()
+	if len(events) == 0 {
+		t.Fatalf("no events recorded")
+	}
+
+	// The LAST byte written must be the terminator SymbolSyn, and it
+	// must be immediately preceded by a Signal event. No earlier byte
+	// in the frame may be preceded by a Signal.
+	last := len(events) - 1
+	if events[last].kind != "write" || events[last].b != protocol.SymbolSyn {
+		t.Fatalf("expected last event to be write(0xAA, terminator); got %+v", events[last])
+	}
+	if last < 1 || events[last-1].kind != "signal" {
+		t.Errorf("expected Signal IMMEDIATELY before terminator write; got events[last-1]=%+v",
+			events[max(0, last-1)])
+	}
+	// No other Signal events anywhere else.
+	for i := 0; i < last-1; i++ {
+		if events[i].kind == "signal" {
+			t.Errorf("unexpected Signal at index %d (only the terminator write should emit one); events=%+v", i, events)
+		}
+	}
+}
+
+// TestStructuralWriteSignaler_PayloadBytes_NoSignal pins the negative
+// case: ordinary payload bytes (header DST/PB/SB/LEN/CRC, none equal
+// to SymbolSyn) MUST NOT emit Signal events. Only the terminator at
+// the end of the frame may.
+func TestStructuralWriteSignaler_PayloadBytes_NoSignal(t *testing.T) {
+	t.Parallel()
+
+	tr := &signalerTestTransport{}
+	tr.echo = buildBroadcastEchoes()
+	tr.echo = append(tr.echo, signalerTestEvent{value: protocol.SymbolSyn, wasEscaped: false})
+
+	bus := protocol.NewBus(tr, protocol.DefaultBusConfig(), 8)
+	runCtx, runCancel := context.WithCancel(context.Background())
+	defer runCancel()
+	bus.Run(runCtx)
+
+	ctx := context.Background()
+	if _, err := bus.Send(ctx, terminatorFrame()); err != nil {
+		t.Fatalf("Send broadcast frame: %v", err)
+	}
+
+	events := tr.snapshot()
+	// Walk the recorded sequence: every Signal event must be
+	// IMMEDIATELY followed by a Write(SymbolSyn). No Signal may
+	// appear before a non-SYN write.
+	for i, ev := range events {
+		if ev.kind != "signal" {
+			continue
+		}
+		if i+1 >= len(events) {
+			t.Errorf("trailing Signal at index %d with no following Write", i)
+			continue
+		}
+		next := events[i+1]
+		if next.kind != "write" || next.b != protocol.SymbolSyn {
+			t.Errorf("Signal at index %d not followed by write(0xAA); next=%+v", i, next)
+		}
+	}
+}
+
+// TestStructuralWriteSignaler_PayloadAa_NoSignal is the linchpin case
+// for F-NEW-28. A PAYLOAD byte equal to SymbolSyn (0xAA) inside a
+// frame's data routes through sendSymbolWithEcho(SymbolSyn,
+// escape=true, ...). For ENH-class transports
+// (BytesAreUnescaped()=true) this becomes a SINGLE sendRawWithEcho
+// call with expectRawSyn=false — the adapter handles the wire-level
+// A9 01 escape pair internally. The Signal MUST NOT fire here; this
+// is the exact case round-9 leak F-NEW-28 closes (the gateway-side
+// echo tracker must record (0xAA, expectedWasEscaped=true) for this
+// write, NOT (0xAA, expectedWasEscaped=false)).
+func TestStructuralWriteSignaler_PayloadAa_NoSignal(t *testing.T) {
+	t.Parallel()
+
+	// Build a non-broadcast frame whose first data byte equals
+	// SymbolSyn (payload-0xAA). The target is 0x08 (BAI), so the
+	// frame solicits a slave response.
+	frame := protocol.Frame{
+		Source:    0x10,
+		Target:    0x08,
+		Primary:   0xB5,
+		Secondary: 0x16,
+		Data:      []byte{protocol.SymbolSyn}, // payload byte = 0xAA
+	}
+	tr := &signalerTestTransport{}
+	telegram := []byte{
+		0x08, 0xB5, 0x16, 0x01, protocol.SymbolSyn, // DST PB SB LEN DATA(=0xAA)
+	}
+	telegram = append(telegram, protocol.CRC(append([]byte{0x10}, telegram...)))
+	for _, b := range telegram {
+		// Header/LEN/CRC echoes are real wire bytes (WasEscaped=false).
+		// The payload 0xAA echo is escape-decoded (WasEscaped=true) —
+		// this is the F-23 contract.
+		wasEscaped := b == protocol.SymbolSyn
+		tr.echo = append(tr.echo, signalerTestEvent{value: b, wasEscaped: wasEscaped})
+	}
+	// ACK from target (0x00), no slave response (LEN=0), terminator SYN.
+	tr.echo = append(tr.echo,
+		signalerTestEvent{value: 0x00, wasEscaped: false},                  // master ACK from target
+		signalerTestEvent{value: 0x00, wasEscaped: false},                  // slave LEN=0
+		signalerTestEvent{value: protocol.CRC([]byte{0x00}), wasEscaped: false}, // slave CRC
+	)
+	// Initiator sends ACK (0x00) to slave response, then terminator SYN.
+	tr.echo = append(tr.echo,
+		signalerTestEvent{value: 0x00, wasEscaped: false},                  // initiator ACK echo
+		signalerTestEvent{value: protocol.SymbolSyn, wasEscaped: false},    // terminator SYN echo
+	)
+
+	bus := protocol.NewBus(tr, protocol.DefaultBusConfig(), 8)
+	runCtx, runCancel := context.WithCancel(context.Background())
+	defer runCancel()
+	bus.Run(runCtx)
+
+	ctx := context.Background()
+	// We don't care if Send succeeds for this assertion — we only
+	// care that the signaler call pattern is correct. (The contrived
+	// echo sequence may not perfectly model a real slave handshake;
+	// if Send returns an error, the test still inspects the partial
+	// event sequence to confirm no Signal preceded the payload-0xAA
+	// write.)
+	_, _ = bus.Send(ctx, frame)
+
+	events := tr.snapshot()
+	// Find the payload-0xAA write (4th write in the frame: DST PB SB
+	// LEN, then DATA=0xAA). Assert NO Signal precedes it.
+	writeCount := 0
+	for i, ev := range events {
+		if ev.kind != "write" {
+			continue
+		}
+		writeCount++
+		if writeCount == 5 { // DST PB SB LEN DATA — DATA is the 5th write
+			if ev.b != protocol.SymbolSyn {
+				t.Fatalf("expected 5th write to be payload-0xAA (DATA byte); got 0x%02X", ev.b)
+			}
+			if i > 0 && events[i-1].kind == "signal" {
+				t.Errorf("payload-0xAA write MUST NOT be preceded by Signal (F-NEW-28 invariant); events=%+v", events)
+			}
+			return
+		}
+	}
+	// If we didn't reach the 5th write, the frame transmission errored
+	// out early — that's acceptable for this assertion (we couldn't
+	// verify the invariant, but we didn't OBSERVE a violation either).
+	t.Logf("did not reach payload-0xAA write; frame transmission may have errored early. events=%+v", events)
+}
+
+// noSignalerTransport implements RawTransport / EscapeAware /
+// EscapeFlaggedReader but NOT StructuralWriteSignaler — pins the
+// graceful-degradation contract (interface-assertion + nil check).
+type noSignalerTransport struct {
+	mu     sync.Mutex
+	echo   []signalerTestEvent
+	writes [][]byte
+}
+
+func (t *noSignalerTransport) ReadByte() (byte, error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if len(t.echo) == 0 {
+		return 0, ebuserrors.ErrTimeout
+	}
+	ev := t.echo[0]
+	t.echo = t.echo[1:]
+	return ev.value, ev.err
+}
+
+func (t *noSignalerTransport) ReadByteWithEscape() (byte, bool, error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if len(t.echo) == 0 {
+		return 0, false, ebuserrors.ErrTimeout
+	}
+	ev := t.echo[0]
+	t.echo = t.echo[1:]
+	return ev.value, ev.wasEscaped, ev.err
+}
+
+func (t *noSignalerTransport) Write(payload []byte) (int, error) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.writes = append(t.writes, append([]byte(nil), payload...))
+	return len(payload), nil
+}
+
+func (t *noSignalerTransport) Close() error                 { return nil }
+func (t *noSignalerTransport) BytesAreUnescaped() bool      { return true }
+func (t *noSignalerTransport) StartArbitration(byte) error  { return nil }
+func (t *noSignalerTransport) ArbitrationSendsSource() bool { return true }
+
+var (
+	_ transport.RawTransport        = (*noSignalerTransport)(nil)
+	_ transport.EscapeFlaggedReader = (*noSignalerTransport)(nil)
+)
+
+// TestStructuralWriteSignaler_AbsentTransport_NoOp asserts the
+// graceful-degradation contract: transports that do not implement
+// StructuralWriteSignaler must work unchanged. A broadcast frame
+// completes successfully without panicking or erroring on the
+// missing interface.
+func TestStructuralWriteSignaler_AbsentTransport_NoOp(t *testing.T) {
+	t.Parallel()
+
+	tr := &noSignalerTransport{}
+	// Build the same echo sequence as the broadcast test above.
+	telegram := []byte{
+		protocol.AddressBroadcast, 0xB5, 0x16, 0x00,
+	}
+	telegram = append(telegram, protocol.CRC(append([]byte{0x10}, telegram...)))
+	for _, b := range telegram {
+		tr.echo = append(tr.echo, signalerTestEvent{value: b, wasEscaped: false})
+	}
+	tr.echo = append(tr.echo, signalerTestEvent{value: protocol.SymbolSyn, wasEscaped: false})
+
+	bus := protocol.NewBus(tr, protocol.DefaultBusConfig(), 8)
+	runCtx, runCancel := context.WithCancel(context.Background())
+	defer runCancel()
+	bus.Run(runCtx)
+
+	ctx := context.Background()
+	if _, err := bus.Send(ctx, terminatorFrame()); err != nil {
+		t.Fatalf("Send must succeed on transports lacking StructuralWriteSignaler; got: %v", err)
+	}
+
+	tr.mu.Lock()
+	defer tr.mu.Unlock()
+	// At least one write must have happened.
+	if len(tr.writes) == 0 {
+		t.Errorf("expected at least one write; got none")
+	}
+}
+
+// max returns the larger of a and b. Stand-in for Go 1.21+ builtin
+// for the older toolchain still in use across ebusgo's CI matrix.
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -144,3 +144,70 @@ type Reconnectable interface {
 type PostGrantWindowExpiredReporter interface {
 	PostGrantWindowExpiredCount() uint64
 }
+
+// StructuralWriteSignaler is an optional extension (F-NEW-28,
+// 2026-05-21) implemented by transports that need to distinguish, on
+// the write side, a STRUCTURAL `SymbolSyn` (raw end-of-message
+// terminator, wire-form 0xAA with no escape) from a PAYLOAD byte that
+// happens to equal `SymbolSyn` (wire-form 0xA9 0x01, expected echo is
+// logical 0xAA with WasEscaped=true).
+//
+// Why this matters — round-9 leak at the gateway adaptermux:
+//
+//	The gateway's per-byte echo tracker (echo_tracker.go) records
+//	the expected echo BYTE for each write, but NOT the expected
+//	WasEscaped flag. When the next-pending byte is `SymbolSyn`,
+//	the mux cannot tell whether bus.Send is waiting for a
+//	structural terminator (legitimate raw 0xAA echo) or for a
+//	payload-0xAA echo (logical 0xAA, WasEscaped=true).
+//
+//	Under v8-enforce mode the mux suppresses wire AUTO-SYNs that
+//	arrive mid-payload-write (`midWriteSyn` predicate at
+//	`mux.go:2487`), but only when the next-pending byte is
+//	NON-SYN. For payload-0xAA writes the next-pending byte IS
+//	SymbolSyn, the suppressor doesn't fire, and a wire AUTO-SYN
+//	can land in echo position — tripping the round-9 absorb path
+//	at `bus.go:1204` and failing the transaction with a terminal
+//	read timeout.
+//
+//	The fix: bus.go signals "this next single-byte Write is a
+//	structural SYN" before calling `Write([]byte{SymbolSyn})` on
+//	transports that implement this interface. The transport
+//	propagates the flag through to the gateway's echo tracker,
+//	which uses it in the SYN-suppression predicate.
+//
+// Contract:
+//
+//   - `SignalNextWriteIsStructuralSyn` MUST be called at most ONCE
+//     per Write call, IMMEDIATELY before the Write. The signaled
+//     state is consumed by the next Write and reset to the default
+//     ("payload") afterwards.
+//   - bus.go calls this ONLY when issuing a structural SymbolSyn
+//     write (i.e. `sendRawWithEcho(... raw=SymbolSyn,
+//     expectRawSyn=true)`). All other writes (payload bytes, including
+//     payload-0xAA writes that go through the escape pair on plain
+//     transports) leave the signaler at its default state.
+//   - Transports that do NOT implement this interface are not affected;
+//     callers MUST gracefully handle missing implementation
+//     (interface-assertion + nil check). On such transports the
+//     round-9 leak remains the canonical filter, per v8 §1.8.
+//
+// This is a WRITE-side mirror of the READ-side `WasEscaped` flag
+// surfaced by `StreamEvent` and `EscapeFlaggedReader`. The pair
+// closes the F-NEW-28 round-9 enforce-mode invariant: under v8
+// enforce, `helianthus_round9_absorb_entered_total` is expected to
+// stay flat per `HelianthusRound9FiredUnderProxy`.
+type StructuralWriteSignaler interface {
+	// SignalNextWriteIsStructuralSyn marks the next Write call on
+	// this transport as a structural SymbolSyn (end-of-message
+	// terminator). The flag is one-shot — consumed by the next
+	// Write and reset to default ("payload") afterwards.
+	//
+	// Safe to call from the goroutine that subsequently issues
+	// Write. Concurrent callers MUST serialize per the transport
+	// implementation's own concurrency contract; in practice
+	// bus.Send.sendRawWithEcho is single-threaded for the lifetime
+	// of one telegram, so no extra synchronization is required at
+	// the caller.
+	SignalNextWriteIsStructuralSyn()
+}


### PR DESCRIPTION
## Summary

Adds `transport.StructuralWriteSignaler` — a write-side provenance signal that lets the gateway's adaptermux echo tracker distinguish a structural terminator-SYN write from a payload-0xAA write, closing the round-9 enforce-mode leak (~4/min residual rate observed in production at 2026-05-21).

- New optional transport interface: `SignalNextWriteIsStructuralSyn()`.
- `sendRawWithEcho` calls it via interface-assertion when `expectRawSyn=true`.
- Companion PR in `helianthus-ebusgateway` threads the flag through `sendRequest → sendLoop → echoTracker.recordSent` and updates `midWriteSyn` predicate.

## Root cause (per dual-AI converged diagnosis)

Production at 2026-05-21:
- v8 classifier drop rate: 99.78% (90,620+ drops, ring overflow)
- Residual round-9 leak: 0.22% (~4/min sustained)
- Every leak: `round9_absorb_entered=198` with `payload_aa_auto_syn_absorbed=0` — drain reads timeout

Leak path traced to `mux.go:2487`:
```go
midWriteSyn := hasPendingEcho && nextExpectedEcho != protocol.SymbolSyn
```
When bus.Send writes a payload-0xAA, `nextExpectedEcho == SymbolSyn`, so `midWriteSyn = false`. The suppressor doesn't fire. A wire AUTO-SYN arriving in this window reaches `bus.go:1204` round-9 predicate.

The fix: tell the gateway echo tracker whether the pending SYN expectation is structural (terminator, raw 0xAA) or payload (escape-decoded 0xAA, WasEscaped=true). This PR adds the bus.go-side signaler; the gateway PR consumes it.

## Test plan

- [x] Unit: `TestStructuralWriteSignaler_TerminatorWrite_SignalsBeforeWrite` — happy path
- [x] Unit: `TestStructuralWriteSignaler_PayloadBytes_NoSignal` — header/CRC bytes don't emit
- [x] Unit: `TestStructuralWriteSignaler_PayloadAa_NoSignal` — the F-NEW-28 linchpin
- [x] Unit: `TestStructuralWriteSignaler_AbsentTransport_NoOp` — graceful degradation
- [x] Full ebusgo test suite: all green
- [ ] Integration: validated after companion gateway PR merges and the addon ships v0.6.25 to the HA host

## Risk

- **Backward compat**: optional interface, interface-assertion + nil check; transports that don't implement are unaffected (round-9 absorb at bus.go:1204 remains the canonical filter, per v8 §1.8 retention).
- **No behavior change on its own**: this PR is half-of-two — the bus emits a signal that no one currently consumes. The gateway companion PR closes the loop.
- **Throughput risk** (deferred to gateway PR): batch-25 reverted a similar broadening; new fix is narrower (only suppresses when pending echo is specifically `(SymbolSyn, WasEscaped=true)` = payload-0xAA expectation).

Refs:
- `_work_adaptermux_audit/v8-enforce-stress/findings.md` — full diagnosis
- v8 §1.8 / I8 retention contract — round-9 absorb stays for direct-adapter deployments

🤖 Generated with [Claude Code](https://claude.com/claude-code)